### PR TITLE
fix: harden browser control lifecycle recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ local Node relay.
   `--session`; it never infers agent identity from shared current-session state.
 - Relay-backed CLI commands auto-start a detached relay when needed. `status`
   and `doctor` remain observational, and `serve` is only the foreground/debug
-  path. The first session is created atomically in the execute request.
+  path. MCP uses the same detached relay lifecycle instead of owning an
+  in-process relay, so an MCP restart cannot interrupt CLI handoffs. The first
+  session is created atomically in the execute request.
 - Each Browser Control session owns one default page and persistent JavaScript
   `state`; do not default to arbitrary shared tabs for normal execute calls.
 - Use stock `playwright-core` for v1.
@@ -173,7 +175,7 @@ local Node relay.
 - Extension shim changes require reloading the unpacked extension once in Brave.
 - Relay-only changes should not require reloading the extension.
 - Use `termctrl` for long-running relay sessions during testing.
-- Run `SMOKE_CASE=local-forms,local-cart,local-checkout,reconnect-evaluate,redirect-reconnect-evaluate,execute-target-url,execute-page-recovery,execute-fill-helpers,execute-snapshot-refs,handoff-navigation,handoff-cross-tab,handoff-target-detach,oopif-reconnect,dedicated-worker,session-download-capability,execute-ghost-cursor,session-isolation,multi-client,stale-client-checkout,raw-first-checkout pnpm smoke`
+- Run `SMOKE_CASE=local-forms,local-cart,local-checkout,reconnect-evaluate,redirect-reconnect-evaluate,execute-target-url,execute-page-recovery,execute-page-detach-recovery,execute-fill-helpers,execute-snapshot-refs,handoff-navigation,handoff-cross-tab,handoff-target-detach,oopif-reconnect,dedicated-worker,session-download-capability,execute-ghost-cursor,session-isolation,multi-client,stale-client-checkout,raw-first-checkout pnpm smoke`
   before claiming the current smoke set is green.
 - CDP target visibility is scoped per client (`src/cdp-visibility.ts`):
   session-owned tabs are announced and their events delivered only to that

--- a/PLAN.md
+++ b/PLAN.md
@@ -269,8 +269,10 @@ reconciles existing client announcements, browser grouping, and page status.
 
 ### Operations And Diagnostics
 
-- Relay-backed CLI commands start a detached relay when needed. `status` and
-  `doctor` remain observational; `serve` is the foreground debugging path.
+- Relay-backed CLI and MCP commands share one detached relay and start it when
+  needed. The relay outlives the MCP process, so a CLI handoff is not coupled to
+  MCP lifecycle. `status` and `doctor` remain observational; `serve` is the
+  foreground debugging path.
 - `doctor` reports relay and extension versions, build mismatches, sessions,
   active targets, child targets, crashed/browser-error targets, and built
   artifacts.
@@ -428,10 +430,10 @@ session isolation, compact snapshots, handoffs, media returns, and local fixture
 checkout flows.
 
 The current smoke matrix covers local forms, cart and checkout, reconnect and
-redirect reconnect, explicit target selection, crashed-page recovery, fill
-helpers, snapshot refs, handoff navigation and cross-tab binding, OOPIF
-reconnect, dedicated workers, the download capability boundary, cursor behavior,
-session isolation,
+redirect reconnect, explicit target selection, crashed- and detached-page
+recovery, fill helpers with string and Locator targets, snapshot refs, handoff
+navigation and cross-tab binding, OOPIF reconnect, dedicated workers, the
+download capability boundary, cursor behavior, session isolation,
 multi-client visibility, stale-client ordering, and raw-client checkout.
 Historical milestone scope is no longer used as the active backlog; `Next
 Priorities` is authoritative.

--- a/README.md
+++ b/README.md
@@ -99,11 +99,14 @@ Agents that prefer MCP over shell commands can use `browser-control-mcp`:
 claude mcp add browser-control -- browser-control-mcp
 ```
 
-The skill-driven CLI workflow and MCP expose the same relay sessions. MCP
-`execute` extracts returned screenshot buffers, including buffers nested in
-objects and arrays, as native image attachments without writing temporary files.
-This allows one result to return metadata and multiple images. Screenshots that
-are saved to a path but not returned remain file-only.
+The skill-driven CLI workflow and MCP expose the same relay sessions. MCP reuses
+the detached relay or starts it through the same lifecycle as the CLI; the relay
+does not belong to the MCP process, so restarting MCP does not interrupt a CLI
+execute or pending handoff. MCP `execute` extracts returned screenshot buffers,
+including buffers nested in objects and arrays, as native image attachments
+without writing temporary files. This allows one result to return metadata and
+multiple images. Screenshots that are saved to a path but not returned remain
+file-only.
 
 ### Explicit sessions
 
@@ -302,9 +305,10 @@ SMOKE_CASE=oopif-reconnect pnpm smoke
 
 The current smoke set covers local action/form fixtures, local cart and
 checkout flows, reconnect/evaluate, a local HTTP redirect followed by reconnect
-and evaluate, explicit target URL selection, execute fill helpers, the explicit
-download capability boundary, OOPIF reconnect, session isolation, and
-concurrent multi-client sessions. Run the
+and evaluate, explicit target URL selection, crashed and detached session-page
+recovery, execute fill helpers (including Locator targets), the explicit
+download capability boundary, OOPIF reconnect, session isolation, and concurrent
+multi-client sessions. Run the
 focused redirect/context regression with:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anomalyco/browser-control",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Local browser driver for trusted agents: control your existing Chromium-family browser through a small extension and a local relay.",
   "repository": {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -525,6 +525,34 @@ const cases: SmokeCase[] = [
     }),
   },
   {
+    name: "execute-page-detach-recovery",
+    run: Effect.fnUntraced(function* () {
+      const smokeSession = `bc-detach-recovery-${Date.now()}`
+      return yield* Effect.gen(function* () {
+        yield* runBrowserControl(["session", "new", smokeSession])
+        const closeOutput = yield* runBrowserControl([
+          "execute",
+          "--session",
+          smokeSession,
+          "await page.setContent('<title>Detach recovery fixture</title>'); await page.close(); return 'closed'",
+        ])
+        if (!closeOutput.includes("session default page was closed")) {
+          return yield* Effect.fail(new Error(`closing the session root did not report stale page state: ${closeOutput}`))
+        }
+        const output = yield* runBrowserControl([
+          "execute",
+          "--session",
+          smokeSession,
+          "return { url: page.url(), title: await page.title() }",
+        ])
+        if (!output.includes("about:blank")) {
+          return yield* Effect.fail(new Error(`execute retained the detached session page: ${output}`))
+        }
+        return output.trim()
+      }).pipe(Effect.ensuring(runBrowserControl(["session", "delete", smokeSession]).pipe(Effect.ignore)))
+    }),
+  },
+  {
     name: "execute-fill-helpers",
     run: Effect.fnUntraced(function* () {
       const marker = `bc-fill-${Date.now()}`
@@ -540,7 +568,7 @@ const cases: SmokeCase[] = [
 await page.setContent('<input id="one" placeholder="One"><input id="two"><textarea id="three"></textarea>')
 await fillInput('#one', 'alpha')
 await fillInputs(page, [
-  { selector: '#two', value: 'beta' },
+  { selector: page.getByRole('textbox').nth(1), value: 'beta' },
   { selector: '#three', value: 'gamma' },
 ])
 const values = await page.evaluate(() => ({

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -21,6 +21,8 @@ browser-control execute 'return { url: page.url(), title: await page.title() }'
 Relay-backed commands start a detached relay when needed and wait briefly for
 the extension to reconnect. Do not start `browser-control serve` first; it is
 the foreground debugging path and intentionally does not return.
+CLI and MCP share this detached relay; restarting the MCP process does not stop
+the relay or interrupt a CLI execute or pending handoff.
 
 If `browser-control` is not on PATH, follow the source setup in the repository
 README (`pnpm install`, `pnpm build`, `bun link`).

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -1,5 +1,5 @@
 import { Effect, Schema, Scope } from "effect"
-import { chromium, type Browser, type BrowserContext, type ConsoleMessage, type Frame, type Locator, type Page } from "playwright-core"
+import { chromium, type Browser, type BrowserContext, type ConsoleMessage, type ElementHandle, type Frame, type Locator, type Page } from "playwright-core"
 import * as acorn from "acorn"
 import fs from "node:fs"
 import path from "node:path"
@@ -250,7 +250,7 @@ export const defaultAriaSnapshotTimeoutMs = 5_000
 export const defaultSnapshotTimeoutMs = 10_000
 
 type InputField = {
-  readonly selector: string
+  readonly selector: InputTarget
   readonly value: string
 }
 
@@ -652,6 +652,20 @@ export class ExecuteSandbox {
     this.pageHealthCheckRequired = true
     if (!this.pendingWarnings.includes(defaultPageCrashedWarning)) {
       this.pendingWarnings.push(defaultPageCrashedWarning)
+    }
+    return true
+  }
+
+  markTargetDetached(targetId: string): boolean {
+    if (this.defaultPageTargetId !== targetId) {
+      return false
+    }
+    this.page = undefined
+    this.defaultPageTargetId = undefined
+    this.ownsPage = false
+    this.pageHealthCheckRequired = false
+    if (!this.pendingWarnings.includes(defaultPageClosedWarning)) {
+      this.pendingWarnings.push(defaultPageClosedWarning)
     }
     return true
   }
@@ -1518,32 +1532,56 @@ async function fillInput(options: { readonly page: Page; readonly target: InputT
   }, options.value, { timeout: 30_000 })
 }
 
-async function fillInputs(page: Page, fields: ReadonlyArray<InputField>): Promise<void> {
-  await page.evaluate((inputFields) => {
-    return inputFields.map((field) => {
-      const matches = document.querySelectorAll(field.selector)
+export async function fillInputs(page: Page, fields: ReadonlyArray<InputField>): Promise<void> {
+  const locatorHandles: ElementHandle[] = []
+  try {
+    const resolvedFields: Array<{ readonly target: string | ElementHandle; readonly label: string; readonly value: string }> = []
+    for (const field of fields) {
+      if (typeof field.selector === "string") {
+        resolvedFields.push({ target: field.selector, label: `selector: ${field.selector}`, value: field.value })
+        continue
+      }
+      const matches = await field.selector.elementHandles()
+      locatorHandles.push(...matches)
       if (matches.length !== 1) {
-        throw new Error(`fillInputs expects exactly one match for selector: ${field.selector}; got ${matches.length}`)
+        throw new Error(`fillInputs expects exactly one match for locator; got ${matches.length}`)
       }
-      const element = matches[0]
-      if (!(element instanceof HTMLInputElement) && !(element instanceof HTMLTextAreaElement)) {
-        throw new Error(`fillInputs expects input or textarea selector: ${field.selector}`)
-      }
-      const prototype = Object.getPrototypeOf(element) as HTMLInputElement | HTMLTextAreaElement
-      const valueSetter = Object.getOwnPropertyDescriptor(element, "value")?.set
-      const prototypeValueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set
-      element.focus()
-      if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
-        prototypeValueSetter.call(element, field.value)
-      } else {
-        element.value = field.value
-      }
-      element.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: field.value }))
-      element.dispatchEvent(new Event("change", { bubbles: true }))
-      element.blur()
-      return field.selector
-    })
-  }, fields)
+      resolvedFields.push({ target: matches[0]!, label: "locator", value: field.value })
+    }
+
+    await page.evaluate((inputFields) => {
+      return inputFields.map((field) => {
+        let element: Node | undefined
+        if (typeof field.target === "string") {
+          const matches = document.querySelectorAll(field.target)
+          if (matches.length !== 1) {
+            throw new Error(`fillInputs expects exactly one match for ${field.label}; got ${matches.length}`)
+          }
+          element = matches[0]
+        } else {
+          element = field.target
+        }
+        if (!(element instanceof HTMLInputElement) && !(element instanceof HTMLTextAreaElement)) {
+          throw new Error(`fillInputs expects input or textarea ${field.label}`)
+        }
+        const prototype = Object.getPrototypeOf(element) as HTMLInputElement | HTMLTextAreaElement
+        const valueSetter = Object.getOwnPropertyDescriptor(element, "value")?.set
+        const prototypeValueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set
+        element.focus()
+        if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+          prototypeValueSetter.call(element, field.value)
+        } else {
+          element.value = field.value
+        }
+        element.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: field.value }))
+        element.dispatchEvent(new Event("change", { bubbles: true }))
+        element.blur()
+        return field.label
+      })
+    }, resolvedFields)
+  } finally {
+    await Promise.all(locatorHandles.map((handle) => handle.dispose().catch(() => {})))
+  }
 }
 
 async function screenshotWithLabels(options: ScreenshotWithLabelsOptions): Promise<ScreenshotWithLabelsResult> {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -8,7 +8,6 @@ import type { JsonObject } from "./protocol.ts"
 import { getObject, parseTargetSelection } from "./relay-helpers.ts"
 import * as RelayClient from "./relay-client.ts"
 import * as RelayLifecycle from "./relay-lifecycle.ts"
-import { startRelay } from "./relay.ts"
 import { browserControlVersion } from "./version.ts"
 
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
@@ -223,31 +222,13 @@ function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSess
   ]
 }
 
-/**
- * Embedded relay: start one in-process. If the port is already taken, probe
- * `/version` through RelayClient to confirm a Browser Control relay is
- * actually serving there before assuming it is safe to proceed.
- */
 const relayLayer = Layer.effectDiscard(
   Effect.gen(function* () {
     const relay = yield* RelayClient.Service
-    const port = yield* RelayClient.portConfig
-    yield* startRelay({ port }).pipe(
-      Effect.catch((error) => {
-        if (isAddressInUse(error)) {
-          return relay.version.pipe(
-            Effect.mapError(() =>
-              new Error(`Port ${port} is in use but does not answer like a Browser Control relay; stop the other process or set BROWSER_CONTROL_PORT`)
-            ),
-            Effect.flatMap((version) => {
-              const problem = RelayLifecycle.relayBuildProblem(version)
-              return problem ? Effect.fail(new Error(problem)) : Effect.void
-            }),
-          )
-        }
-        return Effect.fail(error)
-      }),
-    )
+    const readiness = yield* RelayLifecycle.ensureRelay({ relay })
+    if (readiness.buildProblem) {
+      return yield* Effect.fail(new Error(readiness.buildProblem))
+    }
   }),
 )
 
@@ -431,10 +412,4 @@ function objectSchema(properties: JsonObject, required: readonly string[] = []):
     required: [...required],
     additionalProperties: false,
   }
-}
-
-function isAddressInUse(error: Error): boolean {
-  const nodeError = error as NodeJS.ErrnoException
-  const cause = error.cause as NodeJS.ErrnoException | undefined
-  return nodeError.code === "EADDRINUSE" || cause?.code === "EADDRINUSE"
 }

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -1,5 +1,6 @@
 import { Effect, Schedule, Schema } from "effect"
 import { spawn } from "node:child_process"
+import path from "node:path"
 import process from "node:process"
 import * as RelayClient from "./relay-client.ts"
 import type { ExtensionStatus, RelayVersion } from "./relay-schema.ts"
@@ -126,7 +127,7 @@ function spawnManagedRelay(): Effect.Effect<void, Error> {
       if (!entrypoint) {
         throw new Error("Cannot locate the browser-control CLI entrypoint")
       }
-      const child = spawn(process.execPath, [...process.execArgv, entrypoint, "serve"], {
+      const child = spawn(process.execPath, [...process.execArgv, managedRelayEntrypoint(entrypoint), "serve"], {
         detached: true,
         stdio: "ignore",
         env: { ...process.env, BROWSER_CONTROL_MANAGED_RELAY: "1" },
@@ -135,6 +136,17 @@ function spawnManagedRelay(): Effect.Effect<void, Error> {
     },
     catch: (cause) => cause instanceof Error ? cause : new Error("Failed to start Browser Control relay", { cause }),
   })
+}
+
+export function managedRelayEntrypoint(entrypoint: string): string {
+  const name = path.basename(entrypoint)
+  if (name === "mcp.js") {
+    return path.join(path.dirname(entrypoint), "cli.js")
+  }
+  if (name === "mcp-main.ts") {
+    return path.join(path.dirname(entrypoint), "cli.ts")
+  }
+  return entrypoint
 }
 
 function isRelayUnreachable(error: unknown): error is RelayClient.RelayUnreachable {

--- a/src/relay-types.ts
+++ b/src/relay-types.ts
@@ -49,6 +49,7 @@ export interface ExecuteSandboxLike {
   /** Adoption rollback cleanup does not settle before started Playwright close promises settle. */
   closeSettled(): Effect.Effect<void, Error>
   markTargetCrashed(targetId: string): boolean
+  markTargetDetached(targetId: string): boolean
   getStatus(): {
     readonly sessionId?: string
     readonly connected: boolean

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -1283,6 +1283,7 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       return
     }
     cancelTargetHandoffs(detached.target, "target-detached")
+    sessions.markTargetDetached(detached.target.targetInfo.targetId)
     sessions.releaseAdoptedTarget(detached.target.targetInfo.targetId)
     removeClientTargetAliases(cdpClientSessionAliases.values(), (alias) => alias.tabId === tabId)
     mainFrameIdsByTab.delete(tabId)

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -145,6 +145,16 @@ export class BrowserControlSessions {
     return affectedSessionIds
   }
 
+  markTargetDetached(targetId: string): string[] {
+    const affectedSessionIds: string[] = []
+    for (const session of this.sessions.values()) {
+      if (session.sandbox.markTargetDetached(targetId)) {
+        affectedSessionIds.push(session.id)
+      }
+    }
+    return affectedSessionIds
+  }
+
   delete(id: string): Effect.Effect<boolean, Error> {
     const manager = this
     return Effect.gen(function* () {

--- a/test/execute-ergonomics.test.ts
+++ b/test/execute-ergonomics.test.ts
@@ -5,6 +5,7 @@ import {
   createExecuteLogCapture,
   createSnapshotHelpers,
   defaultAriaSnapshotTimeoutMs,
+  fillInputs,
   pageTargetId,
   runUserCode,
 } from "../src/execute.ts"
@@ -122,6 +123,64 @@ describe("user code execution", () => {
       },
     })
     expect(page.off).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe("fillInputs", () => {
+  it("resolves locators before the single batched page evaluation", async () => {
+    const dispose = vi.fn().mockResolvedValue(undefined)
+    const handle = { dispose } as unknown as Awaited<ReturnType<Locator["elementHandle"]>>
+    const locator = {
+      _frame: { _platform: { boxedStackPrefixes: new Map([["secret", "internal"]]) } },
+      elementHandles: vi.fn().mockResolvedValue([handle]),
+    } as unknown as Locator
+    const evaluate = vi.fn(async (_fn, argument: unknown) => {
+      const fields = argument as Array<{ readonly target: unknown; readonly label: string; readonly value: string }>
+      expect(fields).toEqual([
+        { target: handle, label: "locator", value: "first" },
+        { target: "#second", label: "selector: #second", value: "second" },
+      ])
+      expect(fields[0]?.target).not.toBe(locator)
+      return ["locator", "selector: #second"]
+    })
+    const page = { evaluate } as unknown as Page
+
+    await fillInputs(page, [
+      { selector: locator, value: "first" },
+      { selector: "#second", value: "second" },
+    ])
+
+    expect(locator.elementHandles).toHaveBeenCalledOnce()
+    expect(evaluate).toHaveBeenCalledOnce()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it("rejects an ambiguous locator without serializing it or exposing values", async () => {
+    const handles = [
+      { dispose: vi.fn().mockResolvedValue(undefined) },
+      { dispose: vi.fn().mockResolvedValue(undefined) },
+    ]
+    const locator = { elementHandles: vi.fn().mockResolvedValue(handles) } as unknown as Locator
+    const page = { evaluate: vi.fn() } as unknown as Page
+
+    await expect(fillInputs(page, [{ selector: locator, value: "private-value" }]))
+      .rejects.toThrow("fillInputs expects exactly one match for locator; got 2")
+    expect(page.evaluate).not.toHaveBeenCalled()
+    expect(handles.every((handle) => handle.dispose.mock.calls.length === 1)).toBe(true)
+  })
+
+  it("disposes earlier handles when a later locator fails to resolve", async () => {
+    const dispose = vi.fn().mockResolvedValue(undefined)
+    const first = { elementHandles: vi.fn().mockResolvedValue([{ dispose }]) } as unknown as Locator
+    const second = { elementHandles: vi.fn().mockRejectedValue(new Error("target detached")) } as unknown as Locator
+    const page = { evaluate: vi.fn() } as unknown as Page
+
+    await expect(fillInputs(page, [
+      { selector: first, value: "first" },
+      { selector: second, value: "private-value" },
+    ])).rejects.toThrow("target detached")
+    expect(page.evaluate).not.toHaveBeenCalled()
+    expect(dispose).toHaveBeenCalledOnce()
   })
 })
 

--- a/test/relay-child-dedupe.test.ts
+++ b/test/relay-child-dedupe.test.ts
@@ -123,6 +123,14 @@ describe("relay child target announce dedupe", () => {
             params: { context: { id: 100, origin: "chrome-extension://password-manager", auxData: { isDefault: true } } },
           },
         }))
+        extension.send(JSON.stringify({
+          method: "debugger.detached",
+          params: { tabId: 1, reason: "target_closed", sessionId: "password-manager-child-session" },
+        }))
+        extension.send(JSON.stringify({
+          method: "debugger.detached",
+          params: { tabId: 1, reason: "target_closed" },
+        }))
 
         client.send(JSON.stringify({ id: 2, sessionId: rootSessionId, method: "Target.getTargetInfo", params: {} }))
         client.send(JSON.stringify({ id: 3, sessionId: rootSessionId, method: "Page.navigate", params: { url: "https://example.com/after-focus" } }))

--- a/test/relay-lifecycle.test.ts
+++ b/test/relay-lifecycle.test.ts
@@ -4,6 +4,7 @@ import * as RelayClient from "../src/relay-client.ts"
 import {
   ensureExtensionConnected,
   ensureRelay,
+  managedRelayEntrypoint,
   relayBuildProblem,
   statusCollections,
   stoppedRelayStatus,
@@ -110,5 +111,11 @@ describe("relay lifecycle", () => {
     })).toEqual({ sessions: [], targets: [] })
     expect(relayBuildProblem(version, "build-current")).toBeUndefined()
     expect(relayBuildProblem({ ...version, buildId: "build-old" }, "dev")).toBeUndefined()
+  })
+
+  it("starts a managed relay through the CLI entrypoint from MCP builds and source", () => {
+    expect(managedRelayEntrypoint("/package/dist/mcp.js")).toBe("/package/dist/cli.js")
+    expect(managedRelayEntrypoint("/package/src/mcp-main.ts")).toBe("/package/src/cli.ts")
+    expect(managedRelayEntrypoint("/package/dist/cli.js")).toBe("/package/dist/cli.js")
   })
 })

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -8,6 +8,7 @@ type FakeSandbox = ExecuteSandboxLike & {
   readonly closes: () => number
   readonly adoptedSelections: () => unknown[]
   readonly crashedTargets: () => string[]
+  readonly detachedTargets: () => string[]
 }
 
 const makeFakeSandbox = (options?: {
@@ -21,6 +22,7 @@ const makeFakeSandbox = (options?: {
   let closes = 0
   const adoptedSelections: unknown[] = []
   const crashedTargets: string[] = []
+  const detachedTargets: string[] = []
   const close = () => Effect.sync(() => {
     closes += 1
   }).pipe(Effect.andThen(options?.onClose ?? Effect.void))
@@ -58,10 +60,15 @@ const makeFakeSandbox = (options?: {
       crashedTargets.push(targetId)
       return options?.defaultTargetId === undefined || options.defaultTargetId === targetId
     },
+    markTargetDetached: (targetId) => {
+      detachedTargets.push(targetId)
+      return options?.defaultTargetId === undefined || options.defaultTargetId === targetId
+    },
     getStatus: () => ({ connected: false, pageUrl: null, stateKeys: [] }),
     closes: () => closes,
     adoptedSelections: () => adoptedSelections,
     crashedTargets: () => crashedTargets,
+    detachedTargets: () => detachedTargets,
   }
 }
 
@@ -133,6 +140,19 @@ describe("BrowserControlSessions", () => {
     const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox())
     sessions.createNew("alpha")
     expect(() => sessions.createNew("alpha")).toThrow("Session already exists")
+  })
+
+  it("marks only the session page backed by a detached root target", () => {
+    const first = makeFakeSandbox({ defaultTargetId: "target-1" })
+    const second = makeFakeSandbox({ defaultTargetId: "target-2" })
+    const sandboxes = [first, second]
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => sandboxes.shift()!)
+    sessions.createNew("alpha")
+    sessions.createNew("beta")
+
+    expect(sessions.markTargetDetached("target-1")).toEqual(["alpha"])
+    expect(first.detachedTargets()).toEqual(["target-1"])
+    expect(second.detachedTargets()).toEqual(["target-1"])
   })
 
   it("delete waits for a running execute before closing the sandbox", async () => {


### PR DESCRIPTION
## What

Browser Control now survives the failure modes found during extension-heavy onboarding and long human handoffs:

- `fillInputs` accepts Playwright `Locator` targets without serializing Locator internals or exposing field values.
- A confirmed root detach invalidates the matching retained session page so the next execute creates a fresh relay-owned page instead of sending CDP to a dead session.
- Foreign extension child-target churn and ambiguous `target_closed` evidence remain subordinate to the relay-owned root target.
- MCP and CLI share the same detached relay lifecycle, so MCP exit cannot tear down a pending CLI handoff.
- Smoke cleanup is verified to leave an externally owned relay running and return target/client/session counts to baseline.


## Before / After

**Before:** `fillInputs(page, [{ selector: locator, value }])` attempted to serialize the Locator's private Playwright graph and failed before filling. Password-manager child targets could churn while the root page stayed open; after a real root detach, the execute sandbox retained its stale `Page`, and later navigation failed with `Unknown CDP session`. MCP owned an in-process relay, so MCP shutdown or lifecycle churn could terminate a background CLI handoff. Concurrent smoke runs could therefore appear to take down the relay serving that handoff.

**After:** Locator targets are resolved to exactly one element handle before one batched page evaluation, and every handle is disposed on success or failure. The relay remains the sole detach classifier: child-session detach evidence is removed as child state, ambiguous sessionless `target_closed` is ignored, browser tab removal or authoritative debugger revocation detaches the root, and only then is the matching sandbox page invalidated. MCP probes or starts the same detached CLI relay, which outlives the MCP process. No incomplete Playwright CDP state is reconstructed.

## How

- `src/execute.ts`: resolve string and Locator fields into a safe batched payload; clear only a sandbox whose default target actually detached.
- `src/relay.ts` and `src/session-manager.ts`: propagate authoritative root detach into session state before releasing adoption ownership.
- `src/mcp.ts` and `src/relay-lifecycle.ts`: replace the scoped embedded relay with shared `ensureRelay` startup and map MCP entrypoints to the CLI `serve` entrypoint.
- `test/relay-child-dedupe.test.ts`: prove child detach plus ambiguous sessionless `target_closed` cannot retarget or detach the root page.
- `scripts/smoke.ts`: exercise Locator fill and relay-owned page recreation after root close.
- Docs and skill: document shared CLI/MCP relay lifetime and the expanded smoke matrix.
- Package version: `0.1.1`; extension remains `0.0.17` because the shim and protocol did not change.

## Scope

This does not retry arbitrary navigation, reconstruct detached Playwright sessions, override explicit user debugger revocation, or move root-detach classification into the extension. It does not change the extension bundle.

## Testing

- `pnpm typecheck`
- `pnpm test` (32 files, 260 tests)
- `pnpm build`
- `SMOKE_CASE=execute-fill-helpers,execute-page-detach-recovery,handoff-target-detach pnpm smoke` (3/3 passed)
- `SMOKE_CASE=local-forms,local-cart,local-checkout,reconnect-evaluate,redirect-reconnect-evaluate,execute-target-url,execute-page-recovery,execute-page-detach-recovery,execute-fill-helpers,execute-snapshot-refs,handoff-navigation,handoff-cross-tab,handoff-target-detach,oopif-reconnect,dedicated-worker,session-download-capability,execute-ghost-cursor,session-isolation,multi-client,stale-client-checkout,raw-first-checkout pnpm smoke` (21/21 passed)
- External relay PID remained unchanged after MCP EOF and the full smoke matrix.
- On isolated port `21989`, MCP started a detached relay; after MCP exited, the built CLI created a session through the surviving relay, then the test relay was terminated.
- Final built status: relay `0.1.1`, extension `0.0.17`, matching build, zero sessions and CDP clients.

## Flow

```mermaid
sequenceDiagram
  participant Agent
  participant MCP
  participant CLI
  participant Relay
  participant Extension
  participant Browser

  Agent->>MCP: start or call tool
  MCP->>Relay: probe shared endpoint
  alt relay absent
    MCP->>CLI: spawn detached `serve`
    CLI->>Relay: listen independently of MCP
  end
  Agent->>CLI: execute long handoff
  CLI->>Relay: reuse named session
  Relay->>Extension: drive root target
  Extension->>Browser: chrome.debugger commands
  Browser-->>Extension: child detach or root detach evidence
  Extension-->>Relay: preserve event identity
  alt child or ambiguous target_closed
    Relay->>Relay: keep root and handoff authoritative
  else confirmed root detach
    Relay->>Relay: invalidate matching default Page
    Agent->>CLI: next execute
    CLI->>Relay: create fresh relay-owned page
  end
```