### PR TITLE
chore(release): use the opencode-ai npm scope

### DIFF
--- a/.changeset/bright-otters-reference.md
+++ b/.changeset/bright-otters-reference.md
@@ -1,5 +1,5 @@
 ---
-"@anomalyco/browser-control": patch
+"@opencode-ai/browser-control": patch
 ---
 
 Keep snapshot references stable across safe rerenders when a control has a unique class and accessible identity.

--- a/PLAN.md
+++ b/PLAN.md
@@ -161,7 +161,7 @@ require a new extension capture protocol and permission model.
 ## Distribution And Installation
 
 - The product, repository, CLI, and MCP server use the name `browser-control`.
-  The npm package is `@anomalyco/browser-control`.
+  The npm package is `@opencode-ai/browser-control`.
 - The package is published publicly on npm. Normal setup installs the npm
   artifact; source development uses `pnpm install`, `pnpm build`, and `bun
   link`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Requirements: Node 20+ and a Chromium-family browser.
 Install both CLI entrypoints globally from npm:
 
 ```bash
-npm install --global @anomalyco/browser-control
+npm install --global @opencode-ai/browser-control
 ```
 
 ### 2. Load the extension
@@ -40,7 +40,7 @@ npm install --global @anomalyco/browser-control
    directory. Print its location with:
 
    ```bash
-   printf '%s\n' "$(npm root --global)/@anomalyco/browser-control/extension/dist"
+   printf '%s\n' "$(npm root --global)/@opencode-ai/browser-control/extension/dist"
    ```
 
 4. Pin the Browser Control toolbar button.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@anomalyco/browser-control",
+  "name": "@opencode-ai/browser-control",
   "version": "0.1.1",
   "description": "Local browser driver for trusted agents: control your existing Chromium-family browser through a small extension and a local relay.",
   "license": "MIT",

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -25,7 +25,7 @@ CLI and MCP share this detached relay; restarting the MCP process does not stop
 the relay or interrupt a CLI execute or pending handoff.
 
 If `browser-control` is not on PATH, install it with `npm install --global
-@anomalyco/browser-control`. Use the source setup in the repository README only
+@opencode-ai/browser-control`. Use the source setup in the repository README only
 when developing Browser Control itself.
 
 `browser-control skill` prints this skill text from the installed package/repo.


### PR DESCRIPTION
## What

Change the first public package identity from `@anomalyco/browser-control` to `@opencode-ai/browser-control` before any npm publication occurs.

## How

- Rename the package in `package.json`.
- Update the pending Changeset so the generated release PR versions the correct package.
- Update npm installation, unpacked-extension path, plan, and agent-skill documentation.

## Scope

- The GitHub repository remains `anomalyco/browser-control`; npm trusted publishing will point the `@opencode-ai/browser-control` package at this repository and `release.yml` workflow.
- No npm package has been published under either scope.
- The obsolete `@anomalyco` Changesets release PR was closed before this change.

## Testing

- `pnpm run ci`: 32 test files / 260 tests, typecheck, CLI build, extension build.
- `pnpm changeset status --since origin/main`: recognizes `@opencode-ai/browser-control` as a patch release.
- `pnpm pack --dry-run --json`: confirms the renamed package and unchanged 11-file runtime artifact.
