### PR TITLE
feat(network): add authenticated session capture

### DIFF
--- a/.changeset/smart-network-capture.md
+++ b/.changeset/smart-network-capture.md
@@ -1,0 +1,7 @@
+---
+"@opencode-ai/browser-control": minor
+---
+
+Add session-scoped authenticated network capture, credential-redacted HAR
+exports, stable reusable secret profiles, credential refresh, and redacted
+command execution across CLI, MCP, and the execute sandbox.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,14 @@ local Node relay.
   and expose refs only for added or changed current lines. Keep `ariaSnapshot()`
   and raw Playwright as deeper inspection layers; do not replace the code-first
   execute interface with many action commands.
+- Authenticated network capture is owned by the persistent Execute Sandbox and
+  records normalized exchanges; HAR is only an export adapter. Written
+  artifacts always use route-scoped stable `BC_SECRET_N` references. Lossless
+  values live in restrictive secret profiles and enter generated clients only
+  through `secrets run`. Keep recorder transitions serialized, body retention
+  bounded per body and in aggregate, profile updates locked across relay
+  processes, and credential values out of normal outputs, diagnostics, and
+  journals.
 - With `BROWSER_CONTROL_DEBUG=1`, `[bc:ctx]` lines trace bounded metadata for
   target ownership/browser-context identity, main-frame loaders, Runtime context
   lifecycle/reset attempts, and failed evaluates. Never add expressions,
@@ -175,7 +183,7 @@ local Node relay.
 - Extension shim changes require reloading the unpacked extension once in Brave.
 - Relay-only changes should not require reloading the extension.
 - Use `termctrl` for long-running relay sessions during testing.
-- Run `SMOKE_CASE=local-forms,local-cart,local-checkout,reconnect-evaluate,redirect-reconnect-evaluate,execute-target-url,execute-page-recovery,execute-page-detach-recovery,execute-fill-helpers,execute-snapshot-refs,handoff-navigation,handoff-cross-tab,handoff-target-detach,oopif-reconnect,dedicated-worker,session-download-capability,execute-ghost-cursor,session-isolation,multi-client,stale-client-checkout,raw-first-checkout pnpm smoke`
+- Run `SMOKE_CASE=local-forms,local-cart,local-checkout,reconnect-evaluate,redirect-reconnect-evaluate,execute-target-url,execute-page-recovery,execute-page-detach-recovery,execute-fill-helpers,execute-snapshot-refs,handoff-navigation,handoff-cross-tab,handoff-target-detach,oopif-reconnect,dedicated-worker,network-capture,session-download-capability,execute-ghost-cursor,session-isolation,multi-client,stale-client-checkout,raw-first-checkout pnpm smoke`
   before claiming the current smoke set is green.
 - CDP target visibility is scoped per client (`src/cdp-visibility.ts`):
   session-owned tabs are announced and their events delivered only to that

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,28 @@ _Avoid_: Browser storage, tab state
 The implicit persistent execute sandbox owned by one running MCP server process.
 _Avoid_: Explicit MCP session id
 
+**Network Capture**:
+A session-owned recording of normalized request/response exchanges from the
+session's current default page and its child frames. It survives individual
+execute calls and is independent of any export format.
+_Avoid_: HAR recorder, global request log
+
+**Capture Artifact**:
+An agent-readable export of a Network Capture. HAR is the first compatibility
+format; credential values are represented by Stable Secret References.
+_Avoid_: Raw authenticated HAR, credential bundle
+
+**Secret Profile**:
+A restrictive local store of lossless credential values discovered during a
+Network Capture. Agents use profile metadata and injected references rather
+than reading values directly.
+_Avoid_: HAR credentials, generated-source secrets
+
+**Stable Secret Reference**:
+An environment-variable name such as `BC_SECRET_1` that retains its identity
+when a Secret Profile is refreshed from the same request source.
+_Avoid_: Token value, hardcoded credential
+
 ## Relationships
 
 - A **Driver** serves one or more external **Agents**.
@@ -93,6 +115,9 @@ _Avoid_: Explicit MCP session id
 - An **Agent** controls the browser by running code in an **Execute Sandbox**.
 - An **Execute Sandbox** owns **Persistent State**; the Target Registry owns
   target assignment.
+- An **Execute Sandbox** owns at most one active **Network Capture**.
+- A **Capture Artifact** refers to values in a **Secret Profile** through
+  **Stable Secret References**.
 - **Detach** removes an **Attached Tab** from the **Attached-Tab Pool**.
 
 ## Example Dialogue

--- a/PLAN.md
+++ b/PLAN.md
@@ -235,6 +235,27 @@ reconciles existing client announcements, browser grouping, and page status.
   channel. MCP emits native image attachments without temporary files or
   duplicated base64 metadata.
 
+### Authenticated Network Capture
+
+- Each Execute Sandbox owns one normalized network recorder that follows its
+  default or adopted page across execute calls and page recovery.
+- Playwright page events capture root-frame and child-frame exchanges. HAR is
+  an export adapter, not the recorder's domain model.
+- Request and response bodies have per-body and aggregate byte budgets;
+  truncation, failures, and dropped-entry counts remain visible in summaries.
+- Written artifacts always replace credential-bearing headers, cookies, query
+  parameters, and structured body fields with stable `BC_SECRET_N` references.
+- Named secret profiles retain lossless values in restrictive local files.
+  Cross-process locks serialize profile publication; repeated captures and
+  reload-based refresh preserve references by observed request source.
+- `secrets run` injects profile values into a child process and redacts known
+  values from bounded stdout and stderr before returning them.
+- While capture is active, values observed in completed exchanges and
+  secret-shaped returned data are removed from execute results, URLs, logs,
+  and journal records before they leave the sandbox.
+- CLI, MCP, and execute-sandbox helpers call the same session-owned recorder.
+  Capture is cancelled on session reset, deletion, and relay shutdown.
+
 ### Inspection And Interaction Helpers
 
 - `snapshot(options?)` provides a bounded semantic read-before-act view.
@@ -298,6 +319,9 @@ reconciles existing client announcements, browser grouping, and page status.
 - The extension protocol remains custom JSON over websocket until schema or
   versioning needs justify Effect RPC. Its shared pure validators reject
   malformed commands and envelopes without pulling Effect into the MV3 shim.
+- Authenticated capture stays in the relay-backed session sandbox. The
+  extension forwards the CDP traffic Playwright already needs; Node handles
+  correlation, budgets, export, credential profiles, and refresh.
 
 ### One schema and one client define the relay boundary
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,44 @@ Automatic mode uses browser tab capture for user-owned tabs and CDP screencast
 for relay-created tabs. Tab capture writes WebM and can include audio. CDP mode
 writes WebM or MP4, requires `ffmpeg` on `PATH`, and does not capture audio.
 
+## Derive a Direct Client
+
+Capture authenticated API exchanges across as many execute calls or human
+handoffs as the workflow needs:
+
+```bash
+browser-control network start --session github --url /api/ \
+  --resource-type fetch --resource-type xhr
+browser-control execute --session github --file ./perform-flow.js
+browser-control network stop --session github \
+  --output ./github.har --secrets github
+```
+
+Browser Control records normalized request/response exchanges itself; HAR is an
+interoperable export, not the internal capture model. Written artifacts replace
+cookies, authorization headers, CSRF tokens, API keys, and token-like query or
+body fields with stable `${BC_SECRET_N}` references. Lossless values are stored
+separately in a mode-`0600` profile under `~/.browser-control/secrets`.
+Bodies that cannot be reliably redacted, including binary and file-bearing
+multipart content, are omitted and reported as truncated.
+Unknown-length and compressed response bodies are also omitted so Browser
+Control never materializes them before it can enforce the configured budget.
+
+Generated clients read the referenced environment variables and run without
+printing or embedding the values:
+
+```bash
+browser-control secrets status github
+browser-control secrets run github -- ./github-cli repositories
+browser-control secrets refresh github --session github
+```
+
+`secrets refresh` reloads the session page and preserves references while
+updating values observed at the same source. If reauthentication requires a
+human flow, log in through the browser and repeat the capture with the same
+profile name instead. Child stdout and stderr are redacted before Browser
+Control returns them.
+
 ## Safety Boundaries
 
 Browser Control trusts the local agent code it executes. It is a driver, not an

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -6,9 +6,11 @@ import { WebSocket } from "ws"
 import cp from "node:child_process"
 import fs from "node:fs/promises"
 import http from "node:http"
+import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import util from "node:util"
+import { getObject } from "../src/relay-helpers.ts"
 
 const endpointUrl = process.env.BROWSER_CONTROL_ENDPOINT ?? "http://127.0.0.1:19989"
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
@@ -1046,6 +1048,74 @@ return { answer: await worker.evaluate(() => globalThis.answer), url: worker.url
     }),
   },
   {
+    name: "network-capture",
+    run: Effect.fnUntraced(function* () {
+      const marker = `bc-network-${Date.now()}`
+      const smokeSession = `${marker}-session`
+      const profile = `${marker}-profile`
+      const outputPath = path.join(repoRoot, "tmp", `${marker}.har`)
+      return yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fixture = yield* scopedNetworkFixture(marker)
+          yield* runBrowserControl(["session", "new", smokeSession])
+          yield* runBrowserControl([
+            "network", "start", "--session", smokeSession, "--url", "/api/", "--resource-type", "fetch",
+          ])
+          const executeOutput = yield* runBrowserControl([
+            "execute",
+            "--session",
+            smokeSession,
+            `const responsePromise = page.waitForResponse((candidate) => candidate.url().includes('/api/data'), { timeout: 10000 }); await page.goto(${JSON.stringify(fixture.url)}); const body = await (await responsePromise).json(); return { marker: body.marker, refreshToken: body.refreshToken }`,
+          ])
+          if (!executeOutput.includes(marker) || executeOutput.includes("smoke-refresh-")) {
+            return yield* Effect.fail(new Error(`network fixture execute output was missing its marker or exposed a credential: ${executeOutput}`))
+          }
+          const journalOutput = yield* runBrowserControl(["journal", "--session", smokeSession, "--json"])
+          if (journalOutput.includes("smoke-refresh-") || journalOutput.includes("smoke-access-") || journalOutput.includes("smoke-query-token")) {
+            return yield* Effect.fail(new Error("network capture credential appeared in the session journal"))
+          }
+          const stopOutput = yield* runBrowserControl([
+            "network", "stop", "--session", smokeSession, "--output", outputPath, "--secrets", profile, "--json",
+          ])
+          const stop = parseJsonObject(stopOutput, "network stop")
+          if (stop.entryCount !== 1 || stop.responseCount !== 1 || !Array.isArray(stop.observedSecretRefs) || stop.observedSecretRefs.length < 2) {
+            return yield* Effect.fail(new Error(`network stop summary invalid: ${stopOutput}`))
+          }
+          const artifact = yield* Effect.tryPromise({
+            try: () => fs.readFile(outputPath, "utf8"),
+            catch: (cause) => new Error("read network smoke artifact", { cause }),
+          })
+          if (artifact.includes("smoke-access-") || artifact.includes("smoke-query-token") || !artifact.includes("${BC_SECRET_1}")) {
+            return yield* Effect.fail(new Error("network artifact did not redact synthetic credentials"))
+          }
+          const refreshOutput = yield* runBrowserControl([
+            "secrets", "refresh", profile, "--session", smokeSession, "--url", "/api/", "--json",
+          ])
+          const refresh = parseJsonObject(refreshOutput, "secrets refresh")
+          if (!Array.isArray(refresh.observedSecretRefs) || refresh.observedSecretRefs.length < 2 || !Array.isArray(refresh.updatedSecretRefs) || refresh.updatedSecretRefs.length < 1) {
+            return yield* Effect.fail(new Error(`secret refresh did not observe and update stable refs: ${refreshOutput}`))
+          }
+          const runOutput = yield* runBrowserControl([
+            "secrets", "run", profile, "--", process.execPath, "-e", "process.stdout.write(process.env.BC_SECRET_1 || '')",
+          ])
+          if (runOutput !== "${BC_SECRET_1}") {
+            return yield* Effect.fail(new Error(`secret command output was not redacted: ${runOutput}`))
+          }
+          return { entries: stop.entryCount, observed: refresh.observedSecretRefs.length, refreshed: refresh.updatedSecretRefs.length }
+        }).pipe(
+          Effect.ensuring(
+            Effect.gen(function* () {
+              yield* runBrowserControl(["network", "cancel", "--session", smokeSession]).pipe(Effect.ignore)
+              yield* runBrowserControl(["session", "delete", smokeSession]).pipe(Effect.ignore)
+              yield* removePath(outputPath)
+              yield* removePath(path.join(os.homedir(), ".browser-control", "secrets", `${profile}.json`))
+            }),
+          ),
+        ),
+      )
+    }),
+  },
+  {
     name: "session-download-capability",
     run: Effect.fnUntraced(function* () {
       const marker = `bc-download-${Date.now()}`
@@ -1682,6 +1752,51 @@ const scopedDownloadFixture = Effect.fnUntraced(function* (marker: string) {
     (fixture) => boundedCleanup("close download fixture", () => new Promise<void>((resolve) => fixture.server.close(() => resolve()))),
   )
 })
+
+const scopedNetworkFixture = Effect.fnUntraced(function* (marker: string) {
+  return yield* Effect.acquireRelease(
+    Effect.tryPromise({
+      try: () => new Promise<{ readonly server: http.Server; readonly url: string }>((resolve, reject) => {
+        let pageLoads = 0
+        const server = http.createServer((request, response) => {
+          if (request.url?.startsWith("/api/data")) {
+            const body = JSON.stringify({ marker, refreshToken: `smoke-refresh-${pageLoads}` })
+            response.writeHead(200, { "content-type": "application/json", "content-length": Buffer.byteLength(body) })
+            response.end(body)
+            return
+          }
+          pageLoads += 1
+          response.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+          response.end(`<!doctype html><title>${marker}</title><script>
+            fetch('/api/data?access_token=smoke-query-token', {
+              headers: { authorization: 'Bearer smoke-access-${pageLoads}' }
+            })
+          </script>`)
+        })
+        server.once("error", reject)
+        server.listen(0, "127.0.0.1", () => {
+          server.off("error", reject)
+          const address = server.address()
+          if (!address || typeof address === "string") {
+            server.close()
+            reject(new Error("network fixture did not receive a TCP address"))
+            return
+          }
+          resolve({ server, url: `http://127.0.0.1:${address.port}/` })
+        })
+      }),
+      catch: (cause) => new Error("start network fixture", { cause }),
+    }),
+    (fixture) => boundedCleanup("close network fixture", () => new Promise<void>((resolve) => fixture.server.close(() => resolve()))),
+  )
+})
+
+function parseJsonObject(text: string, label: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(text)
+  const object = getObject(parsed)
+  if (!object) throw new Error(`${label} did not return a JSON object`)
+  return object
+}
 
 function getBrowserContext(browser: Browser): Promise<BrowserContext> {
   const existing = browser.contexts()[0]

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -348,6 +348,91 @@ in-progress form edits. Persistent tabs preserve navigation and DOM state betwee
 commands, but a single script is safer when one action creates the exact UI state
 that the next action must consume.
 
+## Authenticated Network Capture
+
+Use network capture when repeated direct HTTP calls would be faster and more
+reliable than driving the browser every time. Browser Control records normalized
+Playwright request/response exchanges itself; HAR is only the interoperable
+export format.
+
+Start from a logged-in session, then exercise each client flow at least twice
+with different inputs so constants and parameters can be distinguished:
+
+```bash
+browser-control network start --session github --url /api/ \
+  --resource-type fetch --resource-type xhr
+browser-control execute --session github --file ./perform-flow.js
+browser-control network status --session github
+browser-control network stop --session github \
+  --output ./github.har --secrets github
+```
+
+Captures span execute calls and handoffs and follow the session's default page
+when it is adopted or recovered. Bodies default to `embed`; use `--content omit`
+when shapes are unnecessary. The defaults cap each body at 1 MB, total retained
+body data at 25 MB, and entries at 1000. Status and stop results report body
+bytes, truncations, failures, and dropped entries without captured values.
+JSON, URL-encoded forms, and text-only multipart forms are exported with
+credential substitution. Opaque, malformed, file-bearing multipart, binary, and
+truncated bodies are omitted and counted as truncated rather than written
+without reliable redaction.
+Response bodies also require an uncompressed declared `Content-Length` within
+the remaining budgets; unknown-length or compressed bodies are omitted rather
+than materialized without a memory bound.
+
+Written artifacts are safe by default: credential-bearing headers, cookies,
+token-like query parameters, and structured body fields become literal stable
+references such as `${BC_SECRET_1}`. `--secrets github` stores the original
+values separately in `~/.browser-control/secrets/github.json` with mode `0600`.
+Never copy profile values into generated source, output, diagnostics, or a
+session journal.
+While capture is active, Browser Control also substitutes values observed in
+completed exchanges and removes secret-shaped returned fields from execute
+results, logs, URLs, and journal records. Do not deliberately return or log
+credentials; this redaction is a final safety boundary, not a secret-inspection
+interface.
+
+Inspect the HAR offline to identify first-party JSON endpoints, request
+dependencies, response shapes, pagination, and required headers. Generate one
+typed function per observed flow. Generated code reads the exact `BC_SECRET_N`
+environment variables referenced by the artifact and gives a concise refresh
+instruction on 401/403. Verify every generated function with a harmless live
+request before declaring the client complete.
+
+Run a generated client without exposing credential values:
+
+```bash
+browser-control secrets status github
+browser-control secrets run github -- ./github-cli repositories
+```
+
+Browser Control injects the profile as environment variables and replaces known
+values in bounded child stdout/stderr with their references. Do not print the
+environment variables in generated code; redaction is defense in depth, not an
+invitation to log credentials.
+
+For credentials normally renewed by a page reload:
+
+```bash
+browser-control secrets refresh github --session github --url /api/
+```
+
+Refresh preserves a reference when the credential observed at that source
+changes, and succeeds when a still-valid value is observed unchanged. If the
+site requires login, 2FA, or another human action instead, reauthenticate in the
+adopted tab and repeat `network start`/`network stop --secrets github`; the same
+source-based refresh behavior applies.
+
+Execute code has equivalent `network.start(options)`, `network.status()`,
+`network.stop({ outputPath, secrets })`, and `network.cancel()` helpers. MCP
+provides `network_start`, `network_status`, `network_stop`, `network_cancel`,
+`secrets_status`, `secrets_refresh`, and `secrets_run` over the same recorder and
+profile store.
+Pass an absolute `outputPath` from execute code (use the provided `path.resolve`)
+so artifact location does not depend on the detached relay's original working
+directory. CLI and MCP resolve relative output and child-command paths against
+their caller process working directory before contacting the relay.
+
 ## Labeled Screenshots
 
 Use `screenshotWithLabels({ page, path? })` when a visual page read would help.

--- a/src/auth-profile.ts
+++ b/src/auth-profile.ts
@@ -1,0 +1,413 @@
+import { Effect, Schema, Semaphore } from "effect"
+import { spawn } from "node:child_process"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { redactKnownValues, type CredentialSlot } from "./network-redaction.ts"
+
+const StoredCredentialSlot = Schema.Struct({
+  ref: Schema.String.check(Schema.isPattern(/^BC_SECRET_[1-9][0-9]*$/)),
+  value: Schema.String,
+  sources: Schema.Array(Schema.String),
+  expiresAt: Schema.optionalKey(Schema.String),
+})
+
+const StoredAuthProfile = Schema.Struct({
+  version: Schema.Literal(1),
+  name: Schema.String,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  slots: Schema.Array(StoredCredentialSlot),
+}).check(Schema.makeFilter((profile) => {
+  const refs = profile.slots.map((slot) => slot.ref)
+  if (new Set(refs).size !== refs.length) return "Auth profile refs must be unique"
+  const sources = profile.slots.flatMap((slot) => slot.sources)
+  return new Set(sources).size === sources.length ? undefined : "Auth profile sources must be unique"
+}))
+
+export interface AuthProfile extends Schema.Schema.Type<typeof StoredAuthProfile> {}
+
+export type AuthProfileSummary = {
+  readonly name: string
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly slotCount: number
+  readonly slots: readonly {
+    readonly ref: string
+    readonly sources: readonly string[]
+    readonly expiresAt?: string
+    readonly expired: boolean
+  }[]
+}
+
+export type AuthRunResult = {
+  readonly exitCode: number
+  readonly signal: string | null
+  readonly stdout: string
+  readonly stderr: string
+  readonly stdoutTruncated: boolean
+  readonly stderrTruncated: boolean
+  readonly durationMs: number
+}
+
+export class AuthProfileError extends Schema.TaggedErrorClass<AuthProfileError>()(
+  "AuthProfile.Error",
+  {
+    message: Schema.String,
+    operation: Schema.String,
+    reason: Schema.Literals(["invalid-name", "not-found", "read-failed", "invalid-json", "invalid-profile", "write-failed", "run-failed"]),
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {}
+
+export const defaultBaseDir = (): string => path.join(os.homedir(), ".browser-control", "secrets")
+const writeLock = Semaphore.makeUnsafe(1)
+const profileLockTimeoutMs = 30_000
+const staleProfileLockMs = 60_000
+
+export const read = Effect.fn("AuthProfile.read")(function* (name: string, options: { readonly baseDir?: string } = {}) {
+  const filePath = yield* profilePath(options.baseDir ?? defaultBaseDir(), name)
+  const text = yield* Effect.tryPromise({
+    try: () => fs.readFile(filePath, "utf8"),
+    catch: (cause) => isNodeError(cause) && cause.code === "ENOENT"
+      ? new AuthProfileError({ message: `Auth profile not found: ${name}`, operation: "read", reason: "not-found", cause })
+      : new AuthProfileError({ message: `Could not read auth profile: ${name}`, operation: "read", reason: "read-failed", cause }),
+  })
+  return yield* Schema.decodeUnknownEffect(StoredAuthProfile)(yield* Effect.try({
+    try: () => JSON.parse(text),
+    catch: (cause) => new AuthProfileError({ message: `Auth profile is not valid JSON: ${name}`, operation: "read", reason: "invalid-json", cause }),
+  })).pipe(
+    Effect.mapError((cause) => cause instanceof AuthProfileError
+      ? cause
+      : new AuthProfileError({ message: `Auth profile has an invalid shape: ${name}`, operation: "read", reason: "invalid-profile", cause })),
+  )
+})
+
+export const readOptional = Effect.fn("AuthProfile.readOptional")(function* (name: string, options: { readonly baseDir?: string } = {}) {
+  return yield* read(name, options).pipe(
+    Effect.catchIf((error) => error.reason === "not-found", () => Effect.succeed(undefined)),
+  )
+})
+
+export function withLock<A, E, R>(
+  name: string,
+  options: { readonly baseDir?: string },
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | AuthProfileError, R> {
+  const baseDir = options.baseDir ?? defaultBaseDir()
+  const acquire = Effect.gen(function* () {
+    const filePath = yield* profilePath(baseDir, name)
+    const lockPath = `${filePath}.lock`
+    yield* Effect.tryPromise({
+      try: async () => {
+        await fs.mkdir(baseDir, { recursive: true, mode: 0o700 })
+        await fs.chmod(baseDir, 0o700)
+        const deadline = Date.now() + profileLockTimeoutMs
+        while (true) {
+          try {
+            const handle = await fs.open(lockPath, "wx", 0o600)
+            let written = false
+            try {
+              await handle.writeFile(`${process.pid}\n`)
+              written = true
+            } finally {
+              await handle.close()
+              if (!written) await fs.unlink(lockPath).catch(() => {})
+            }
+            return
+          } catch (cause) {
+            if (!isNodeError(cause) || cause.code !== "EEXIST") throw cause
+            const stat = await fs.stat(lockPath).catch(() => undefined)
+            if (stat && Date.now() - stat.mtimeMs > staleProfileLockMs) {
+              await fs.unlink(lockPath).catch(() => {})
+              continue
+            }
+            if (Date.now() >= deadline) throw new Error(`Timed out waiting for auth profile lock: ${name}`)
+            await new Promise((resolve) => setTimeout(resolve, 25))
+          }
+        }
+      },
+      catch: (cause) => new AuthProfileError({ message: `Could not lock auth profile: ${name}`, operation: "lock", reason: "write-failed", cause }),
+    })
+    return lockPath
+  })
+  return Effect.acquireUseRelease(
+    acquire,
+    () => effect,
+    (lockPath) => Effect.tryPromise({
+      try: () => fs.unlink(lockPath).catch(() => {}).then(() => {}),
+      catch: (cause) => new AuthProfileError({ message: `Could not release auth profile lock: ${name}`, operation: "lock", reason: "write-failed", cause }),
+    }),
+  )
+}
+
+const writeProfile = Effect.fnUntraced(function* (options: {
+  readonly name: string
+  readonly slots: readonly CredentialSlot[]
+  readonly baseDir?: string
+}) {
+  const baseDir = options.baseDir ?? defaultBaseDir()
+  const filePath = yield* profilePath(baseDir, options.name)
+  const existing = yield* readOptional(options.name, { baseDir })
+  const now = new Date().toISOString()
+  const profile: AuthProfile = {
+    version: 1,
+    name: options.name,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+    slots: options.slots.map((slot) => ({
+      ref: slot.ref,
+      value: slot.value,
+      sources: [...slot.sources],
+      ...(slot.expiresAt ? { expiresAt: slot.expiresAt } : {}),
+    })),
+  }
+  yield* Schema.decodeUnknownEffect(StoredAuthProfile)(profile).pipe(
+    Effect.mapError((cause) => new AuthProfileError({ message: `Auth profile has an invalid shape: ${options.name}`, operation: "write", reason: "invalid-profile", cause })),
+  )
+  if (existing && sameSlots(existing.slots, profile.slots)) return summary(existing)
+  yield* Effect.tryPromise({
+    try: async () => {
+      await fs.mkdir(baseDir, { recursive: true, mode: 0o700 })
+      await fs.chmod(baseDir, 0o700)
+      const temporaryPath = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`
+      let renamed = false
+      try {
+        await fs.writeFile(temporaryPath, `${JSON.stringify(profile, null, 2)}\n`, { mode: 0o600 })
+        await fs.rename(temporaryPath, filePath)
+        renamed = true
+        await fs.chmod(filePath, 0o600)
+      } finally {
+        if (!renamed) await fs.rm(temporaryPath, { force: true }).catch(() => {})
+      }
+    },
+    catch: (cause) => new AuthProfileError({ message: `Could not write auth profile: ${options.name}`, operation: "write", reason: "write-failed", cause }),
+  })
+  return summary(profile)
+})
+
+export const write = Effect.fn("AuthProfile.write")(function* (options: {
+  readonly name: string
+  readonly slots: readonly CredentialSlot[]
+  readonly baseDir?: string
+}) {
+  return yield* writeLock.withPermit(writeProfile(options))
+})
+
+export const status = Effect.fn("AuthProfile.status")(function* (name: string, options: { readonly baseDir?: string } = {}) {
+  return summary(yield* read(name, options))
+})
+
+export const run = Effect.fn("AuthProfile.run")(function* (options: {
+  readonly name: string
+  readonly command: string
+  readonly args?: readonly string[]
+  readonly cwd?: string
+  readonly timeoutMs?: number
+  readonly maxOutputBytes?: number
+  readonly baseDir?: string
+}) {
+  if (!options.command.trim()) {
+    return yield* Effect.fail(new AuthProfileError({ message: "Auth command must not be empty", operation: "run", reason: "run-failed" }))
+  }
+  const profile = yield* read(options.name, { ...(options.baseDir ? { baseDir: options.baseDir } : {}) })
+  const startedAt = Date.now()
+  const maxOutputBytes = options.maxOutputBytes ?? 1_000_000
+  const maxSecretBytes = profile.slots.reduce((max, slot) => Math.max(max, Buffer.byteLength(slot.value)), 0)
+  const result = yield* runChild({
+      command: options.command,
+      args: options.args ?? [],
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+      timeoutMs: options.timeoutMs ?? 120_000,
+      maxOutputBytes: maxOutputBytes + maxSecretBytes,
+      env: Object.fromEntries(profile.slots.map((slot) => [slot.ref, slot.value])),
+    }).pipe(
+      Effect.mapError((cause) => new AuthProfileError({ message: `Could not run command with auth profile ${options.name}`, operation: "run", reason: "run-failed", cause })),
+    )
+  const stdout = redactOutput(result.stdout, profile.slots, maxOutputBytes)
+  const stderr = redactOutput(result.stderr, profile.slots, maxOutputBytes)
+  return {
+    ...result,
+    stdout: stdout.text,
+    stderr: stderr.text,
+    stdoutTruncated: result.stdoutTruncated || stdout.truncated,
+    stderrTruncated: result.stderrTruncated || stderr.truncated,
+    durationMs: Date.now() - startedAt,
+  } satisfies AuthRunResult
+})
+
+export const remove = Effect.fn("AuthProfile.remove")(function* (name: string, options: { readonly baseDir?: string } = {}) {
+  const filePath = yield* profilePath(options.baseDir ?? defaultBaseDir(), name)
+  return yield* Effect.tryPromise({
+    try: async () => {
+      try {
+        await fs.unlink(filePath)
+        return true
+      } catch (cause) {
+        if (isNodeError(cause) && cause.code === "ENOENT") return false
+        throw cause
+      }
+    },
+    catch: (cause) => new AuthProfileError({ message: `Could not delete auth profile: ${name}`, operation: "delete", reason: "write-failed", cause }),
+  })
+})
+
+function summary(profile: AuthProfile): AuthProfileSummary {
+  const now = Date.now()
+  return {
+    name: profile.name,
+    createdAt: profile.createdAt,
+    updatedAt: profile.updatedAt,
+    slotCount: profile.slots.length,
+    slots: profile.slots.map((slot) => ({
+      ref: slot.ref,
+      sources: [...slot.sources],
+      ...(slot.expiresAt ? { expiresAt: slot.expiresAt } : {}),
+      expired: slot.expiresAt ? Date.parse(slot.expiresAt) <= now : false,
+    })),
+  }
+}
+
+function profilePath(baseDir: string, name: string): Effect.Effect<string, AuthProfileError> {
+  return /^[a-z0-9][a-z0-9._-]{0,63}$/i.test(name)
+    ? Effect.succeed(path.join(baseDir, `${name}.json`))
+    : Effect.fail(new AuthProfileError({ message: `Invalid auth profile name: ${name}`, operation: "path", reason: "invalid-name" }))
+}
+
+function sameSlots(left: readonly CredentialSlot[], right: readonly CredentialSlot[]): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function redactOutput(text: string, slots: readonly CredentialSlot[], maxBytes: number): { readonly text: string; readonly truncated: boolean } {
+  const bytes = Buffer.from(text)
+  let cutoff = Math.min(bytes.length, maxBytes)
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const slot of slots) {
+      if (!slot.value) continue
+      const secret = Buffer.from(slot.value)
+      let start = bytes.indexOf(secret)
+      while (start >= 0 && start < cutoff) {
+        if (start + secret.length > cutoff) {
+          cutoff = start
+          changed = true
+          break
+        }
+        start = bytes.indexOf(secret, start + secret.length)
+      }
+    }
+  }
+  return {
+    text: redactKnownValues(bytes.subarray(0, cutoff).toString("utf8"), slots),
+    truncated: cutoff < bytes.length,
+  }
+}
+
+function runChild(options: {
+  readonly command: string
+  readonly args: readonly string[]
+  readonly cwd?: string
+  readonly timeoutMs: number
+  readonly maxOutputBytes: number
+  readonly env: Readonly<Record<string, string>>
+}): Effect.Effect<Omit<AuthRunResult, "durationMs">, Error> {
+  return Effect.callback((resume) => {
+    const child = spawn(options.command, [...options.args], {
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+      env: childEnvironment(options.env),
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    let stdoutBytes = 0
+    let stderrBytes = 0
+    let stdoutTruncated = false
+    let stderrTruncated = false
+    const append = (chunks: Buffer[], chunk: Buffer, currentBytes: number): number => {
+      const remaining = options.maxOutputBytes - currentBytes
+      if (remaining <= 0) return currentBytes
+      chunks.push(chunk.subarray(0, remaining))
+      return currentBytes + Math.min(chunk.length, remaining)
+    }
+    child.stdout.on("data", (chunk: Buffer) => {
+      const next = append(stdout, chunk, stdoutBytes)
+      stdoutTruncated ||= next - stdoutBytes < chunk.length
+      stdoutBytes = next
+    })
+    child.stderr.on("data", (chunk: Buffer) => {
+      const next = append(stderr, chunk, stderrBytes)
+      stderrTruncated ||= next - stderrBytes < chunk.length
+      stderrBytes = next
+    })
+    let closed = false
+    let settled = false
+    let closePromiseResolve: (() => void) | undefined
+    const closePromise = new Promise<void>((resolve) => {
+      closePromiseResolve = resolve
+    })
+    const timeout = setTimeout(() => {
+      void terminateChild(child, closePromise, () => closed)
+    }, options.timeoutMs)
+    child.once("error", (cause) => {
+      clearTimeout(timeout)
+      closed = true
+      closePromiseResolve?.()
+      if (settled) return
+      settled = true
+      resume(Effect.fail(cause))
+    })
+    child.once("close", (code, signal) => {
+      clearTimeout(timeout)
+      closed = true
+      closePromiseResolve?.()
+      if (settled) return
+      settled = true
+      resume(Effect.succeed({
+        exitCode: code ?? 1,
+        signal,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        stdoutTruncated,
+        stderrTruncated,
+      }))
+    })
+    return Effect.promise(() => terminateChild(child, closePromise, () => closed))
+  })
+}
+
+function childEnvironment(profile: Readonly<Record<string, string>>): NodeJS.ProcessEnv {
+  const inherited = Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => !/^BC_SECRET_[1-9][0-9]*$/.test(name)),
+  )
+  return { ...inherited, ...profile }
+}
+
+async function terminateChild(child: ReturnType<typeof spawn>, closePromise: Promise<void>, isClosed: () => boolean): Promise<void> {
+  if (isClosed()) return
+  signalChild(child, "SIGTERM")
+  await Promise.race([closePromise, new Promise<void>((resolve) => setTimeout(resolve, 1_000))])
+  if (!isClosed()) {
+    signalChild(child, "SIGKILL")
+    await closePromise
+  }
+}
+
+function signalChild(child: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
+  if (process.platform !== "win32" && child.pid !== undefined) {
+    try {
+      process.kill(-child.pid, signal)
+      return
+    } catch {
+      // The child may have exited between the state check and the signal.
+    }
+  }
+  child.kill(signal)
+}
+
+function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error && "code" in value
+}
+
+export * as AuthProfile from "./auth-profile.ts"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { createDoctorReport, formatDoctorReport } from "./doctor.ts"
 import { runMcpServer } from "./mcp.ts"
 import * as RelayClient from "./relay-client.ts"
 import * as RelayLifecycle from "./relay-lifecycle.ts"
-import type { ExecuteAftermath, ExecuteLogEntry, ExecuteResponse } from "./relay-schema.ts"
+import type { ExecuteAftermath, ExecuteLogEntry, ExecuteResponse, NetworkStatusResponse, NetworkStopResponse } from "./relay-schema.ts"
 import { startRelay } from "./relay.ts"
 import { defaultJournalBaseDir, formatJournalEntry, readJournalEntries } from "./session-journal.ts"
 import * as SessionStore from "./session-store.ts"
@@ -623,6 +623,196 @@ const recording = Command.make("recording").pipe(
   Command.withSubcommands([recordingStart, recordingStop, recordingStatus, recordingCancel]),
 )
 
+const networkSession = Effect.fnUntraced(function* (session: Option.Option<string>) {
+  return yield* resolveExistingSessionId(optionString(session) ?? Option.getOrUndefined(yield* sessionIdConfig))
+})
+
+const parseNetworkContent = Effect.fnUntraced(function* (content: Option.Option<string>) {
+  const value = optionString(content)
+  if (value === undefined || value === "embed" || value === "omit") return value
+  return yield* Effect.fail(new Error("Network content must be embed or omit"))
+})
+
+function formatNetworkStatus(status: NetworkStatusResponse): string {
+  if (!status.active) return "Network capture: inactive"
+  return `Network capture: active entries=${status.entryCount} responses=${status.responseCount} failures=${status.failureCount} bodyBytes=${status.capturedBodyBytes} truncated=${status.truncatedBodyCount} dropped=${status.droppedEntryCount} startedAt=${status.startedAt ?? "unknown"}`
+}
+
+function formatNetworkResult(result: NetworkStopResponse): string {
+  const output = result.outputPath ? ` output=${result.outputPath}` : ""
+  const profile = result.authProfile ? ` secrets=${result.authProfile.name}(${result.authProfile.slotCount})` : ""
+  return `Network capture stopped: entries=${result.entryCount} responses=${result.responseCount} failures=${result.failureCount} bodyBytes=${result.capturedBodyBytes} truncated=${result.truncatedBodyCount} dropped=${result.droppedEntryCount}${output}${profile}`
+}
+
+const networkStart = Command.make(
+  "start",
+  {
+    session: Flag.string("session").pipe(Flag.optional, Flag.withAlias("s"), Flag.withDescription("Capture the default page for this Browser Control session")),
+    urlFilter: Flag.string("url").pipe(Flag.optional, Flag.withDescription("Capture only requests whose URL contains this text")),
+    resourceTypes: Flag.string("resource-type").pipe(Flag.atMost(50), Flag.withDescription("Capture this Playwright resource type; repeat for multiple types")),
+    content: Flag.string("content").pipe(Flag.optional, Flag.withDescription("Response and request body mode: embed (default) or omit")),
+    maxBodyBytes: Flag.integer("max-body-bytes").pipe(Flag.optional, Flag.withDescription("Maximum captured bytes per body, defaults to 1000000")),
+    maxTotalBodyBytes: Flag.integer("max-total-body-bytes").pipe(Flag.optional, Flag.withDescription("Maximum captured body bytes for the whole capture, defaults to 25000000")),
+    maxEntries: Flag.integer("max-entries").pipe(Flag.optional, Flag.withDescription("Maximum request entries, defaults to 1000")),
+    json: Flag.boolean("json").pipe(Flag.withDescription("Print machine-readable JSON")),
+  },
+  Effect.fn("Cli.networkStart")(function* ({ session, urlFilter, resourceTypes, content, maxBodyBytes, maxTotalBodyBytes, maxEntries, json }) {
+    const relay = yield* RelayClient.Service
+    yield* ensureCliRelayAndExtension()
+    const sessionId = yield* networkSession(session)
+    const contentValue = yield* parseNetworkContent(content)
+    const urlFilterValue = optionString(urlFilter)
+    const maxBodyBytesValue = optionNumber(maxBodyBytes)
+    const maxTotalBodyBytesValue = optionNumber(maxTotalBodyBytes)
+    const maxEntriesValue = optionNumber(maxEntries)
+    const result = yield* relay.networkStart({
+      sessionId,
+      ...(urlFilterValue === undefined ? {} : { urlFilter: urlFilterValue }),
+      ...(resourceTypes.length === 0 ? {} : { resourceTypes }),
+      ...(contentValue === undefined ? {} : { content: contentValue }),
+      ...(maxBodyBytesValue === undefined ? {} : { maxBodyBytes: maxBodyBytesValue }),
+      ...(maxTotalBodyBytesValue === undefined ? {} : { maxTotalBodyBytes: maxTotalBodyBytesValue }),
+      ...(maxEntriesValue === undefined ? {} : { maxEntries: maxEntriesValue }),
+    })
+    yield* Console.log(json ? JSON.stringify(result, null, 2) : formatNetworkStatus(result))
+  }),
+).pipe(Command.withDescription("Start session-scoped network capture"))
+
+const networkStatus = Command.make(
+  "status",
+  {
+    session: Flag.string("session").pipe(Flag.optional, Flag.withAlias("s")),
+    json: Flag.boolean("json").pipe(Flag.withDescription("Print machine-readable JSON")),
+  },
+  Effect.fn("Cli.networkStatus")(function* ({ session, json }) {
+    const relay = yield* RelayClient.Service
+    const sessionId = yield* networkSession(session)
+    const result = yield* relay.networkStatus({ sessionId })
+    yield* Console.log(json ? JSON.stringify(result, null, 2) : formatNetworkStatus(result))
+  }),
+).pipe(Command.withDescription("Show session-scoped network capture status"))
+
+const networkStop = Command.make(
+  "stop",
+  {
+    session: Flag.string("session").pipe(Flag.optional, Flag.withAlias("s")),
+    output: Flag.string("output").pipe(Flag.optional, Flag.withAlias("o"), Flag.withDescription("Write a credential-redacted HAR artifact to this path")),
+    secrets: Flag.string("secrets").pipe(Flag.optional, Flag.withDescription("Store captured credentials under this reusable profile name")),
+    json: Flag.boolean("json").pipe(Flag.withDescription("Print machine-readable JSON")),
+  },
+  Effect.fn("Cli.networkStop")(function* ({ session, output, secrets, json }) {
+    const relay = yield* RelayClient.Service
+    const sessionId = yield* networkSession(session)
+    const outputValue = optionString(output)
+    const secretsValue = optionString(secrets)
+    if (!outputValue && !secretsValue) {
+      return yield* Effect.fail(new Error("network stop requires --output, --secrets, or both"))
+    }
+    const result = yield* relay.networkStop({
+      sessionId,
+      ...(outputValue ? { outputPath: path.resolve(outputValue) } : {}),
+      ...(secretsValue ? { secrets: secretsValue } : {}),
+    })
+    yield* Console.log(json ? JSON.stringify(result, null, 2) : formatNetworkResult(result))
+  }),
+).pipe(Command.withDescription("Stop capture and write a redacted artifact or reusable secret profile"))
+
+const networkCancel = Command.make(
+  "cancel",
+  { session: Flag.string("session").pipe(Flag.optional, Flag.withAlias("s")) },
+  Effect.fn("Cli.networkCancel")(function* ({ session }) {
+    const relay = yield* RelayClient.Service
+    const sessionId = yield* networkSession(session)
+    const result = yield* relay.networkCancel({ sessionId })
+    yield* Console.log(result.cancelled ? "Network capture cancelled" : "Network capture was not active")
+  }),
+).pipe(Command.withDescription("Cancel capture without writing an artifact"))
+
+const network = Command.make("network").pipe(
+  Command.withDescription("Capture authenticated network exchanges for direct client derivation"),
+  Command.withSubcommands([networkStart, networkStatus, networkStop, networkCancel]),
+)
+
+const secretsStatus = Command.make(
+  "status",
+  {
+    name: Argument.string("name"),
+    json: Flag.boolean("json").pipe(Flag.withDescription("Print machine-readable JSON")),
+  },
+  Effect.fn("Cli.secretsStatus")(function* ({ name, json }) {
+    const relay = yield* RelayClient.Service
+    yield* ensureCliRelay()
+    const result = yield* relay.authStatus({ name })
+    if (json) {
+      yield* Console.log(JSON.stringify(result, null, 2))
+      return
+    }
+    yield* Console.log(`Secrets profile ${result.name}: slots=${result.slotCount} updatedAt=${result.updatedAt}`)
+    yield* Effect.forEach(result.slots, (slot) => Console.log(`- ${slot.ref} sources=${slot.sources.join(",")} expired=${slot.expired}${slot.expiresAt ? ` expiresAt=${slot.expiresAt}` : ""}`))
+  }),
+).pipe(Command.withDescription("Show secret profile metadata without revealing values"))
+
+const secretsRefresh = Command.make(
+  "refresh",
+  {
+    name: Argument.string("name"),
+    session: Flag.string("session").pipe(Flag.optional, Flag.withAlias("s")),
+    urlFilter: Flag.string("url").pipe(Flag.optional, Flag.withDescription("Observe credentials only on matching request URLs")),
+    timeoutMs: Flag.integer("timeout-ms").pipe(Flag.optional, Flag.withDescription("Page reload timeout, defaults to 30000")),
+    json: Flag.boolean("json").pipe(Flag.withDescription("Print machine-readable JSON")),
+  },
+  Effect.fn("Cli.secretsRefresh")(function* ({ name, session, urlFilter, timeoutMs, json }) {
+    const relay = yield* RelayClient.Service
+    yield* ensureCliRelayAndExtension()
+    const sessionId = yield* networkSession(session)
+    const urlFilterValue = optionString(urlFilter)
+    const timeoutMsValue = optionNumber(timeoutMs)
+    const result = yield* relay.authRefresh({
+      sessionId,
+      name,
+      ...(urlFilterValue === undefined ? {} : { urlFilter: urlFilterValue }),
+      ...(timeoutMsValue === undefined ? {} : { timeoutMs: timeoutMsValue }),
+    })
+    yield* Console.log(json ? JSON.stringify(result, null, 2) : `Secrets profile ${name} refreshed: observed=${result.observedSecretRefs.length} changed=${result.updatedSecretRefs.length}`)
+  }),
+).pipe(Command.withDescription("Reload a session page and refresh a profile while preserving stable references"))
+
+const secretsRun = Command.make(
+  "run",
+  {
+    name: Argument.string("name"),
+    command: Argument.string("command").pipe(Argument.variadic({ min: 1 })),
+    cwd: Flag.string("cwd").pipe(Flag.optional, Flag.withDescription("Child process working directory")),
+    timeoutMs: Flag.integer("timeout-ms").pipe(Flag.optional, Flag.withDescription("Child timeout in milliseconds, defaults to 120000")),
+  },
+  Effect.fn("Cli.secretsRun")(function* ({ name, command, cwd, timeoutMs }) {
+    const relay = yield* RelayClient.Service
+    yield* ensureCliRelay()
+    const [executable, ...args] = command
+    if (!executable) return yield* Effect.fail(new Error("secrets run requires a command after --"))
+    const cwdValue = optionString(cwd)
+    const timeoutMsValue = optionNumber(timeoutMs)
+    const result = yield* relay.authRun({
+      name,
+      command: executable,
+      args,
+      cwd: path.resolve(cwdValue ?? process.cwd()),
+      ...(timeoutMsValue === undefined ? {} : { timeoutMs: timeoutMsValue }),
+    })
+    yield* Effect.sync(() => {
+      if (result.stdout) process.stdout.write(result.stdout)
+      if (result.stderr) process.stderr.write(result.stderr)
+      if (result.stdoutTruncated || result.stderrTruncated) process.stderr.write("\nBrowser Control truncated child output.\n")
+      if (result.exitCode !== 0) process.exitCode = result.exitCode
+    })
+  }),
+).pipe(Command.withDescription("Run a command with profile values injected as BC_SECRET_* environment variables"))
+
+const secrets = Command.make("secrets").pipe(
+  Command.withDescription("Inspect, refresh, and use captured credentials without revealing their values"),
+  Command.withSubcommands([secretsStatus, secretsRefresh, secretsRun]),
+)
+
 const journal = Command.make(
   "journal",
   {
@@ -697,7 +887,7 @@ const mcp = Command.make(
 
 const browserControl = Command.make("browser-control").pipe(
   Command.withDescription("Control the user's existing browser through the Browser Control extension"),
-  Command.withSubcommands([serve, execute, session, status, recording, journal, doctor, skill, mcp]),
+  Command.withSubcommands([serve, execute, session, status, network, secrets, recording, journal, doctor, skill, mcp]),
 )
 
 const mainLayer = Layer.mergeAll(RelayClient.layerFetch, SessionStore.layer).pipe(

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -15,6 +15,8 @@ import https from "node:https"
 import zlib from "node:zlib"
 import { hideGhostCursor as hideGhostCursorOnPage, showGhostCursor as showGhostCursorOnPage, type GhostCursorClientOptions } from "./ghost-cursor.ts"
 import type { HandoffOutcome } from "./handoff.ts"
+import * as AuthProfile from "./auth-profile.ts"
+import * as NetworkCapture from "./network-capture.ts"
 import type { ExecuteAftermath, ExecuteLogEntry, ExecuteLogSummary, ExecuteMedia } from "./relay-schema.ts"
 import { executionContextFailureDiagnostic } from "./runtime-diagnostics.ts"
 
@@ -163,6 +165,12 @@ type SandboxGlobals = {
     readonly hide: (options?: HideGhostCursorOptions) => Promise<void>
   }
   readonly handoff: (message?: string, options?: HandoffCallOptions) => Promise<void>
+  readonly network: {
+    readonly start: (options?: NetworkCapture.NetworkCaptureOptions) => Promise<NetworkCapture.NetworkCaptureStatus>
+    readonly status: () => NetworkCapture.NetworkCaptureStatus
+    readonly stop: (options?: NetworkCapture.NetworkCaptureStopOptions) => Promise<NetworkCapture.NetworkCaptureResult>
+    readonly cancel: () => Promise<{ readonly cancelled: boolean }>
+  }
   readonly handoffTracker: { count: number }
 }
 
@@ -361,6 +369,7 @@ export class ExecuteSandbox {
   private pageHealthCheckRequired = false
   private readonly state: Record<string, unknown> = {}
   private readonly snapshotRefs: SnapshotRefRegistry = { selectors: new Map() }
+  private readonly networkCapture = new NetworkCapture.Recorder()
   private pendingWarnings: string[] = []
 
   constructor(readonly options: ExecuteSandboxOptions) {}
@@ -377,8 +386,10 @@ export class ExecuteSandbox {
       try: async () => {
         const globals = await this.getGlobals(options)
         const { result, logs, logSummary, aftermath } = await runUserCode({ code, globals })
+        await this.networkCapture.settleForOutput()
         const extracted = extractExecuteMedia(result)
-        const jsonSafeResult = toJsonSafeValue(extracted.value)
+        const redactedValue = this.networkCapture.redactValue(extracted.value)
+        const jsonSafeResult = toJsonSafeValue(redactedValue)
         const warnings = this.drainWarnings()
         const logCompactionWarning = formatLogCompactionWarning(logSummary)
         if (logCompactionWarning) {
@@ -388,14 +399,14 @@ export class ExecuteSandbox {
           warnings.push(`Execute result could not be represented as JSON value: ${jsonSafeResult.reason}`)
         }
         return {
-          text: stringifyResult(extracted.value),
+          text: stringifyResult(redactedValue),
           ...(jsonSafeResult.serializable ? { value: jsonSafeResult.value } : {}),
           ...(extracted.media.length > 0 ? { media: extracted.media } : {}),
           isError: false,
-          logs,
+          logs: this.redactCaptureLogs(logs),
           logSummary,
-          warnings,
-          aftermath,
+          warnings: warnings.map((warning) => this.networkCapture.redactText(warning)),
+          aftermath: this.redactCaptureAftermath(aftermath),
         }
       },
       catch: (cause) => {
@@ -406,6 +417,7 @@ export class ExecuteSandbox {
       },
     }).pipe(
       Effect.uninterruptible,
+      Effect.ensuring(Effect.promise(() => this.networkCapture.settleForOutput())),
       Effect.match({
         onFailure: (error): ExecuteResult => {
           const logSummary = error instanceof ExecuteCodeError ? error.logSummary : emptyExecuteLogSummary()
@@ -420,13 +432,13 @@ export class ExecuteSandbox {
             warnings.push(logCompactionWarning)
           }
           return {
-            text: error instanceof ExecuteCodeError ? error.stack ?? error.message : error.message,
+            text: this.networkCapture.redactText(error instanceof ExecuteCodeError ? error.stack ?? error.message : error.message),
             isError: true,
-            logs: error instanceof ExecuteCodeError ? error.logs : [],
+            logs: this.redactCaptureLogs(error instanceof ExecuteCodeError ? error.logs : []),
             logSummary,
-            warnings,
-            ...(diagnostic ? { diagnostic } : {}),
-            ...(aftermath ? { aftermath } : {}),
+            warnings: warnings.map((warning) => this.networkCapture.redactText(warning)),
+            ...(diagnostic ? { diagnostic: this.networkCapture.redactText(diagnostic) } : {}),
+            ...(aftermath ? { aftermath: this.redactCaptureAftermath(aftermath) } : {}),
             ...(error instanceof ExecuteCodeError ? {} : { setupFailed: true as const }),
           }
         },
@@ -443,6 +455,29 @@ export class ExecuteSandbox {
     return warnings
   }
 
+  redactNetworkCaptureText(text: string): string {
+    return this.networkCapture.redactText(text)
+  }
+
+  private redactCaptureLogs(logs: readonly ExecuteLogEntry[]): readonly ExecuteLogEntry[] {
+    return logs.map((log) => ({
+      ...log,
+      text: this.networkCapture.redactText(log.text),
+      ...(log.location ? {
+        location: { ...log.location, url: this.networkCapture.redactUrl(log.location.url) },
+      } : {}),
+    }))
+  }
+
+  private redactCaptureAftermath(aftermath: ExecuteAftermath): ExecuteAftermath {
+    return {
+      ...aftermath,
+      startUrl: aftermath.startUrl ? this.networkCapture.redactUrl(aftermath.startUrl) : aftermath.startUrl,
+      endUrl: aftermath.endUrl ? this.networkCapture.redactUrl(aftermath.endUrl) : aftermath.endUrl,
+      navigations: aftermath.navigations.map((url) => this.networkCapture.redactUrl(url)),
+    }
+  }
+
   close(): Effect.Effect<void, Error> {
     const sandbox = this
     return Effect.gen(function* () {
@@ -454,6 +489,7 @@ export class ExecuteSandbox {
       sandbox.defaultPageTargetId = undefined
       sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
+      yield* sandbox.networkCapture.cancel()
 
       if (ownsOpenPage) {
         yield* runPlaywrightOperation({
@@ -483,6 +519,7 @@ export class ExecuteSandbox {
       sandbox.defaultPageTargetId = undefined
       sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
+      yield* sandbox.networkCapture.cancel()
 
       if (ownsOpenPage) {
         yield* runSettledPlaywrightOperation({
@@ -522,6 +559,7 @@ export class ExecuteSandbox {
         sandbox.defaultPageTargetId = undefined
         sandbox.ownsPage = false
         sandbox.pageHealthCheckRequired = false
+        sandbox.networkCapture.bindPage(undefined)
       }
       const browser = sandbox.browser
       if (!browser) {
@@ -555,6 +593,7 @@ export class ExecuteSandbox {
       sandbox.defaultPageTargetId = target.targetId
       sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
+      sandbox.networkCapture.bindPage(selected)
       return selected.url()
     })
   }
@@ -578,6 +617,7 @@ export class ExecuteSandbox {
       this.defaultPageTargetId = undefined
       this.ownsPage = false
       this.pageHealthCheckRequired = false
+      this.networkCapture.bindPage(undefined)
       if (hadBrowser) {
         this.pendingWarnings.push("Relay connection was lost and re-established; the session default page was re-resolved.")
       }
@@ -586,6 +626,7 @@ export class ExecuteSandbox {
     installDownloadCapabilityGuards(context)
     const targetSelection = options.targetSelection
     const page = await this.getSessionPage({ context, ...(targetSelection ? { targetSelection } : {}) })
+    this.networkCapture.bindPage(this.page)
     const showGhostCursor = async (options?: ShowGhostCursorOptions) => {
       const cursorOptions = ghostCursorOptions(options)
       await showGhostCursorOnPage({ page: options?.page ?? page, ...(cursorOptions ? { cursorOptions } : {}) })
@@ -641,6 +682,12 @@ export class ExecuteSandbox {
         hide: hideGhostCursor,
       },
       handoff,
+      network: {
+        start: (options) => Effect.runPromise(this.networkCapture.start(page, options)),
+        status: () => this.networkCapture.status(),
+        stop: (options) => Effect.runPromise(this.networkCapture.stop(options)),
+        cancel: () => Effect.runPromise(this.networkCapture.cancel()),
+      },
       handoffTracker,
     }
   }
@@ -664,6 +711,7 @@ export class ExecuteSandbox {
     this.defaultPageTargetId = undefined
     this.ownsPage = false
     this.pageHealthCheckRequired = false
+    this.networkCapture.bindPage(undefined)
     if (!this.pendingWarnings.includes(defaultPageClosedWarning)) {
       this.pendingWarnings.push(defaultPageClosedWarning)
     }
@@ -677,6 +725,58 @@ export class ExecuteSandbox {
       pageUrl: this.page && !this.page.isClosed() ? this.page.url() : null,
       stateKeys: Object.keys(this.state),
     }
+  }
+
+  networkStart(options: NetworkCapture.NetworkCaptureOptions = {}): Effect.Effect<NetworkCapture.NetworkCaptureStatus, Error> {
+    const sandbox = this
+    return Effect.gen(function* () {
+      const globals = yield* Effect.tryPromise({
+        try: () => sandbox.getGlobals({}),
+        catch: (cause) => cause instanceof Error ? cause : new Error("Set up page for network capture", { cause }),
+      })
+      return yield* sandbox.networkCapture.start(globals.page, options)
+    }).pipe(Effect.uninterruptible)
+  }
+
+  networkStatus(): NetworkCapture.NetworkCaptureStatus {
+    return this.networkCapture.status()
+  }
+
+  networkStop(options: NetworkCapture.NetworkCaptureStopOptions = {}): Effect.Effect<NetworkCapture.NetworkCaptureResult, Error> {
+    return this.networkCapture.stop(options)
+  }
+
+  networkCancel(): Effect.Effect<{ readonly cancelled: boolean }> {
+    return this.networkCapture.cancel()
+  }
+
+  authRefresh(options: {
+    readonly name: string
+    readonly urlFilter?: string
+    readonly timeoutMs?: number
+  }): Effect.Effect<NetworkCapture.NetworkCaptureResult, Error> {
+    const sandbox = this
+    return Effect.gen(function* () {
+      const globals = yield* Effect.tryPromise({
+        try: () => sandbox.getGlobals({}),
+        catch: (cause) => cause instanceof Error ? cause : new Error("Set up page for auth refresh", { cause }),
+      })
+      yield* AuthProfile.read(options.name).pipe(Effect.asVoid)
+      yield* sandbox.networkCapture.start(globals.page, {
+        ...(options.urlFilter ? { urlFilter: options.urlFilter } : {}),
+      })
+      return yield* Effect.gen(function* () {
+        yield* Effect.tryPromise({
+          try: () => globals.page.reload({ waitUntil: "domcontentloaded", timeout: options.timeoutMs ?? 30_000 }),
+          catch: (cause) => cause instanceof Error ? cause : new Error("Refresh auth profile", { cause }),
+        })
+        yield* Effect.tryPromise({
+          try: () => globals.page.waitForLoadState("networkidle", { timeout: Math.min(options.timeoutMs ?? 30_000, 5_000) }).catch(() => {}),
+          catch: (cause) => cause instanceof Error ? cause : new Error("Wait for auth refresh network", { cause }),
+        })
+        return yield* sandbox.networkCapture.stop({ secrets: options.name, requireObservedSecrets: true })
+      }).pipe(Effect.ensuring(sandbox.networkCapture.cancel()))
+    }).pipe(Effect.uninterruptible)
   }
 
   private async getSessionPage({ context, targetSelection }: { readonly context: BrowserContext; readonly targetSelection?: ExecuteTargetSelection }): Promise<Page> {
@@ -2077,6 +2177,7 @@ export async function runUserCode({ code, globals }: { readonly code: string; re
       "hideGhostCursor",
       "ghostCursor",
       "handoff",
+      "network",
       wrapCodeWithModuleAliases(code),
     )
     const result = await fn(
@@ -2096,6 +2197,7 @@ export async function runUserCode({ code, globals }: { readonly code: string; re
       globals.hideGhostCursor,
       globals.ghostCursor,
       globals.handoff,
+      globals.network,
     )
     return { result, ...buildResultMetadata() }
   } catch (cause) {

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -1,5 +1,7 @@
 import http from "node:http"
 import { Effect, Schema } from "effect"
+import * as AuthProfile from "./auth-profile.ts"
+import { NetworkCaptureError } from "./network-capture.ts"
 import {
   HttpRouteError,
   formatHostForUrl,
@@ -14,7 +16,13 @@ import {
 } from "./relay-helpers.ts"
 import { selectTarget, TargetSelectionError } from "./execute.ts"
 import {
+  AuthProfileRequest,
+  AuthRefreshRequest,
+  AuthRunRequest,
   ExecuteRequest,
+  NetworkSessionRequest,
+  NetworkStartRequest,
+  NetworkStopRequest,
   RecordingStartRequest,
   RecordingTargetRequest,
   SessionAdoptRequest,
@@ -92,6 +100,14 @@ export function createHttpRequestHandler(options: {
       runRequestEffect(response, handleRecordingRequest({ request, response, pathname, requestUrl, registry: options.registry, recordingRelay: options.recordingRelay }))
       return
     }
+    if (pathname.startsWith("/network/")) {
+      runRequestEffect(response, handleNetworkRequest({ request, response, pathname, sessions: options.sessions }))
+      return
+    }
+    if (pathname.startsWith("/auth/")) {
+      runRequestEffect(response, handleAuthRequest({ request, response, pathname, sessions: options.sessions }))
+      return
+    }
     if (pathname.startsWith("/cli/")) {
       runRequestEffect(response, handleCliRequest({
         request,
@@ -105,6 +121,69 @@ export function createHttpRequestHandler(options: {
     response.writeHead(404)
     response.end("Not found")
   }
+}
+
+function handleNetworkRequest(options: {
+  readonly request: http.IncomingMessage
+  readonly response: http.ServerResponse
+  readonly pathname: string
+  readonly sessions: BrowserControlSessions
+}): Effect.Effect<void, Error> {
+  return Effect.gen(function* () {
+    if (options.pathname === "/network/start" && options.request.method === "POST") {
+      const request = yield* decodeRequest(NetworkStartRequest, yield* readJsonBody(options.request), "network start")
+      const { sessionId, ...captureOptions } = request
+      const result = yield* options.sessions.networkStart(sessionId, captureOptions)
+      sendJson(options.response, result)
+      return
+    }
+    if (options.pathname === "/network/status" && options.request.method === "POST") {
+      const request = yield* decodeRequest(NetworkSessionRequest, yield* readJsonBody(options.request), "network status")
+      sendJson(options.response, yield* options.sessions.networkStatus(request.sessionId))
+      return
+    }
+    if (options.pathname === "/network/stop" && options.request.method === "POST") {
+      const request = yield* decodeRequest(NetworkStopRequest, yield* readJsonBody(options.request), "network stop")
+      const { sessionId, ...stopOptions } = request
+      sendJson(options.response, yield* options.sessions.networkStop(sessionId, stopOptions))
+      return
+    }
+    if (options.pathname === "/network/cancel" && options.request.method === "POST") {
+      const request = yield* decodeRequest(NetworkSessionRequest, yield* readJsonBody(options.request), "network cancel")
+      sendJson(options.response, yield* options.sessions.networkCancel(request.sessionId))
+      return
+    }
+    options.response.writeHead(404)
+    options.response.end("Not found")
+  })
+}
+
+function handleAuthRequest(options: {
+  readonly request: http.IncomingMessage
+  readonly response: http.ServerResponse
+  readonly pathname: string
+  readonly sessions: BrowserControlSessions
+}): Effect.Effect<void, Error> {
+  return Effect.gen(function* () {
+    if (options.pathname === "/auth/status" && options.request.method === "POST") {
+      const request = yield* decodeRequest(AuthProfileRequest, yield* readJsonBody(options.request), "auth status")
+      sendJson(options.response, yield* AuthProfile.status(request.name))
+      return
+    }
+    if (options.pathname === "/auth/refresh" && options.request.method === "POST") {
+      const request = yield* decodeRequest(AuthRefreshRequest, yield* readJsonBody(options.request), "auth refresh")
+      const { sessionId, ...refreshOptions } = request
+      sendJson(options.response, yield* options.sessions.authRefresh(sessionId, refreshOptions))
+      return
+    }
+    if (options.pathname === "/auth/run" && options.request.method === "POST") {
+      const request = yield* decodeRequest(AuthRunRequest, yield* readJsonBody(options.request), "auth run")
+      sendJson(options.response, yield* AuthProfile.run(request))
+      return
+    }
+    options.response.writeHead(404)
+    options.response.end("Not found")
+  })
 }
 
 function runRequestEffect(response: http.ServerResponse, effect: Effect.Effect<void, Error>): void {
@@ -403,6 +482,20 @@ export function relayHttpError(error: unknown): HttpRouteError {
       case "setup-failed":
         return new HttpRouteError({ message: error.message, status: 500, code: "setup-failed" })
     }
+  }
+  if (error instanceof NetworkCaptureError) {
+    return new HttpRouteError({
+      message: error.message,
+      status: error.reason === "invalid-options" ? 400 : error.reason === "already-active" || error.reason === "inactive" ? 409 : 500,
+      code: error.reason === "invalid-options" ? "invalid-request" : error.reason === "already-active" || error.reason === "inactive" ? "capture-conflict" : "internal",
+    })
+  }
+  if (error instanceof AuthProfile.AuthProfileError) {
+    return new HttpRouteError({
+      message: error.message,
+      status: error.reason === "invalid-name" ? 400 : error.reason === "not-found" ? 404 : 500,
+      code: error.reason === "invalid-name" ? "invalid-request" : error.reason === "not-found" ? "auth-profile-not-found" : "internal",
+    })
   }
   if (error instanceof TargetSelectionError) {
     return new HttpRouteError({

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -208,6 +208,162 @@ function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSess
       }),
     },
     {
+      name: "network_start",
+      description: "Start session-scoped network capture. Browser Control records normalized Playwright exchanges; HAR is only the optional export format. Bodies are embedded by default with per-body and total memory limits.",
+      inputSchema: objectSchema({
+        session: { type: "string", description: "Optional existing session id. Omit to use or create this MCP server's current session." },
+        urlFilter: { type: "string", description: "Capture only request URLs containing this text." },
+        resourceTypes: { type: "array", items: { type: "string" }, description: "Optional Playwright resource types such as fetch and xhr." },
+        content: { type: "string", enum: ["embed", "omit"], description: "Request and response body mode. Defaults to embed." },
+        maxBodyBytes: { type: "integer", minimum: 1, description: "Maximum bytes captured from each body. Defaults to 1000000." },
+        maxTotalBodyBytes: { type: "integer", minimum: 1, description: "Maximum body bytes retained for the capture. Defaults to 25000000." },
+        maxEntries: { type: "integer", minimum: 1, description: "Maximum captured requests. Defaults to 1000." },
+      }),
+      readOnly: false,
+      destructive: false,
+      idempotent: false,
+      handle: (input) => Effect.gen(function* () {
+        const object = requireObject(input)
+        const explicitSession = optionalStringField(object, "session")
+        const sessionId = explicitSession ?? currentSession.id
+        if (explicitSession) {
+          yield* ensureSessionExists(relay, sessionId)
+        } else {
+          const sessions = yield* relay.sessions
+          if (!sessions.some((session) => session.id === sessionId)) {
+            yield* relay.sessionNew(sessionId)
+          }
+          currentSession.established = true
+        }
+        yield* RelayLifecycle.ensureExtensionConnected({ relay, waitForReconnect: true })
+        const content = optionalStringField(object, "content")
+        if (content !== undefined && content !== "embed" && content !== "omit") {
+          return yield* Effect.fail(new Error("content must be embed or omit"))
+        }
+        const urlFilter = optionalStringField(object, "urlFilter")
+        const resourceTypes = optionalStringArrayField(object, "resourceTypes")
+        const maxBodyBytes = optionalPositiveIntegerField(object, "maxBodyBytes")
+        const maxTotalBodyBytes = optionalPositiveIntegerField(object, "maxTotalBodyBytes")
+        const maxEntries = optionalPositiveIntegerField(object, "maxEntries")
+        const result = yield* relay.networkStart({
+          sessionId,
+          ...(urlFilter ? { urlFilter } : {}),
+          ...(resourceTypes && resourceTypes.length > 0 ? { resourceTypes } : {}),
+          ...(content ? { content } : {}),
+          ...(maxBodyBytes === undefined ? {} : { maxBodyBytes }),
+          ...(maxTotalBodyBytes === undefined ? {} : { maxTotalBodyBytes }),
+          ...(maxEntries === undefined ? {} : { maxEntries }),
+        })
+        return { session: sessionId, ...result }
+      }),
+    },
+    {
+      name: "network_status",
+      description: "Return bounded metadata for a session's active network capture. Captured values are never included.",
+      inputSchema: objectSchema({ session: { type: "string", description: "Optional session id. Defaults to this MCP server's current session." } }),
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+      handle: (input) => {
+        const sessionId = optionalStringField(input, "session") ?? currentSession.id
+        return relay.networkStatus({ sessionId }).pipe(Effect.map((result) => ({ session: sessionId, ...result })))
+      },
+    },
+    {
+      name: "network_stop",
+      description: "Stop network capture. Optionally write a credential-redacted HAR and store lossless credential values in a reusable secret profile. At least one of outputPath or secrets is required.",
+      inputSchema: objectSchema({
+        session: { type: "string", description: "Optional session id. Defaults to this MCP server's current session." },
+        outputPath: { type: "string", description: "Optional artifact path, resolved against the MCP process working directory. The HAR contains stable ${BC_SECRET_N} references, not captured values." },
+        secrets: { type: "string", description: "Optional reusable profile name for captured credential values." },
+      }),
+      readOnly: false,
+      destructive: false,
+      idempotent: false,
+      handle: (input) => Effect.gen(function* () {
+        const sessionId = optionalStringField(input, "session") ?? currentSession.id
+        const outputPath = optionalStringField(input, "outputPath")
+        const secrets = optionalStringField(input, "secrets")
+        if (!outputPath && !secrets) {
+          return yield* Effect.fail(new Error("network_stop requires outputPath, secrets, or both"))
+        }
+        return yield* relay.networkStop({
+          sessionId,
+          ...(outputPath ? { outputPath: path.resolve(outputPath) } : {}),
+          ...(secrets ? { secrets } : {}),
+        })
+      }),
+    },
+    {
+      name: "network_cancel",
+      description: "Cancel a session's network capture and discard its in-memory exchanges.",
+      inputSchema: objectSchema({ session: { type: "string", description: "Optional session id. Defaults to this MCP server's current session." } }),
+      readOnly: false,
+      destructive: true,
+      idempotent: true,
+      handle: (input) => relay.networkCancel({ sessionId: optionalStringField(input, "session") ?? currentSession.id }),
+    },
+    {
+      name: "secrets_status",
+      description: "Return secret profile references, sources, and expiration metadata without revealing credential values.",
+      inputSchema: objectSchema({ name: { type: "string", description: "Secret profile name." } }, ["name"]),
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+      handle: (input) => relay.authStatus({ name: requiredStringField(input, "name") }),
+    },
+    {
+      name: "secrets_refresh",
+      description: "Reload a session page, observe fresh credentials, and update a secret profile while preserving stable BC_SECRET_N references.",
+      inputSchema: objectSchema({
+        name: { type: "string", description: "Existing secret profile name." },
+        session: { type: "string", description: "Optional session id. Defaults to this MCP server's current session." },
+        urlFilter: { type: "string", description: "Observe credentials only on matching request URLs." },
+        timeoutMs: { type: "integer", minimum: 1, description: "Reload timeout. Defaults to 30000." },
+      }, ["name"]),
+      readOnly: false,
+      destructive: true,
+      idempotent: false,
+      handle: (input) => {
+        const object = requireObject(input)
+        const timeoutMs = optionalPositiveIntegerField(object, "timeoutMs")
+        const urlFilter = optionalStringField(object, "urlFilter")
+        return relay.authRefresh({
+          sessionId: optionalStringField(object, "session") ?? currentSession.id,
+          name: requiredStringField(object, "name"),
+          ...(urlFilter ? { urlFilter } : {}),
+          ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        })
+      },
+    },
+    {
+      name: "secrets_run",
+      description: "Run a local command with a captured profile injected as BC_SECRET_N environment variables. Known values are replaced with their references in stdout and stderr.",
+      inputSchema: objectSchema({
+        name: { type: "string", description: "Secret profile name." },
+        command: { type: "string", description: "Executable path or command name." },
+        args: { type: "array", items: { type: "string" }, description: "Command arguments." },
+        cwd: { type: "string", description: "Optional child working directory." },
+        timeoutMs: { type: "integer", minimum: 1, description: "Child timeout. Defaults to 120000." },
+      }, ["name", "command"]),
+      readOnly: false,
+      destructive: true,
+      idempotent: false,
+      handle: (input) => {
+        const object = requireObject(input)
+        const args = optionalStringArrayField(object, "args")
+        const cwd = optionalStringField(object, "cwd")
+        const timeoutMs = optionalPositiveIntegerField(object, "timeoutMs")
+        return relay.authRun({
+          name: requiredStringField(object, "name"),
+          command: requiredStringField(object, "command"),
+          ...(args ? { args } : {}),
+          cwd: path.resolve(cwd ?? process.cwd()),
+          ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        })
+      },
+    },
+    {
       name: "skill",
       description: "Return the Browser Control agent skill instructions.",
       inputSchema: emptyInputSchema,
@@ -341,6 +497,33 @@ function optionalBooleanField(input: unknown, field: string): boolean | undefine
   const object = requireObject(input)
   const value = object[field]
   return typeof value === "boolean" ? value : undefined
+}
+
+function optionalPositiveIntegerField(input: unknown, field: string): number | undefined {
+  const object = requireObject(input)
+  const value = object[field]
+  if (value === undefined) return undefined
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive integer`)
+  }
+  return value
+}
+
+function optionalStringArrayField(input: unknown, field: string): readonly string[] | undefined {
+  const object = requireObject(input)
+  const value = object[field]
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    throw new Error(`${field} must be an array of non-empty strings`)
+  }
+  const strings: string[] = []
+  for (const item of value) {
+    if (typeof item !== "string" || item.length === 0) {
+      throw new Error(`${field} must be an array of non-empty strings`)
+    }
+    strings.push(item)
+  }
+  return strings
 }
 
 function requireObject(input: unknown): JsonObject {

--- a/src/network-capture.ts
+++ b/src/network-capture.ts
@@ -1,0 +1,837 @@
+import { Effect, Schema, Semaphore } from "effect"
+import fs from "node:fs/promises"
+import path from "node:path"
+import type { Page, Request, Response } from "playwright-core"
+import * as AuthProfile from "./auth-profile.ts"
+import { type CredentialSlot, SecretCollector } from "./network-redaction.ts"
+
+export type NetworkCaptureOptions = {
+  readonly urlFilter?: string
+  readonly resourceTypes?: readonly string[]
+  readonly content?: "omit" | "embed"
+  readonly maxBodyBytes?: number
+  readonly maxTotalBodyBytes?: number
+  readonly maxEntries?: number
+}
+
+export type NetworkCaptureStopOptions = {
+  readonly outputPath?: string
+  readonly secrets?: string
+  readonly requireObservedSecrets?: boolean
+}
+
+export type NetworkCaptureStatus = {
+  readonly active: boolean
+  readonly startedAt?: string
+  readonly entryCount: number
+  readonly responseCount: number
+  readonly failureCount: number
+  readonly capturedBodyBytes: number
+  readonly truncatedBodyCount: number
+  readonly droppedEntryCount: number
+  readonly urlFilter?: string
+  readonly resourceTypes?: readonly string[]
+  readonly content?: "omit" | "embed"
+  readonly secrets?: string
+}
+
+export type NetworkCaptureResult = NetworkCaptureStatus & {
+  readonly active: false
+  readonly stoppedAt: string
+  readonly outputPath?: string
+  readonly authProfile?: AuthProfile.AuthProfileSummary
+  readonly updatedSecretRefs: readonly string[]
+  readonly observedSecretRefs: readonly string[]
+}
+
+export class NetworkCaptureError extends Schema.TaggedErrorClass<NetworkCaptureError>()(
+  "NetworkCapture.Error",
+  {
+    message: Schema.String,
+    operation: Schema.String,
+    reason: Schema.Literals(["already-active", "inactive", "invalid-options", "finalize-failed", "persistence-failed"]),
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {}
+
+type Header = { readonly name: string; readonly value: string }
+
+type CapturedBody = {
+  readonly size: number
+  readonly mimeType: string
+  readonly text?: string
+  readonly truncated: boolean
+}
+
+type CapturedEntry = {
+  readonly id: string
+  readonly startedDateTime: string
+  readonly durationMs: number
+  readonly request: {
+    readonly method: string
+    readonly url: string
+    readonly headers: readonly Header[]
+    readonly resourceType: string
+    readonly body?: CapturedBody
+    readonly redirectedFrom?: string
+  }
+  readonly response?: {
+    readonly status: number
+    readonly statusText: string
+    readonly headers: readonly Header[]
+    readonly body?: CapturedBody
+  }
+  readonly failure?: string
+}
+
+type PendingEntry = {
+  readonly id: string
+  readonly startedAt: number
+  readonly startedDateTime: string
+  readonly request: Request
+  response?: Response
+  failure?: string
+  finalized: boolean
+  epoch: number
+}
+
+type FinalizeWork = {
+  readonly pending: PendingEntry
+  readonly generation: number
+}
+
+type ActiveCapture = {
+  readonly startedAt: string
+  readonly options: Required<Pick<NetworkCaptureOptions, "content" | "maxBodyBytes" | "maxTotalBodyBytes" | "maxEntries">> & NetworkCaptureOptions
+  readonly pending: Map<Request, PendingEntry>
+  readonly entries: CapturedEntry[]
+  readonly finalizeQueue: FinalizeWork[]
+  readonly finalizeWaiters: Array<() => void>
+  readonly liveCollector: SecretCollector
+  finalizeWorkers: number
+  finalizeGeneration: number
+  capturedBodyBytes: number
+  truncatedBodyCount: number
+  droppedEntryCount: number
+  stopping: boolean
+  cancelled: boolean
+  outputUnsafe: boolean
+}
+
+const maxAllowedBodyBytes = 10_000_000
+const maxAllowedTotalBodyBytes = 100_000_000
+const maxAllowedEntries = 10_000
+const maxAllowedResourceTypes = 50
+const maxFinalizeWorkers = 4
+
+export class Recorder {
+  private active: ActiveCapture | undefined
+  private page: Page | undefined
+  private pageEpoch = 0
+  private readonly transition = Semaphore.makeUnsafe(1)
+
+  constructor(private readonly recorderOptions: {
+    readonly authProfileBaseDir?: string
+    readonly outputSettleTimeoutMs?: number
+  } = {}) {}
+
+  start(page: Page, options: NetworkCaptureOptions = {}): Effect.Effect<NetworkCaptureStatus, NetworkCaptureError> {
+    const capture = this
+    return this.transition.withPermit(Effect.try({
+      try: () => {
+        validateOptions(options)
+        if (capture.active) {
+          throw new NetworkCaptureError({ message: "Network capture is already active for this session", operation: "start", reason: "already-active" })
+        }
+        capture.active = {
+          startedAt: new Date().toISOString(),
+          options: {
+            ...options,
+            content: options.content ?? "embed",
+            maxBodyBytes: options.maxBodyBytes ?? 1_000_000,
+            maxTotalBodyBytes: options.maxTotalBodyBytes ?? 25_000_000,
+            maxEntries: options.maxEntries ?? 1_000,
+          },
+          pending: new Map(),
+          entries: [],
+          finalizeQueue: [],
+          finalizeWaiters: [],
+          liveCollector: new SecretCollector(),
+          finalizeWorkers: 0,
+          finalizeGeneration: 0,
+          capturedBodyBytes: 0,
+          truncatedBodyCount: 0,
+          droppedEntryCount: 0,
+          stopping: false,
+          cancelled: false,
+          outputUnsafe: false,
+        }
+        capture.bindPage(page)
+        return capture.status()
+      },
+      catch: (cause) => cause instanceof NetworkCaptureError
+        ? cause
+        : new NetworkCaptureError({ message: "Invalid network capture options", operation: "start", reason: "invalid-options", cause }),
+    }))
+  }
+
+  status(): NetworkCaptureStatus {
+    const active = this.active
+    if (!active) {
+      return {
+        active: false,
+        entryCount: 0,
+        responseCount: 0,
+        failureCount: 0,
+        capturedBodyBytes: 0,
+        truncatedBodyCount: 0,
+        droppedEntryCount: 0,
+      }
+    }
+    return {
+      active: true,
+      startedAt: active.startedAt,
+      entryCount: active.entries.length + active.pending.size,
+      responseCount: active.entries.filter((entry) => entry.response).length,
+      failureCount: active.entries.filter((entry) => entry.failure).length,
+      capturedBodyBytes: active.capturedBodyBytes,
+      truncatedBodyCount: active.truncatedBodyCount,
+      droppedEntryCount: active.droppedEntryCount,
+      ...(active.options.urlFilter ? { urlFilter: active.options.urlFilter } : {}),
+      ...(active.options.resourceTypes ? { resourceTypes: [...active.options.resourceTypes] } : {}),
+      content: active.options.content,
+    }
+  }
+
+  stop(options: NetworkCaptureStopOptions = {}): Effect.Effect<NetworkCaptureResult, NetworkCaptureError> {
+    const capture = this
+    return this.transition.withPermit(Effect.gen(function* () {
+      const active = capture.active
+      if (!active) {
+        return yield* Effect.fail(new NetworkCaptureError({ message: "Network capture is not active for this session", operation: "stop", reason: "inactive" }))
+      }
+      const boundPage = capture.page
+      active.stopping = true
+      capture.unbindPage()
+      const operation = Effect.gen(function* () {
+        for (const pending of [...active.pending.values()]) {
+          if (!pending.finalized) {
+            pending.failure ??= "Capture stopped before request completed"
+            delete pending.response
+          }
+          capture.scheduleFinalize(pending)
+        }
+        const settled = yield* Effect.promise(() => settleFinalizers(active, 5_000))
+        if (!settled) {
+          active.droppedEntryCount += active.pending.size
+          capture.discardFinalizers(active)
+        }
+
+        const secrets = options.secrets
+        const profileOptions = capture.recorderOptions.authProfileBaseDir ? { baseDir: capture.recorderOptions.authProfileBaseDir } : {}
+        const finish = finishCapture(active, options, secrets, profileOptions)
+        const finished = yield* secrets
+          ? AuthProfile.withLock(secrets, profileOptions, finish).pipe(
+            Effect.mapError((cause) => cause instanceof NetworkCaptureError
+              ? cause
+              : new NetworkCaptureError({ message: cause.message, operation: "auth-profile", reason: "persistence-failed", cause })),
+          )
+          : finish
+        const finalStatus = statusForFinished(active, secrets)
+        capture.active = undefined
+        return {
+          ...finalStatus,
+          truncatedBodyCount: finalStatus.truncatedBodyCount + finished.redactionOmissionCount,
+          active: false as const,
+          stoppedAt: new Date().toISOString(),
+          ...(options.outputPath ? { outputPath: path.resolve(options.outputPath) } : {}),
+          ...(finished.authProfile ? { authProfile: finished.authProfile } : {}),
+          updatedSecretRefs: finished.updatedSecretRefs,
+          observedSecretRefs: finished.observedSecretRefs,
+        }
+      }).pipe(
+        Effect.tapError(() => Effect.sync(() => {
+          active.stopping = false
+          if (capture.active === active) capture.bindPage(boundPage)
+        })),
+      )
+      return yield* operation
+    })).pipe(Effect.uninterruptible)
+  }
+
+  cancel(): Effect.Effect<{ readonly cancelled: boolean }> {
+    const capture = this
+    return this.transition.withPermit(Effect.gen(function* () {
+      const active = capture.active
+      if (!active) return { cancelled: false }
+      active.stopping = true
+      active.cancelled = true
+      capture.unbindPage()
+      capture.discardFinalizers(active)
+      yield* Effect.promise(() => settleFinalizers(active, 5_000))
+      if (capture.active === active) capture.active = undefined
+      return { cancelled: true }
+    })).pipe(Effect.uninterruptible)
+  }
+
+  bindPage(page: Page | undefined): void {
+    const active = this.active
+    if (!active || active.stopping || this.page === page) return
+    if (this.page) {
+      for (const pending of active.pending.values()) {
+        if (pending.epoch !== this.pageEpoch || pending.finalized) continue
+        pending.failure ??= "Page changed before request completed"
+        delete pending.response
+        this.scheduleFinalize(pending)
+      }
+    }
+    this.unbindPage()
+    if (!page || page.isClosed()) return
+    this.page = page
+    this.pageEpoch += 1
+    page.on("request", this.onRequest)
+    page.on("response", this.onResponse)
+    page.on("requestfinished", this.onRequestFinished)
+    page.on("requestfailed", this.onRequestFailed)
+  }
+
+  async settleForOutput(): Promise<void> {
+    const active = this.active
+    if (!active) return
+    active.outputUnsafe = !await settleFinalizers(active, this.recorderOptions.outputSettleTimeoutMs ?? 5_000)
+  }
+
+  redactText(text: string): string {
+    const active = this.active
+    if (!active) return text
+    return active.outputUnsafe ? "[REDACTED: network capture finalization pending]" : active.liveCollector.redactText(text)
+  }
+
+  redactValue(value: unknown): unknown {
+    const active = this.active
+    if (!active) return value
+    return active.outputUnsafe ? "[REDACTED: network capture finalization pending]" : active.liveCollector.redactValue(value)
+  }
+
+  redactUrl(url: string): string {
+    const active = this.active
+    if (!active) return url
+    if (active.outputUnsafe) return "[REDACTED: network capture finalization pending]"
+    return active.liveCollector.redactText(active.liveCollector.protectUrl(url, "execute"))
+  }
+
+  private readonly onRequest = (request: Request): void => {
+    const active = this.active
+    if (!active || !matches(request, active.options)) return
+    if (active.entries.length + active.pending.size >= active.options.maxEntries) {
+      active.droppedEntryCount += 1
+      return
+    }
+    active.pending.set(request, {
+      id: `request-${active.entries.length + active.pending.size + 1}`,
+      startedAt: Date.now(),
+      startedDateTime: new Date().toISOString(),
+      request,
+      finalized: false,
+      epoch: this.pageEpoch,
+    })
+  }
+
+  private readonly onResponse = (response: Response): void => {
+    const pending = this.active?.pending.get(response.request())
+    if (pending) pending.response = response
+  }
+
+  private readonly onRequestFinished = (request: Request): void => {
+    const pending = this.active?.pending.get(request)
+    if (pending) this.scheduleFinalize(pending)
+  }
+
+  private readonly onRequestFailed = (request: Request): void => {
+    const pending = this.active?.pending.get(request)
+    if (!pending) return
+    pending.failure = request.failure()?.errorText ?? "Request failed"
+    this.scheduleFinalize(pending)
+  }
+
+  private scheduleFinalize(pending: PendingEntry): void {
+    const active = this.active
+    if (!active || pending.finalized) return
+    pending.finalized = true
+    active.finalizeQueue.push({ pending, generation: active.finalizeGeneration })
+    this.pumpFinalizers(active)
+  }
+
+  private pumpFinalizers(active: ActiveCapture): void {
+    if (active.cancelled) active.finalizeQueue.length = 0
+    while (!active.cancelled && active.finalizeWorkers < maxFinalizeWorkers) {
+      const work = active.finalizeQueue.shift()
+      if (!work) break
+      active.finalizeWorkers += 1
+      void this.finalize(work.pending, active, work.generation).catch(() => {}).finally(() => {
+        active.finalizeWorkers -= 1
+        this.pumpFinalizers(active)
+        notifyFinalizersSettled(active)
+      })
+    }
+    notifyFinalizersSettled(active)
+  }
+
+  private discardFinalizers(active: ActiveCapture): void {
+    active.finalizeGeneration += 1
+    active.finalizeQueue.length = 0
+    active.pending.clear()
+    notifyFinalizersSettled(active)
+  }
+
+  private async finalize(pending: PendingEntry, active: ActiveCapture, generation: number): Promise<void> {
+      const request = pending.request
+    try {
+      const requestHeaders = await safeHeaders(() => request.headersArray())
+      const requestLimit = Math.min(active.options.maxBodyBytes, active.options.maxTotalBodyBytes - active.capturedBodyBytes)
+      const requestSize = declaredBodySize(requestHeaders)
+      const requestMayHaveBody = requestSize !== undefined
+        ? requestSize > 0
+        : contentType(requestHeaders) !== undefined && !/^(GET|HEAD)$/i.test(request.method())
+      const requestBody = active.options.content === "embed" && requestMayHaveBody
+        ? bodyCanFit(requestHeaders, requestLimit)
+          ? captureBuffer(request.postDataBuffer(), contentType(requestHeaders), active)
+          : truncatedBody(contentType(requestHeaders), active, requestSize ?? 0)
+        : undefined
+      const response = pending.response
+      const responseHeaders = response ? await safeHeaders(() => response.headersArray()) : []
+      const shouldCaptureResponseBody = response && active.options.content === "embed"
+      const hasBodyBudget = active.capturedBodyBytes < active.options.maxTotalBodyBytes
+      let responseBody: CapturedBody | undefined
+      if (shouldCaptureResponseBody) {
+        if (hasBodyBudget) {
+          const responseBuffer = bodyCanFit(responseHeaders, Math.min(active.options.maxBodyBytes, active.options.maxTotalBodyBytes - active.capturedBodyBytes))
+            ? await bodyWithTimeout(response, 1_000)
+            : null
+          responseBody = responseBuffer === null
+            ? truncatedBody(contentType(responseHeaders), active, declaredBodySize(responseHeaders) ?? 0)
+            : captureBuffer(responseBuffer, contentType(responseHeaders), active)
+        } else {
+          responseBody = truncatedBody(contentType(responseHeaders), active)
+        }
+      }
+      const redirectedFrom = request.redirectedFrom()?.url()
+      this.recordEntry(active, generation, {
+        id: pending.id,
+        startedDateTime: pending.startedDateTime,
+        durationMs: Math.max(0, Date.now() - pending.startedAt),
+        request: {
+          method: request.method(),
+          url: request.url(),
+          headers: requestHeaders,
+          resourceType: request.resourceType(),
+          ...(requestBody ? { body: requestBody } : {}),
+          ...(redirectedFrom ? { redirectedFrom } : {}),
+        },
+        ...(response ? {
+          response: {
+            status: response.status(),
+            statusText: response.statusText(),
+            headers: responseHeaders,
+            ...(responseBody ? { body: responseBody } : {}),
+          },
+        } : {}),
+        ...(pending.failure ? { failure: pending.failure } : {}),
+      })
+    } catch {
+      this.recordEntry(active, generation, {
+        id: pending.id,
+        startedDateTime: pending.startedDateTime,
+        durationMs: Math.max(0, Date.now() - pending.startedAt),
+        request: {
+          method: safeValue(() => request.method(), "UNKNOWN"),
+          url: safeValue(() => request.url(), ""),
+          headers: [],
+          resourceType: safeValue(() => request.resourceType(), "unknown"),
+        },
+        failure: "Capture finalization failed",
+      })
+    } finally {
+      active.pending.delete(request)
+    }
+  }
+
+  private recordEntry(active: ActiveCapture, generation: number, entry: CapturedEntry): void {
+    if (active.cancelled || generation !== active.finalizeGeneration) return
+    active.entries.push(entry)
+    protectEntry(entry, active.liveCollector)
+  }
+
+  private unbindPage(): void {
+    const page = this.page
+    this.page = undefined
+    if (!page) return
+    page.off("request", this.onRequest)
+    page.off("response", this.onResponse)
+    page.off("requestfinished", this.onRequestFinished)
+    page.off("requestfailed", this.onRequestFailed)
+  }
+}
+
+function finishCapture(
+  active: ActiveCapture,
+  options: NetworkCaptureStopOptions,
+  secrets: string | undefined,
+  profileOptions: { readonly baseDir?: string },
+): Effect.Effect<{
+  readonly authProfile?: AuthProfile.AuthProfileSummary
+  readonly updatedSecretRefs: readonly string[]
+  readonly observedSecretRefs: readonly string[]
+  readonly redactionOmissionCount: number
+}, NetworkCaptureError> {
+  return Effect.gen(function* () {
+    const existingProfile = secrets
+      ? yield* AuthProfile.readOptional(secrets, profileOptions).pipe(
+        Effect.mapError((cause) => new NetworkCaptureError({ message: cause.message, operation: "auth-profile", reason: "persistence-failed", cause })),
+      )
+      : undefined
+    const collector = new SecretCollector(existingProfile?.slots ?? [])
+    let protectedEntries: readonly CapturedEntry[] | undefined
+    if (options.outputPath) {
+      const structurallyProtected = active.entries.map((entry) => protectEntry(entry, collector))
+      const slots = collector.slots()
+      protectedEntries = structurallyProtected.map((entry) => redactEntryKnownValues(entry, slots))
+    } else if (secrets) {
+      for (const entry of active.entries) protectEntry(entry, collector)
+    }
+    if (options.requireObservedSecrets && collector.observedRefs().length === 0) {
+      return yield* Effect.fail(new NetworkCaptureError({
+        message: `Auth refresh did not observe credentials for profile ${secrets ?? "unknown"}`,
+        operation: "auth-profile",
+        reason: "persistence-failed",
+      }))
+    }
+    const authProfile = secrets
+      ? yield* AuthProfile.write({ name: secrets, slots: collector.slots(), ...profileOptions }).pipe(
+        Effect.mapError((cause) => new NetworkCaptureError({ message: cause.message, operation: "auth-profile", reason: "persistence-failed", cause })),
+      )
+      : undefined
+    if (options.outputPath) {
+      yield* writeArtifact(options.outputPath, {
+        log: {
+          version: "1.2",
+          creator: { name: "Browser Control", version: "1" },
+          entries: (protectedEntries ?? []).map(toHarEntry),
+        },
+      })
+    }
+    return {
+      ...(authProfile ? { authProfile } : {}),
+      updatedSecretRefs: collector.updatedRefs(),
+      observedSecretRefs: collector.observedRefs(),
+      redactionOmissionCount: protectedEntries ? countRedactionOmissions(active.entries, protectedEntries) : 0,
+    }
+  })
+}
+
+function countRedactionOmissions(original: readonly CapturedEntry[], protectedEntries: readonly CapturedEntry[]): number {
+  let count = 0
+  for (let index = 0; index < original.length; index += 1) {
+    const before = original[index]
+    const after = protectedEntries[index]
+    if (before?.request.body?.text && !before.request.body.truncated && !after?.request.body?.text) count += 1
+    if (before?.response?.body?.text && !before.response.body.truncated && !after?.response?.body?.text) count += 1
+  }
+  return count
+}
+
+function matches(request: Request, options: ActiveCapture["options"]): boolean {
+  if (options.urlFilter && !request.url().includes(options.urlFilter)) return false
+  return !options.resourceTypes || options.resourceTypes.includes(request.resourceType())
+}
+
+function validateOptions(options: NetworkCaptureOptions): void {
+  if (options.content !== undefined && options.content !== "embed" && options.content !== "omit") {
+    throw new NetworkCaptureError({ message: "Network content must be embed or omit", operation: "start", reason: "invalid-options" })
+  }
+  validateLimit("maxBodyBytes", options.maxBodyBytes, maxAllowedBodyBytes)
+  validateLimit("maxTotalBodyBytes", options.maxTotalBodyBytes, maxAllowedTotalBodyBytes)
+  validateLimit("maxEntries", options.maxEntries, maxAllowedEntries)
+  if (options.resourceTypes && options.resourceTypes.length > maxAllowedResourceTypes) {
+    throw new NetworkCaptureError({ message: `resourceTypes cannot contain more than ${maxAllowedResourceTypes} values`, operation: "start", reason: "invalid-options" })
+  }
+}
+
+function validateLimit(name: string, value: number | undefined, maximum: number): void {
+  if (value === undefined) return
+  if (!Number.isInteger(value) || value <= 0 || value > maximum) {
+    throw new NetworkCaptureError({ message: `${name} must be an integer from 1 to ${maximum}`, operation: "start", reason: "invalid-options" })
+  }
+}
+
+function captureBuffer(buffer: Buffer | null, mimeType: string | undefined, active: ActiveCapture): CapturedBody | undefined {
+  if (!buffer) return undefined
+  const remaining = Math.max(0, active.options.maxTotalBodyBytes - active.capturedBodyBytes)
+  const captureBytes = Math.min(buffer.length, active.options.maxBodyBytes, remaining)
+  const truncated = captureBytes < buffer.length
+  const captured = Buffer.from(buffer.subarray(0, captureBytes))
+  active.capturedBodyBytes += captured.length
+  const textual = isTextualMimeType(mimeType)
+  const omitted = truncated || !textual
+  if (omitted) active.truncatedBodyCount += 1
+  return {
+    size: buffer.length,
+    mimeType: mimeType ?? "application/octet-stream",
+    ...(!truncated && textual ? { text: captured.toString("utf8") } : {}),
+    truncated: omitted,
+  }
+}
+
+function bodyCanFit(headers: readonly Header[], limit: number): boolean {
+  const length = declaredBodySize(headers)
+  const encoding = header(headers, "content-encoding")?.trim().toLowerCase()
+  return length !== undefined && length <= Math.max(0, limit) && (!encoding || encoding === "identity")
+}
+
+function declaredBodySize(headers: readonly Header[]): number | undefined {
+  const value = header(headers, "content-length")
+  if (!value) return undefined
+  const length = Number(value)
+  return Number.isSafeInteger(length) && length >= 0 ? length : undefined
+}
+
+function truncatedBody(mimeType: string | undefined, active: ActiveCapture, size = 0): CapturedBody {
+  active.truncatedBodyCount += 1
+  return { size, mimeType: mimeType ?? "application/octet-stream", truncated: true }
+}
+
+function protectEntry(entry: CapturedEntry, collector: SecretCollector): CapturedEntry {
+  const scope = requestScope(entry.request.method, entry.request.url)
+  const requestHeaders = collector.protectHeaders(entry.request.headers, "request", scope)
+  const responseHeaders = entry.response ? collector.protectHeaders(entry.response.headers, "response", scope) : undefined
+  const requestBody = protectCapturedBody(entry.request.body, collector, "request", scope)
+  const responseBody = protectCapturedBody(entry.response?.body, collector, "response", scope)
+  return {
+    ...entry,
+    request: {
+      ...entry.request,
+      url: collector.protectUrl(entry.request.url, scope),
+      headers: requestHeaders,
+      ...(requestBody ? { body: requestBody } : {}),
+      ...(entry.request.redirectedFrom ? { redirectedFrom: collector.protectUrl(entry.request.redirectedFrom, scope) } : {}),
+    },
+    ...(entry.response ? {
+      response: {
+        ...entry.response,
+        headers: responseHeaders ?? [],
+        ...(responseBody ? { body: responseBody } : {}),
+      },
+    } : {}),
+  }
+}
+
+function protectCapturedBody(
+  body: CapturedBody | undefined,
+  collector: SecretCollector,
+  location: "request" | "response",
+  scope: string,
+): CapturedBody | undefined {
+  if (!body) return undefined
+  if (!body.text) {
+    return { size: body.size, mimeType: body.mimeType, truncated: true }
+  }
+  const text = collector.protectBody(body.text, body.mimeType, location, scope)
+  return text === undefined
+    ? { size: body.size, mimeType: body.mimeType, truncated: true }
+    : { ...body, text }
+}
+
+function redactEntryKnownValues(entry: CapturedEntry, slots: readonly CredentialSlot[]): CapturedEntry {
+  return {
+    ...entry,
+    request: {
+      ...entry.request,
+      ...(entry.request.body?.text ? { body: redactStructuredBody(entry.request.body, slots) } : {}),
+    },
+    ...(entry.response ? {
+      response: {
+        ...entry.response,
+        ...(entry.response.body?.text ? { body: redactStructuredBody(entry.response.body, slots) } : {}),
+      },
+    } : {}),
+  }
+}
+
+function redactStructuredBody(body: CapturedBody, slots: readonly CredentialSlot[]): CapturedBody {
+  if (!body.text || !body.mimeType.toLowerCase().includes("json")) return body
+  try {
+    return { ...body, text: JSON.stringify(redactKnownScalars(JSON.parse(body.text), slots)) }
+  } catch {
+    return { size: body.size, mimeType: body.mimeType, truncated: true }
+  }
+}
+
+function redactKnownScalars(value: unknown, slots: readonly CredentialSlot[]): unknown {
+  if (Array.isArray(value)) return value.map((item) => redactKnownScalars(item, slots))
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactKnownScalars(item, slots)]))
+  }
+  const serialized = typeof value === "string" || typeof value === "number" || typeof value === "boolean" ? String(value) : undefined
+  const slot = serialized === undefined ? undefined : slots.find((candidate) => candidate.value.length >= 8 && candidate.value === serialized)
+  return slot ? `\${${slot.ref}}` : value
+}
+
+function toHarEntry(entry: CapturedEntry): Record<string, unknown> {
+  return {
+    startedDateTime: entry.startedDateTime,
+    time: entry.durationMs,
+    request: {
+      method: entry.request.method,
+      url: entry.request.url,
+      httpVersion: "",
+      cookies: [],
+      headers: entry.request.headers,
+      queryString: queryString(entry.request.url),
+      headersSize: -1,
+      bodySize: entry.request.body?.size ?? 0,
+      ...(entry.request.body?.text ? {
+        postData: { mimeType: entry.request.body.mimeType, text: entry.request.body.text },
+      } : {}),
+    },
+    response: entry.response ? {
+      status: entry.response.status,
+      statusText: entry.response.statusText,
+      httpVersion: "",
+      cookies: [],
+      headers: entry.response.headers,
+      content: {
+        size: entry.response.body?.size ?? 0,
+        mimeType: entry.response.body?.mimeType ?? contentType(entry.response.headers) ?? "application/octet-stream",
+        ...(entry.response.body?.text ? { text: entry.response.body.text } : {}),
+      },
+      redirectURL: header(entry.response.headers, "location") ?? "",
+      headersSize: -1,
+      bodySize: entry.response.body?.size ?? 0,
+    } : { status: 0, statusText: entry.failure ?? "No response", httpVersion: "", cookies: [], headers: [], content: { size: 0, mimeType: "application/octet-stream" }, redirectURL: "", headersSize: -1, bodySize: 0 },
+    cache: {},
+    timings: { send: 0, wait: entry.durationMs, receive: 0 },
+    _browserControl: {
+      id: entry.id,
+      resourceType: entry.request.resourceType,
+      ...(entry.request.redirectedFrom ? { redirectedFrom: entry.request.redirectedFrom } : {}),
+      ...(entry.failure ? { failure: entry.failure } : {}),
+      requestBodyTruncated: entry.request.body?.truncated ?? false,
+      responseBodyTruncated: entry.response?.body?.truncated ?? false,
+    },
+  }
+}
+
+function statusForFinished(active: ActiveCapture, secrets: string | undefined): Omit<NetworkCaptureStatus, "active"> {
+  return {
+    startedAt: active.startedAt,
+    entryCount: active.entries.length,
+    responseCount: active.entries.filter((entry) => entry.response).length,
+    failureCount: active.entries.filter((entry) => entry.failure).length,
+    capturedBodyBytes: active.capturedBodyBytes,
+    truncatedBodyCount: active.truncatedBodyCount,
+    droppedEntryCount: active.droppedEntryCount,
+    ...(active.options.urlFilter ? { urlFilter: active.options.urlFilter } : {}),
+    ...(active.options.resourceTypes ? { resourceTypes: [...active.options.resourceTypes] } : {}),
+    content: active.options.content,
+    ...(secrets ? { secrets } : {}),
+  }
+}
+
+function writeArtifact(outputPath: string, value: unknown): Effect.Effect<void, NetworkCaptureError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const absolutePath = path.resolve(outputPath)
+      await fs.mkdir(path.dirname(absolutePath), { recursive: true })
+      const temporaryPath = `${absolutePath}.${process.pid}.${crypto.randomUUID()}.tmp`
+      let renamed = false
+      try {
+        await fs.writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+        await fs.rename(temporaryPath, absolutePath)
+        renamed = true
+        await fs.chmod(absolutePath, 0o600)
+      } finally {
+        if (!renamed) await fs.rm(temporaryPath, { force: true }).catch(() => {})
+      }
+    },
+    catch: (cause) => new NetworkCaptureError({ message: `Could not write network capture: ${outputPath}`, operation: "write", reason: "persistence-failed", cause }),
+  })
+}
+
+async function safeHeaders(read: () => Promise<Header[]>): Promise<Header[]> {
+  return read().catch(() => [])
+}
+
+async function bodyWithTimeout(response: Response, timeoutMs: number): Promise<Buffer | null> {
+  let timeout: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      response.body().catch(() => null),
+      new Promise<null>((resolve) => {
+        timeout = setTimeout(() => resolve(null), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+async function settleFinalizers(active: ActiveCapture, timeoutMs: number): Promise<boolean> {
+  if (active.pending.size === 0 && active.finalizeQueue.length === 0 && active.finalizeWorkers === 0) return true
+  let timeout: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      new Promise<true>((resolve) => {
+        active.finalizeWaiters.push(() => resolve(true))
+      }),
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+function notifyFinalizersSettled(active: ActiveCapture): void {
+  if (active.pending.size > 0 || active.finalizeQueue.length > 0 || active.finalizeWorkers > 0) return
+  for (const resolve of active.finalizeWaiters.splice(0)) resolve()
+}
+
+function safeValue<A>(read: () => A, fallback: A): A {
+  try {
+    return read()
+  } catch {
+    return fallback
+  }
+}
+
+function requestScope(method: string, rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    return `${method.toUpperCase()} ${url.origin}${url.pathname}`
+  } catch {
+    return `${method.toUpperCase()} ${rawUrl.split("?", 1)[0] ?? rawUrl}`
+  }
+}
+
+function contentType(headers: readonly Header[]): string | undefined {
+  return header(headers, "content-type")?.trim()
+}
+
+function header(headers: readonly Header[], name: string): string | undefined {
+  return headers.find((candidate) => candidate.name.toLowerCase() === name)?.value
+}
+
+function queryString(rawUrl: string): Array<{ name: string; value: string }> {
+  try {
+    return Array.from(new URL(rawUrl).searchParams, ([name, value]) => ({ name, value }))
+  } catch {
+    return []
+  }
+}
+
+function isTextualMimeType(mimeType: string | undefined): boolean {
+  return !mimeType || mimeType.startsWith("text/") || /json|javascript|xml|x-www-form-urlencoded|multipart\/form-data|graphql/.test(mimeType)
+}
+
+export * as NetworkCapture from "./network-capture.ts"

--- a/src/network-redaction.ts
+++ b/src/network-redaction.ts
@@ -1,0 +1,372 @@
+export type CredentialSlot = {
+  readonly ref: string
+  value: string
+  readonly sources: readonly string[]
+  expiresAt?: string
+}
+
+type MutableCredentialSlot = Omit<CredentialSlot, "sources"> & { readonly sources: string[] }
+
+const secretNamePattern = /auth(?:orization)?|cookie|credential|csrf|xsrf|token|secret|session|password|passwd|pwd|passcode|otp|(?:^|[-_.])code(?:$|[-_.])|(?:api|access|refresh)[-_.]?key|signature|(?:^|[-_.])sig(?:$|[-_.])/i
+const secretHeaders = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-api-key",
+  "api-key",
+  "x-csrf-token",
+  "csrf-token",
+  "x-xsrf-token",
+])
+
+export class SecretCollector {
+  private readonly slotsByRef = new Map<string, MutableCredentialSlot>()
+  private readonly refsByValue = new Map<string, string>()
+  private readonly refsBySource = new Map<string, string>()
+  private nextRef = 1
+  private updated = new Set<string>()
+  private observed = new Set<string>()
+
+  constructor(existing: readonly CredentialSlot[] = []) {
+    for (const slot of existing) {
+      const copy: MutableCredentialSlot = {
+        ref: slot.ref,
+        value: slot.value,
+        sources: [...slot.sources],
+        ...(slot.expiresAt ? { expiresAt: slot.expiresAt } : {}),
+      }
+      this.slotsByRef.set(copy.ref, copy)
+      this.refsByValue.set(copy.value, copy.ref)
+      for (const source of copy.sources) {
+        this.refsBySource.set(source, copy.ref)
+      }
+      const number = /^BC_SECRET_(\d+)$/.exec(copy.ref)?.[1]
+      if (number) this.nextRef = Math.max(this.nextRef, Number(number) + 1)
+    }
+  }
+
+  protectHeaders(headers: readonly { readonly name: string; readonly value: string }[], location: "request" | "response", requestScope = ""): Array<{ name: string; value: string }> {
+    const occurrences = new Map<string, number>()
+    return headers.map(({ name, value }) => {
+      const lowerName = name.toLowerCase()
+      const occurrence = occurrences.get(lowerName) ?? 0
+      occurrences.set(lowerName, occurrence + 1)
+      return {
+      name,
+        value: this.protectHeader(name, value, sourceName(requestScope, `${location}.header.${lowerName}`, occurrence)),
+      }
+    })
+  }
+
+  protectUrl(rawUrl: string, requestScope = ""): string {
+    let url: URL
+    try {
+      url = new URL(rawUrl)
+    } catch {
+      return protectRelativeUrl(rawUrl, (name, value, occurrence) => this.reference(
+        value,
+        sourceName(requestScope, `query.${name}`, occurrence),
+      ))
+    }
+    url.search = protectSearchParams(url.searchParams, (name, value, occurrence) => this.reference(
+      value,
+      sourceName(requestScope, `query.${name}`, occurrence),
+    )).toString()
+    return restoreReferencePlaceholders(url.toString())
+  }
+
+  protectBody(body: string, contentType: string | undefined, location: "request" | "response", requestScope = ""): string | undefined {
+    const type = contentType?.toLowerCase() ?? ""
+    if (type.includes("json")) {
+      try {
+        return JSON.stringify(this.protectJson(JSON.parse(body), sourceName(requestScope, location)))
+      } catch {
+        return undefined
+      }
+    }
+    if (type.includes("application/x-www-form-urlencoded")) {
+      const params = new URLSearchParams(body)
+      const protectedParams = new URLSearchParams()
+      const occurrences = new Map<string, number>()
+      for (const [name, value] of params) {
+        const occurrence = occurrences.get(name) ?? 0
+        occurrences.set(name, occurrence + 1)
+        protectedParams.append(name, value && secretNamePattern.test(name)
+          ? this.reference(value, sourceName(requestScope, `${location}.form.${name}`, occurrence))
+          : value)
+      }
+      return restoreReferencePlaceholders(protectedParams.toString())
+    }
+    if (type.includes("multipart/form-data")) {
+      return this.protectMultipart(body, contentType ?? "", location, requestScope)
+    }
+    return undefined
+  }
+
+  slots(): readonly CredentialSlot[] {
+    return Array.from(this.slotsByRef.values())
+      .sort((left, right) => left.ref.localeCompare(right.ref, undefined, { numeric: true }))
+      .map((slot) => ({ ...slot, sources: [...slot.sources] }))
+  }
+
+  updatedRefs(): readonly string[] {
+    return Array.from(this.updated).sort()
+  }
+
+  observedRefs(): readonly string[] {
+    return Array.from(this.observed).sort()
+  }
+
+  redactText(text: string): string {
+    return redactKnownValues(text, this.slots())
+  }
+
+  redactValue(value: unknown): unknown {
+    return redactSecretShapedValue(redactKnownValue(value, this.slots()))
+  }
+
+  private protectHeader(name: string, value: string, source: string): string {
+    if (!value) return value
+    const lower = name.toLowerCase()
+    if (lower === "cookie" || lower === "set-cookie") {
+      const cookieOccurrences = new Map<string, number>()
+      return value.split(/;\s*/).map((part, index) => {
+        const separator = part.indexOf("=")
+        if (separator < 1) return part
+        const cookieName = part.slice(0, separator).trim()
+        const cookieValue = part.slice(separator + 1)
+        if (lower === "set-cookie" && index > 0 && /^(domain|path|expires|max-age|samesite)$/i.test(cookieName)) {
+          return part
+        }
+        if (!cookieValue) return part
+        const occurrence = cookieOccurrences.get(cookieName) ?? 0
+        cookieOccurrences.set(cookieName, occurrence + 1)
+        return `${cookieName}=${this.reference(cookieValue, sourceName("", `${source}.${cookieName}`, occurrence))}`
+      }).join("; ")
+    }
+    if (lower === "location" || lower === "referer" || lower === "referrer") {
+      return this.protectUrl(value, `${source}.url`)
+    }
+    if (lower === "authorization" || lower === "proxy-authorization") {
+      const match = /^(\S+)\s+(.+)$/.exec(value)
+      if (match) return `${match[1]} ${this.reference(match[2] ?? "", source)}`
+    }
+    if (secretHeaders.has(lower) || secretNamePattern.test(lower)) {
+      return this.reference(value, source)
+    }
+    return value
+  }
+
+  private protectJson(value: unknown, location: string, path: readonly string[] = []): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item, index) => this.protectJson(item, location, [...path, String(index)]))
+    }
+    if (!value || typeof value !== "object") return value
+    const result: Record<string, unknown> = {}
+    for (const [key, item] of Object.entries(value)) {
+      const nextPath = [...path, key]
+      if (item !== null && item !== "" && secretNamePattern.test(key)) {
+        result[key] = this.protectSecretJsonValue(item, location, nextPath)
+      } else {
+        result[key] = this.protectJson(item, location, nextPath)
+      }
+    }
+    return result
+  }
+
+  private protectSecretJsonValue(value: unknown, location: string, path: readonly string[]): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item, index) => this.protectSecretJsonValue(item, location, [...path, String(index)]))
+    }
+    if (value && typeof value === "object") {
+      return Object.fromEntries(Object.entries(value).map(([key, item]) => [
+        key,
+        this.protectSecretJsonValue(item, location, [...path, key]),
+      ]))
+    }
+    if (value === null || value === "") return value
+    return this.reference(String(value), `${location}.json.${path.join(".")}`)
+  }
+
+  private protectMultipart(body: string, contentType: string, location: "request" | "response", requestScope: string): string | undefined {
+    const boundary = /boundary=(?:"([^"]+)"|([^;\s]+))/i.exec(contentType)?.slice(1).find(Boolean)
+    if (!boundary) return undefined
+    const delimiter = `--${boundary}`
+    const parts = body.split(delimiter)
+    if (parts.length < 3) return undefined
+    const occurrences = new Map<string, number>()
+    for (let index = 1; index < parts.length - 1; index += 1) {
+      const part = parts[index]
+      if (!part?.startsWith("\r\n")) return undefined
+      const headerEnd = part.indexOf("\r\n\r\n")
+      if (headerEnd < 0 || !part.endsWith("\r\n")) return undefined
+      const headers = part.slice(2, headerEnd)
+      const disposition = headers.split("\r\n").find((line) => /^content-disposition:/i.test(line))
+      if (!disposition || /;\s*filename\*?=/i.test(disposition)) return undefined
+      const name = /;\s*name="([^"]+)"/i.exec(disposition)?.[1]
+      if (!name) return undefined
+      const valueStart = headerEnd + 4
+      const valueEnd = part.length - 2
+      const value = part.slice(valueStart, valueEnd)
+      if (!value || !secretNamePattern.test(name)) continue
+      const occurrence = occurrences.get(name) ?? 0
+      occurrences.set(name, occurrence + 1)
+      const reference = this.reference(value, sourceName(requestScope, `${location}.multipart.${name}`, occurrence))
+      parts[index] = `${part.slice(0, valueStart)}${reference}${part.slice(valueEnd)}`
+    }
+    return parts.join(delimiter)
+  }
+
+  private reference(value: string, source: string): string {
+    const sourceRef = this.refsBySource.get(source)
+    if (sourceRef) {
+      const slot = this.slotsByRef.get(sourceRef)
+      if (slot) {
+        if (slot.value === value) {
+          this.observed.add(sourceRef)
+          return `\${${sourceRef}}`
+        }
+        if (slot.sources.length === 1) {
+          if (this.refsByValue.get(slot.value) === sourceRef) this.refsByValue.delete(slot.value)
+          slot.value = value
+          const expiresAt = jwtExpiration(value)
+          if (expiresAt) slot.expiresAt = expiresAt
+          else delete slot.expiresAt
+          this.refsByValue.set(value, sourceRef)
+          this.updated.add(sourceRef)
+          this.observed.add(sourceRef)
+          return `\${${sourceRef}}`
+        }
+        const sourceIndex = slot.sources.indexOf(source)
+        if (sourceIndex >= 0) slot.sources.splice(sourceIndex, 1)
+        const replacementRef = this.refsByValue.get(value)
+        if (replacementRef) {
+          this.refsBySource.set(source, replacementRef)
+          this.addSource(replacementRef, source)
+          this.updated.add(replacementRef)
+          this.observed.add(replacementRef)
+          return `\${${replacementRef}}`
+        }
+      }
+    }
+    const valueRef = this.refsByValue.get(value)
+    if (valueRef) {
+      this.observed.add(valueRef)
+      this.addSource(valueRef, source)
+      return `\${${valueRef}}`
+    }
+    const ref = `BC_SECRET_${this.nextRef++}`
+    const expiresAt = jwtExpiration(value)
+    this.slotsByRef.set(ref, { ref, value, sources: [source], ...(expiresAt ? { expiresAt } : {}) })
+    this.refsByValue.set(value, ref)
+    this.refsBySource.set(source, ref)
+    this.updated.add(ref)
+    this.observed.add(ref)
+    return `\${${ref}}`
+  }
+
+  private addSource(ref: string, source: string): void {
+    const slot = this.slotsByRef.get(ref)
+    if (!slot || slot.sources.includes(source)) return
+    slot.sources.push(source)
+    this.refsBySource.set(source, ref)
+  }
+}
+
+function restoreReferencePlaceholders(value: string): string {
+  return value.replace(/(?:%24|\$)%7B(BC_SECRET_\d+)%7D/gi, (_match, ref: string) => `\${${ref}}`)
+}
+
+function protectRelativeUrl(
+  rawUrl: string,
+  protect: (name: string, value: string, occurrence: number) => string,
+): string {
+  const queryStart = rawUrl.indexOf("?")
+  if (queryStart < 0) return rawUrl
+  const fragmentStart = rawUrl.indexOf("#", queryStart)
+  const queryEnd = fragmentStart < 0 ? rawUrl.length : fragmentStart
+  const params = new URLSearchParams(rawUrl.slice(queryStart + 1, queryEnd))
+  const protectedQuery = protectSearchParams(params, protect).toString()
+  return restoreReferencePlaceholders(`${rawUrl.slice(0, queryStart)}?${protectedQuery}${rawUrl.slice(queryEnd)}`)
+}
+
+function protectSearchParams(
+  params: URLSearchParams,
+  protect: (name: string, value: string, occurrence: number) => string,
+): URLSearchParams {
+  const result = new URLSearchParams()
+  const occurrences = new Map<string, number>()
+  for (const [name, value] of params) {
+    const occurrence = occurrences.get(name) ?? 0
+    occurrences.set(name, occurrence + 1)
+    result.append(name, value && secretNamePattern.test(name) ? protect(name, value, occurrence) : value)
+  }
+  return result
+}
+
+function sourceName(requestScope: string, location: string, occurrence = 0): string {
+  const base = requestScope ? `${requestScope}.${location}` : location
+  return occurrence === 0 ? base : `${base}.${occurrence}`
+}
+
+export function redactKnownValues(text: string, slots: readonly CredentialSlot[]): string {
+  return [...slots]
+    .sort((left, right) => right.value.length - left.value.length)
+    .reduce((output, slot) => replaceOutsideReferences(output, slot.value, `\${${slot.ref}}`), text)
+}
+
+export function redactSecretShapedValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSecretShapedValue)
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [
+    key,
+    secretNamePattern.test(key) && item !== null && item !== ""
+      ? redactSecretValue(item)
+      : redactSecretShapedValue(item),
+  ]))
+}
+
+function redactKnownValue(value: unknown, slots: readonly CredentialSlot[]): unknown {
+  if (typeof value === "string") return redactKnownValues(value, slots)
+  if (typeof value === "number" || typeof value === "boolean") {
+    const slot = slots.find((candidate) => candidate.value === String(value))
+    return slot ? `\${${slot.ref}}` : value
+  }
+  if (Array.isArray(value)) return value.map((item) => redactKnownValue(item, slots))
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactKnownValue(item, slots)]))
+}
+
+function redactSecretValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSecretValue)
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, redactSecretValue(item)]))
+  }
+  return value === null || value === "" ? value : "[REDACTED]"
+}
+
+function replaceOutsideReferences(text: string, value: string, replacement: string): string {
+  if (!value) return text
+  const referencePattern = /\$\{BC_SECRET_\d+\}/g
+  let output = ""
+  let offset = 0
+  for (const match of text.matchAll(referencePattern)) {
+    const index = match.index ?? 0
+    output += text.slice(offset, index).split(value).join(replacement)
+    output += match[0]
+    offset = index + match[0].length
+  }
+  return output + text.slice(offset).split(value).join(replacement)
+}
+
+function jwtExpiration(value: string): string | undefined {
+  const parts = value.split(".")
+  if (parts.length !== 3 || !parts[1]) return undefined
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as { exp?: unknown }
+    return typeof payload.exp === "number" ? new Date(payload.exp * 1_000).toISOString() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export * as NetworkRedaction from "./network-redaction.ts"

--- a/src/relay-client.ts
+++ b/src/relay-client.ts
@@ -1,10 +1,21 @@
 import { Config, Context, Effect, Layer, Option, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest, type HttpClientResponse } from "effect/unstable/http"
 import {
+  type AuthProfileRequest,
+  AuthProfileSummary,
+  type AuthRefreshRequest,
+  type AuthRunRequest,
+  AuthRunResponse,
   ErrorEnvelope,
   type ExecuteRequest,
   ExecuteResponse,
   ExtensionStatus,
+  NetworkCancelResponse,
+  type NetworkSessionRequest,
+  type NetworkStartRequest,
+  NetworkStatusResponse,
+  type NetworkStopRequest,
+  NetworkStopResponse,
   RecordingCancelResponse,
   type RecordingStartRequest,
   RecordingStartResponse,
@@ -93,6 +104,13 @@ export interface Interface {
   readonly sessionAdopt: (request: SessionAdoptRequest) => Effect.Effect<SessionAdoptResponse, RelayClientError>
   readonly sessionDelete: (id: string) => Effect.Effect<SessionDeleted, RelayClientError>
   readonly execute: (request: ExecuteRequest) => Effect.Effect<ExecuteResponse, RelayClientError>
+  readonly networkStart: (request: NetworkStartRequest) => Effect.Effect<NetworkStatusResponse, RelayClientError>
+  readonly networkStatus: (request: NetworkSessionRequest) => Effect.Effect<NetworkStatusResponse, RelayClientError>
+  readonly networkStop: (request: NetworkStopRequest) => Effect.Effect<NetworkStopResponse, RelayClientError>
+  readonly networkCancel: (request: NetworkSessionRequest) => Effect.Effect<NetworkCancelResponse, RelayClientError>
+  readonly authStatus: (request: AuthProfileRequest) => Effect.Effect<AuthProfileSummary, RelayClientError>
+  readonly authRefresh: (request: AuthRefreshRequest) => Effect.Effect<NetworkStopResponse, RelayClientError>
+  readonly authRun: (request: AuthRunRequest) => Effect.Effect<AuthRunResponse, RelayClientError>
   readonly recordingStart: (request: RecordingStartRequest) => Effect.Effect<RecordingStartResponse, RelayClientError>
   readonly recordingStop: (target: RecordingTargetRequest) => Effect.Effect<RecordingStopResponse, RelayClientError>
   readonly recordingStatus: (target: RecordingTargetRequest) => Effect.Effect<RecordingStatusResponse, RelayClientError>
@@ -234,6 +252,13 @@ export const make = Effect.fn("RelayClient.make")(function* (options?: { readonl
         createIfMissing: request.createIfMissing,
         ...(request.targetSelection === undefined ? {} : { targetSelection: request.targetSelection }),
       }, ExecuteResponse),
+    networkStart: (request) => postJson("/network/start", { ...request }, NetworkStatusResponse),
+    networkStatus: (request) => postJson("/network/status", { ...request }, NetworkStatusResponse),
+    networkStop: (request) => postJson("/network/stop", { ...request }, NetworkStopResponse),
+    networkCancel: (request) => postJson("/network/cancel", { ...request }, NetworkCancelResponse),
+    authStatus: (request) => postJson("/auth/status", { ...request }, AuthProfileSummary),
+    authRefresh: (request) => postJson("/auth/refresh", { ...request }, NetworkStopResponse),
+    authRun: (request) => postJson("/auth/run", { ...request }, AuthRunResponse),
     recordingStart: (request) =>
       postJson("/recording/start", {
         ...recordingTargetBody(request),

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -197,6 +197,105 @@ export const RelayVersion = Schema.Struct({
 
 export interface RelayVersion extends Schema.Schema.Type<typeof RelayVersion> {}
 
+export const NetworkContentMode = Schema.Literals(["omit", "embed"])
+
+export const NetworkStartRequest = Schema.Struct({
+  sessionId: Schema.NonEmptyString,
+  urlFilter: Schema.optionalKey(Schema.String),
+  resourceTypes: Schema.optionalKey(Schema.Array(Schema.NonEmptyString).check(Schema.isMaxLength(50))),
+  content: Schema.optionalKey(NetworkContentMode),
+  maxBodyBytes: Schema.optionalKey(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 10_000_000 }))),
+  maxTotalBodyBytes: Schema.optionalKey(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 100_000_000 }))),
+  maxEntries: Schema.optionalKey(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 10_000 }))),
+})
+
+export interface NetworkStartRequest extends Schema.Schema.Type<typeof NetworkStartRequest> {}
+
+export const NetworkSessionRequest = Schema.Struct({ sessionId: Schema.NonEmptyString })
+export interface NetworkSessionRequest extends Schema.Schema.Type<typeof NetworkSessionRequest> {}
+
+export const NetworkStopRequest = NetworkSessionRequest.pipe(Schema.fieldsAssign({
+  outputPath: Schema.optionalKey(Schema.String),
+  secrets: Schema.optionalKey(Schema.NonEmptyString),
+}))
+export interface NetworkStopRequest extends Schema.Schema.Type<typeof NetworkStopRequest> {}
+
+export const NetworkStatusResponse = Schema.Struct({
+  active: Schema.Boolean,
+  startedAt: Schema.optionalKey(Schema.String),
+  entryCount: Schema.Number,
+  responseCount: Schema.Number,
+  failureCount: Schema.Number,
+  capturedBodyBytes: Schema.Number,
+  truncatedBodyCount: Schema.Number,
+  droppedEntryCount: Schema.Number,
+  urlFilter: Schema.optionalKey(Schema.String),
+  resourceTypes: Schema.optionalKey(Schema.Array(Schema.String)),
+  content: Schema.optionalKey(NetworkContentMode),
+  secrets: Schema.optionalKey(Schema.String),
+})
+export interface NetworkStatusResponse extends Schema.Schema.Type<typeof NetworkStatusResponse> {}
+
+export const AuthProfileSlotSummary = Schema.Struct({
+  ref: Schema.String,
+  sources: Schema.Array(Schema.String),
+  expiresAt: Schema.optionalKey(Schema.String),
+  expired: Schema.Boolean,
+})
+
+export const AuthProfileSummary = Schema.Struct({
+  name: Schema.String,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  slotCount: Schema.Number,
+  slots: Schema.Array(AuthProfileSlotSummary),
+})
+export interface AuthProfileSummary extends Schema.Schema.Type<typeof AuthProfileSummary> {}
+
+export const NetworkStopResponse = NetworkStatusResponse.pipe(Schema.fieldsAssign({
+  active: Schema.Literal(false),
+  stoppedAt: Schema.String,
+  outputPath: Schema.optionalKey(Schema.String),
+  authProfile: Schema.optionalKey(AuthProfileSummary),
+  updatedSecretRefs: Schema.Array(Schema.String),
+  observedSecretRefs: Schema.Array(Schema.String),
+}))
+export interface NetworkStopResponse extends Schema.Schema.Type<typeof NetworkStopResponse> {}
+
+export const NetworkCancelResponse = Schema.Struct({ cancelled: Schema.Boolean })
+export interface NetworkCancelResponse extends Schema.Schema.Type<typeof NetworkCancelResponse> {}
+
+export const AuthProfileRequest = Schema.Struct({ name: Schema.NonEmptyString })
+export interface AuthProfileRequest extends Schema.Schema.Type<typeof AuthProfileRequest> {}
+
+export const AuthRefreshRequest = Schema.Struct({
+  sessionId: Schema.NonEmptyString,
+  name: Schema.NonEmptyString,
+  urlFilter: Schema.optionalKey(Schema.String),
+  timeoutMs: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
+})
+export interface AuthRefreshRequest extends Schema.Schema.Type<typeof AuthRefreshRequest> {}
+
+export const AuthRunRequest = Schema.Struct({
+  name: Schema.NonEmptyString,
+  command: Schema.NonEmptyString,
+  args: Schema.optionalKey(Schema.Array(Schema.String)),
+  cwd: Schema.optionalKey(Schema.String),
+  timeoutMs: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
+})
+export interface AuthRunRequest extends Schema.Schema.Type<typeof AuthRunRequest> {}
+
+export const AuthRunResponse = Schema.Struct({
+  exitCode: Schema.Number,
+  signal: Schema.NullOr(Schema.String),
+  stdout: Schema.String,
+  stderr: Schema.String,
+  stdoutTruncated: Schema.Boolean,
+  stderrTruncated: Schema.Boolean,
+  durationMs: Schema.Number,
+})
+export interface AuthRunResponse extends Schema.Schema.Type<typeof AuthRunResponse> {}
+
 export const RecordingMode = Schema.Literals(["tab-capture", "cdp"])
 
 export const RecordingRequestedMode = Schema.Literals(["auto", "tab-capture", "cdp"])
@@ -271,6 +370,8 @@ export interface RecordingCancelResponse extends Schema.Schema.Type<typeof Recor
 
 export const RelayErrorCode = Schema.Literals([
   "invalid-request",
+  "auth-profile-not-found",
+  "capture-conflict",
   "session-already-exists",
   "session-inactive",
   "session-not-found",

--- a/src/relay-types.ts
+++ b/src/relay-types.ts
@@ -1,5 +1,6 @@
 import type { Effect, Semaphore } from "effect"
 import type { AdoptTarget, ExecuteOptions, ExecuteResult } from "./execute.ts"
+import type { NetworkCaptureOptions, NetworkCaptureResult, NetworkCaptureStatus, NetworkCaptureStopOptions } from "./network-capture.ts"
 import type { JsonObject, TargetInfo } from "./protocol.ts"
 import type { SessionSummary } from "./relay-schema.ts"
 
@@ -48,6 +49,12 @@ export interface ExecuteSandboxLike {
   close(): Effect.Effect<void, Error>
   /** Adoption rollback cleanup does not settle before started Playwright close promises settle. */
   closeSettled(): Effect.Effect<void, Error>
+  networkStart(options?: NetworkCaptureOptions): Effect.Effect<NetworkCaptureStatus, Error>
+  networkStatus(): NetworkCaptureStatus
+  networkStop(options?: NetworkCaptureStopOptions): Effect.Effect<NetworkCaptureResult, Error>
+  networkCancel(): Effect.Effect<{ readonly cancelled: boolean }>
+  authRefresh(options: { readonly name: string; readonly urlFilter?: string; readonly timeoutMs?: number }): Effect.Effect<NetworkCaptureResult, Error>
+  redactNetworkCaptureText(text: string): string
   markTargetCrashed(targetId: string): boolean
   markTargetDetached(targetId: string): boolean
   getStatus(): {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1,5 +1,6 @@
 import { Deferred, Effect, Option, Schema, Semaphore } from "effect"
 import { defaultPageClosedWarning, ExecuteSandbox, hasExplicitTargetSelection, type ExecuteResult, type ExecuteTargetSelection } from "./execute.ts"
+import type { NetworkCaptureOptions, NetworkCaptureResult, NetworkCaptureStatus, NetworkCaptureStopOptions } from "./network-capture.ts"
 import { generateSessionId } from "./relay-helpers.ts"
 import type { BrowserControlSession, ExecuteSandboxLike, SessionSummary } from "./relay-types.ts"
 import {
@@ -215,6 +216,61 @@ export class BrowserControlSessions {
     return undefined
   }
 
+  networkStart(id: string, options: NetworkCaptureOptions = {}): Effect.Effect<NetworkCaptureStatus, Error> {
+    const manager = this
+    const session = this.sessions.get(id)
+    if (!session) return Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
+    return this.withLifecyclePermit(session, "network start", Effect.gen(function* () {
+      if (manager.sessions.get(id) !== session) {
+        return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
+      }
+      return yield* session.sandbox.networkStart(options)
+    }))
+  }
+
+  networkStatus(id: string): Effect.Effect<NetworkCaptureStatus, Error> {
+    const session = this.sessions.get(id)
+    return session
+      ? Effect.succeed(session.sandbox.networkStatus())
+      : Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
+  }
+
+  networkStop(id: string, options: NetworkCaptureStopOptions = {}): Effect.Effect<NetworkCaptureResult, Error> {
+    const manager = this
+    const session = this.sessions.get(id)
+    if (!session) return Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
+    return this.withLifecyclePermit(session, "network stop", Effect.gen(function* () {
+      if (manager.sessions.get(id) !== session) {
+        return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
+      }
+      return yield* session.sandbox.networkStop(options)
+    }))
+  }
+
+  networkCancel(id: string): Effect.Effect<{ readonly cancelled: boolean }, Error> {
+    const manager = this
+    const session = this.sessions.get(id)
+    if (!session) return Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
+    return this.withLifecyclePermit(session, "network cancel", Effect.gen(function* () {
+      if (manager.sessions.get(id) !== session) {
+        return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
+      }
+      return yield* session.sandbox.networkCancel()
+    }))
+  }
+
+  authRefresh(id: string, options: { readonly name: string; readonly urlFilter?: string; readonly timeoutMs?: number }): Effect.Effect<NetworkCaptureResult, Error> {
+    const manager = this
+    const session = this.sessions.get(id)
+    if (!session) return Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
+    return this.withLifecyclePermit(session, "auth refresh", Effect.gen(function* () {
+      if (manager.sessions.get(id) !== session) {
+        return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
+      }
+      return yield* session.sandbox.authRefresh(options)
+    }))
+  }
+
   execute(options: {
     readonly sessionId?: string
     readonly code: string
@@ -262,7 +318,12 @@ export class BrowserControlSessions {
             ? { ...result, warnings: [...result.warnings, adoptionTipForUrl(userAttachedPageUrls[0] ?? "about:blank")] }
             : result
           session.updatedAt = new Date().toISOString()
-          manager.recordExecute({ sessionId: session.id, code: options.code, durationMs: Date.now() - startedAt, result: resultWithHint })
+          manager.recordExecute({
+            sessionId: session.id,
+            code: session.sandbox.redactNetworkCaptureText(options.code),
+            durationMs: Date.now() - startedAt,
+            result: resultWithHint,
+          })
           const summary = manager.sessionSummary(session)
           return { result: resultWithHint, session: { ...summary, ...(resolved.created ? { created: true } : {}) } }
         }),

--- a/test/auth-profile.test.ts
+++ b/test/auth-profile.test.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { Effect } from "effect"
+import * as AuthProfile from "../src/auth-profile.ts"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })))
+})
+
+describe("AuthProfile", () => {
+  it("writes restrictive profiles and returns metadata without values", async () => {
+    const baseDir = await temporaryDirectory()
+    const result = await Effect.runPromise(AuthProfile.write({
+      name: "uber",
+      baseDir,
+      slots: [{ ref: "BC_SECRET_1", value: "token-value", sources: ["request.header.authorization"] }],
+    }))
+
+    expect(result).toMatchObject({ name: "uber", slotCount: 1, slots: [{ ref: "BC_SECRET_1", expired: false }] })
+    expect(JSON.stringify(result)).not.toContain("token-value")
+    const stat = await fs.stat(path.join(baseDir, "uber.json"))
+    expect(stat.mode & 0o777).toBe(0o600)
+  })
+
+  it("injects profile values and redacts them from child output", async () => {
+    const baseDir = await temporaryDirectory()
+    await Effect.runPromise(AuthProfile.write({
+      name: "uber",
+      baseDir,
+      slots: [{ ref: "BC_SECRET_1", value: "token-value", sources: ["request.header.authorization"] }],
+    }))
+
+    const result = await Effect.runPromise(AuthProfile.run({
+      name: "uber",
+      baseDir,
+      command: process.execPath,
+      args: ["-e", "process.stdout.write(process.env.BC_SECRET_1 || '')"],
+    }))
+    expect(result).toMatchObject({ exitCode: 0, stdout: "${BC_SECRET_1}", stderr: "" })
+  })
+
+  it("does not leak a credential cut by the output budget", async () => {
+    const baseDir = await temporaryDirectory()
+    await Effect.runPromise(AuthProfile.write({
+      name: "uber",
+      baseDir,
+      slots: [{ ref: "BC_SECRET_1", value: "long-token-value", sources: ["request.header.authorization"] }],
+    }))
+
+    const result = await Effect.runPromise(AuthProfile.run({
+      name: "uber",
+      baseDir,
+      maxOutputBytes: 8,
+      command: process.execPath,
+      args: ["-e", "process.stdout.write(process.env.BC_SECRET_1 || '')"],
+    }))
+    expect(result.stdout).toBe("")
+    expect(result.stdoutTruncated).toBe(true)
+  })
+
+  it("updates an existing profile without changing its creation time", async () => {
+    const baseDir = await temporaryDirectory()
+    await Effect.runPromise(AuthProfile.write({
+      name: "uber",
+      baseDir,
+      slots: [{ ref: "BC_SECRET_1", value: "old", sources: ["request.header.authorization"] }],
+    }))
+    const before = await Effect.runPromise(AuthProfile.read("uber", { baseDir }))
+    await Effect.runPromise(AuthProfile.write({
+      name: "uber",
+      baseDir,
+      slots: [{ ref: "BC_SECRET_1", value: "new", sources: ["request.header.authorization"] }],
+    }))
+    const after = await Effect.runPromise(AuthProfile.read("uber", { baseDir }))
+
+    expect(after.createdAt).toBe(before.createdAt)
+    expect(after.slots[0]?.value).toBe("new")
+  })
+
+  it("does not overwrite a malformed existing profile", async () => {
+    const baseDir = await temporaryDirectory()
+    const filePath = path.join(baseDir, "uber.json")
+    await fs.writeFile(filePath, "not-json", { mode: 0o600 })
+
+    await expect(Effect.runPromise(AuthProfile.write({
+      name: "uber",
+      baseDir,
+      slots: [{ ref: "BC_SECRET_1", value: "new", sources: ["request.header.authorization"] }],
+    }))).rejects.toMatchObject({ _tag: "AuthProfile.Error", reason: "invalid-json" })
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("not-json")
+  })
+
+  it("terminates a timed-out credential-bearing process", async () => {
+    const baseDir = await temporaryDirectory()
+    await Effect.runPromise(AuthProfile.write({
+      name: "uber",
+      baseDir,
+      slots: [{ ref: "BC_SECRET_1", value: "token-value", sources: ["request.header.authorization"] }],
+    }))
+
+    const result = await Effect.runPromise(AuthProfile.run({
+      name: "uber",
+      baseDir,
+      timeoutMs: 20,
+      command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1000)"],
+    }))
+    expect(result.exitCode).toBe(1)
+    expect(result.signal).toMatch(/SIGTERM|SIGKILL/)
+  })
+
+  it("does not pass inherited Browser Control secret slots to the child", async () => {
+    const baseDir = await temporaryDirectory()
+    await Effect.runPromise(AuthProfile.write({
+      name: "uber",
+      baseDir,
+      slots: [{ ref: "BC_SECRET_1", value: "profile-token", sources: ["request.header.authorization"] }],
+    }))
+    process.env.BC_SECRET_999 = "inherited-token"
+    try {
+      const result = await Effect.runPromise(AuthProfile.run({
+        name: "uber",
+        baseDir,
+        command: process.execPath,
+        args: ["-e", "process.stdout.write(process.env.BC_SECRET_999 || '')"],
+      }))
+      expect(result.stdout).toBe("")
+    } finally {
+      delete process.env.BC_SECRET_999
+    }
+  })
+
+  it("serializes profile transactions through a filesystem lock", async () => {
+    const baseDir = await temporaryDirectory()
+    let active = 0
+    let maximumActive = 0
+    const transaction = () => AuthProfile.withLock("uber", { baseDir }, Effect.gen(function* () {
+      active += 1
+      maximumActive = Math.max(maximumActive, active)
+      yield* Effect.sleep(30)
+      active -= 1
+    }))
+
+    await Promise.all([Effect.runPromise(transaction()), Effect.runPromise(transaction())])
+    expect(maximumActive).toBe(1)
+    await expect(fs.stat(path.join(baseDir, "uber.json.lock"))).rejects.toMatchObject({ code: "ENOENT" })
+  })
+})
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "browser-control-auth-"))
+  temporaryDirectories.push(directory)
+  return directory
+}

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -67,6 +67,26 @@ describe("HTTP request schemas", () => {
         status: 400,
         body: { error: expect.stringContaining("Invalid recording start request"), code: "invalid-request" },
       })
+      await expect(postJson(port, "/network/start", { sessionId: "beta", content: "everything" })).resolves.toMatchObject({
+        status: 400,
+        body: { error: expect.stringContaining("Invalid network start request"), code: "invalid-request" },
+      })
+      await expect(postJson(port, "/network/stop", { sessionId: "beta", secrets: 42 })).resolves.toMatchObject({
+        status: 400,
+        body: { error: expect.stringContaining("Invalid network stop request"), code: "invalid-request" },
+      })
+      await expect(postJson(port, "/auth/run", { name: "uber", command: "", timeoutMs: -1 })).resolves.toMatchObject({
+        status: 400,
+        body: { error: expect.stringContaining("Invalid auth run request"), code: "invalid-request" },
+      })
+      await expect(postJson(port, "/auth/status", { name: `missing-${Date.now()}` })).resolves.toMatchObject({
+        status: 404,
+        body: { error: expect.stringContaining("Auth profile not found"), code: "auth-profile-not-found" },
+      })
+      await expect(postJson(port, "/network/stop", { sessionId: "beta", outputPath: "/tmp/unused.har" })).resolves.toMatchObject({
+        status: 409,
+        body: { error: expect.stringContaining("not active"), code: "capture-conflict" },
+      })
       await expect(postJson(port, "/cli/execute", { code: 42, createIfMissing: true })).resolves.toMatchObject({
         status: 400,
         body: { error: expect.stringContaining("Invalid execute request"), code: "invalid-request" },

--- a/test/network-capture.test.ts
+++ b/test/network-capture.test.ts
@@ -1,0 +1,398 @@
+import { EventEmitter } from "node:events"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { Effect } from "effect"
+import type { Page, Request, Response } from "playwright-core"
+import { afterEach, describe, expect, it } from "vitest"
+import { Recorder } from "../src/network-capture.ts"
+import * as AuthProfile from "../src/auth-profile.ts"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })))
+})
+
+describe("NetworkCapture", () => {
+  it("captures complete exchanges across page bindings and writes a reusable auth profile", async () => {
+    const directory = await temporaryDirectory()
+    const profileDirectory = path.join(directory, "profiles")
+    const outputPath = path.join(directory, "capture.har")
+    const firstPage = new FakePage()
+    const secondPage = new FakePage()
+    const recorder = new Recorder({ authProfileBaseDir: profileDirectory })
+
+    await Effect.runPromise(recorder.start(firstPage as unknown as Page, { urlFilter: "/api/" }))
+    firstPage.exchange({
+      url: "https://example.com/api/restaurants?access_token=query-token",
+      requestHeaders: [{ name: "Authorization", value: "Bearer access-token" }],
+      responseHeaders: [{ name: "Content-Type", value: "application/json" }],
+      responseBody: Buffer.from(JSON.stringify({ restaurants: ["A"] })),
+    })
+    recorder.bindPage(secondPage as unknown as Page)
+    firstPage.exchange({ url: "https://example.com/api/ignored" })
+    secondPage.exchange({
+      url: "https://example.com/api/account",
+      requestHeaders: [{ name: "Cookie", value: "session=cookie-value" }],
+      responseHeaders: [{ name: "Content-Type", value: "application/json" }],
+      responseBody: Buffer.from(JSON.stringify({ refreshToken: "refresh-value" })),
+    })
+
+    const result = await Effect.runPromise(recorder.stop({ outputPath, secrets: "uber" }))
+    expect(result).toMatchObject({ active: false, entryCount: 2, responseCount: 2, failureCount: 0 })
+    expect(result.authProfile).toMatchObject({ name: "uber", slotCount: 4 })
+    const artifact = await fs.readFile(outputPath, "utf8")
+    expect(artifact).toContain("${BC_SECRET_1}")
+    expect(artifact).not.toContain("access-token")
+    expect(artifact).not.toContain("cookie-value")
+    expect(artifact).not.toContain("refresh-value")
+    expect(artifact).not.toContain("/api/ignored")
+    expect(artifact).toContain("access_token=${BC_SECRET_2}")
+  })
+
+  it("preserves stable refs when a later capture refreshes values", async () => {
+    const directory = await temporaryDirectory()
+    const page = new FakePage()
+    const recorder = new Recorder({ authProfileBaseDir: directory })
+
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({ requestHeaders: [{ name: "Authorization", value: "Bearer old-token" }] })
+    await Effect.runPromise(recorder.stop({ secrets: "uber" }))
+
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({ requestHeaders: [{ name: "Authorization", value: "Bearer new-token" }] })
+    const refreshed = await Effect.runPromise(recorder.stop({ secrets: "uber" }))
+    const profile = await Effect.runPromise(AuthProfile.read("uber", { baseDir: directory }))
+
+    expect(refreshed.updatedSecretRefs).toContain("BC_SECRET_1")
+    expect(profile.slots).toEqual([expect.objectContaining({ ref: "BC_SECRET_1", value: "new-token" })])
+  })
+
+  it("reports body truncation and request failures", async () => {
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page, { maxBodyBytes: 4 }))
+    page.exchange({ responseBody: Buffer.from("123456789"), responseHeaders: [{ name: "Content-Type", value: "text/plain" }] })
+    page.failedExchange("https://example.com/failure")
+
+    const result = await Effect.runPromise(recorder.stop())
+    expect(result).toMatchObject({ entryCount: 2, responseCount: 1, failureCount: 1, truncatedBodyCount: 1, capturedBodyBytes: 0 })
+  })
+
+  it("bounds aggregate captured body bytes", async () => {
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page, { maxBodyBytes: 10, maxTotalBodyBytes: 6 }))
+    page.exchange({ responseBody: Buffer.from("1234"), responseHeaders: [{ name: "Content-Type", value: "text/plain" }] })
+    page.exchange({ responseBody: Buffer.from("5678"), responseHeaders: [{ name: "Content-Type", value: "text/plain" }] })
+    page.exchange({ responseBody: Buffer.from("9abc"), responseHeaders: [{ name: "Content-Type", value: "text/plain" }] })
+
+    const result = await Effect.runPromise(recorder.stop())
+    expect(result).toMatchObject({ capturedBodyBytes: 6, truncatedBodyCount: 2 })
+  })
+
+  it("redacts artifact credentials even without a persisted profile", async () => {
+    const directory = await temporaryDirectory()
+    const outputPath = path.join(directory, "capture.har")
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({ requestHeaders: [{ name: "Authorization", value: "Bearer never-write-me" }] })
+
+    const result = await Effect.runPromise(recorder.stop({ outputPath }))
+    const artifact = await fs.readFile(outputPath, "utf8")
+    expect(result.authProfile).toBeUndefined()
+    expect(artifact).toContain("Bearer ${BC_SECRET_1}")
+    expect(artifact).not.toContain("never-write-me")
+  })
+
+  it("omits truncated bodies instead of leaking unparseable credential fragments", async () => {
+    const directory = await temporaryDirectory()
+    const outputPath = path.join(directory, "capture.har")
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page, { maxBodyBytes: 24 }))
+    page.exchange({
+      responseHeaders: [{ name: "Content-Type", value: "application/json" }],
+      responseBody: Buffer.from(JSON.stringify({ accessToken: "never-write-this-token" })),
+    })
+
+    await Effect.runPromise(recorder.stop({ outputPath }))
+    const artifact = await fs.readFile(outputPath, "utf8")
+    expect(artifact).not.toContain("never-write")
+    expect(artifact).toContain('"responseBodyTruncated": true')
+  })
+
+  it("does not commit a profile when required refresh credentials are absent", async () => {
+    const directory = await temporaryDirectory()
+    const page = new FakePage()
+    const recorder = new Recorder({ authProfileBaseDir: directory })
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+
+    await expect(Effect.runPromise(recorder.stop({ secrets: "missing", requireObservedSecrets: true }))).rejects.toMatchObject({
+      _tag: "NetworkCapture.Error",
+      reason: "persistence-failed",
+    })
+    await expect(fs.stat(path.join(directory, "missing.json"))).rejects.toMatchObject({ code: "ENOENT" })
+    await Effect.runPromise(recorder.cancel())
+  })
+
+  it("rejects unsafe limits for execute-sandbox callers", async () => {
+    const recorder = new Recorder()
+    await expect(Effect.runPromise(recorder.start(new FakePage() as unknown as Page, { maxEntries: 10_001 }))).rejects.toMatchObject({
+      _tag: "NetworkCapture.Error",
+      reason: "invalid-options",
+    })
+  })
+
+  it("finalizes in-flight requests when the session page changes", async () => {
+    const firstPage = new FakePage()
+    const secondPage = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(firstPage as unknown as Page))
+    firstPage.requestOnly("https://example.com/in-flight")
+    recorder.bindPage(secondPage as unknown as Page)
+
+    const result = await Effect.runPromise(recorder.stop())
+    expect(result).toMatchObject({ entryCount: 1, failureCount: 1 })
+  })
+
+  it("bounds finalization time for a response body that never settles", async () => {
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.hangingExchange()
+
+    const startedAt = Date.now()
+    const result = await Effect.runPromise(recorder.stop())
+    expect(Date.now() - startedAt).toBeLessThan(2_000)
+    expect(result).toMatchObject({ entryCount: 1, truncatedBodyCount: 1 })
+  })
+
+  it("does not materialize response bodies without a declared bound", async () => {
+    const page = new FakePage()
+    const recorder = new Recorder()
+    let bodyReads = 0
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.unknownLengthExchange(() => {
+      bodyReads += 1
+    })
+
+    const result = await Effect.runPromise(recorder.stop())
+    expect(bodyReads).toBe(0)
+    expect(result).toMatchObject({ entryCount: 1, truncatedBodyCount: 1 })
+  })
+
+  it("redacts known values wherever a response echoes them", async () => {
+    const directory = await temporaryDirectory()
+    const outputPath = path.join(directory, "capture.har")
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({
+      requestHeaders: [{ name: "Authorization", value: "Bearer echoed-token" }],
+      responseHeaders: [{ name: "Content-Type", value: "application/json" }],
+      responseBody: Buffer.from(JSON.stringify({ value: "echoed-token" })),
+    })
+
+    await Effect.runPromise(recorder.stop({ outputPath }))
+    const artifact = await fs.readFile(outputPath, "utf8")
+    expect(artifact).not.toContain("echoed-token")
+    expect(artifact).toContain('${BC_SECRET_1}')
+  })
+
+  it("redacts capture-derived values and secret-shaped execute output", async () => {
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({ requestHeaders: [{ name: "Authorization", value: "Bearer captured-token-value" }] })
+    await recorder.settleForOutput()
+
+    expect(recorder.redactText("token=captured-token-value")).toBe("token=${BC_SECRET_1}")
+    expect(recorder.redactValue({ refreshToken: "returned-token", nested: { ok: true } })).toEqual({
+      refreshToken: "[REDACTED]",
+      nested: { ok: true },
+    })
+    expect(recorder.redactUrl("https://example.com/callback?code=callback-secret")).not.toContain("callback-secret")
+    await Effect.runPromise(recorder.cancel())
+  })
+
+  it("fails execute output closed while a matching request is still pending", async () => {
+    const page = new FakePage()
+    const recorder = new Recorder({ outputSettleTimeoutMs: 10 })
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.requestOnly("https://example.com/pending")
+
+    await recorder.settleForOutput()
+    expect(recorder.redactText("possibly sensitive output")).toBe("[REDACTED: network capture finalization pending]")
+    expect(recorder.redactValue({ ok: true })).toBe("[REDACTED: network capture finalization pending]")
+    await Effect.runPromise(recorder.cancel())
+  })
+
+  it("redacts short typed values from execute output after capture", async () => {
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({ requestHeaders: [{ name: "Cookie", value: "count=1" }] })
+    await recorder.settleForOutput()
+
+    expect(recorder.redactValue(1)).toBe("${BC_SECRET_1}")
+    await Effect.runPromise(recorder.cancel())
+  })
+
+  it("leaves an existing artifact untouched when profile publication fails", async () => {
+    const directory = await temporaryDirectory()
+    const outputPath = path.join(directory, "capture.har")
+    await fs.writeFile(outputPath, "existing artifact")
+    const page = new FakePage()
+    const recorder = new Recorder({ authProfileBaseDir: directory })
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({ requestHeaders: [{ name: "Authorization", value: "Bearer captured-token-value" }] })
+
+    await expect(Effect.runPromise(recorder.stop({ outputPath, secrets: "../invalid" }))).rejects.toMatchObject({
+      _tag: "NetworkCapture.Error",
+      reason: "persistence-failed",
+    })
+    await expect(fs.readFile(outputPath, "utf8")).resolves.toBe("existing artifact")
+    await Effect.runPromise(recorder.cancel())
+  })
+
+  it("redacts redirect URLs and omits opaque binary bodies", async () => {
+    const directory = await temporaryDirectory()
+    const outputPath = path.join(directory, "capture.har")
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({
+      redirectedFrom: "https://example.com/callback?code=redirect-secret",
+      responseHeaders: [
+        { name: "Location", value: "https://example.com/next?access_token=location-secret" },
+        { name: "Content-Type", value: "application/octet-stream" },
+      ],
+      responseBody: Buffer.from("binary-secret-value"),
+    })
+
+    const result = await Effect.runPromise(recorder.stop({ outputPath }))
+    const artifact = await fs.readFile(outputPath, "utf8")
+    expect(result.truncatedBodyCount).toBe(1)
+    expect(artifact).not.toContain("redirect-secret")
+    expect(artifact).not.toContain("location-secret")
+    expect(artifact).not.toContain(Buffer.from("binary-secret-value").toString("base64"))
+  })
+
+  it("does not replace unrelated short JSON scalars that equal cookie values", async () => {
+    const directory = await temporaryDirectory()
+    const outputPath = path.join(directory, "capture.har")
+    const page = new FakePage()
+    const recorder = new Recorder()
+    await Effect.runPromise(recorder.start(page as unknown as Page))
+    page.exchange({
+      requestHeaders: [{ name: "Cookie", value: "count=1; theme=dark" }],
+      responseHeaders: [{ name: "Content-Type", value: "application/json" }],
+      responseBody: Buffer.from(JSON.stringify({ count: 1, mode: "dark" })),
+    })
+
+    await Effect.runPromise(recorder.stop({ outputPath }))
+    const artifact = await fs.readFile(outputPath, "utf8")
+    expect(artifact).toContain('\\"count\\":1')
+    expect(artifact).toContain('\\"mode\\":\\"dark\\"')
+  })
+})
+
+class FakePage extends EventEmitter {
+  isClosed(): boolean {
+    return false
+  }
+
+  exchange(options: {
+    readonly url?: string
+    readonly requestHeaders?: readonly Header[]
+    readonly responseHeaders?: readonly Header[]
+    readonly responseBody?: Buffer
+    readonly redirectedFrom?: string
+  } = {}): void {
+    const request = fakeRequest({
+      ...(options.url ? { url: options.url } : {}),
+      ...(options.requestHeaders ? { headers: options.requestHeaders } : {}),
+      ...(options.redirectedFrom ? { redirectedFrom: options.redirectedFrom } : {}),
+    })
+    const response = fakeResponse(request, options.responseHeaders, options.responseBody)
+    this.emit("request", request)
+    this.emit("response", response)
+    this.emit("requestfinished", request)
+  }
+
+  failedExchange(url: string): void {
+    const request = fakeRequest({ url, failure: "net::ERR_FAILED" })
+    this.emit("request", request)
+    this.emit("requestfailed", request)
+  }
+
+  requestOnly(url: string): void {
+    this.emit("request", fakeRequest({ url }))
+  }
+
+  hangingExchange(): void {
+    const request = fakeRequest({})
+    const response = {
+      ...fakeResponse(request, [{ name: "Content-Type", value: "application/json" }]),
+      body: () => new Promise<Buffer>(() => {}),
+    } as unknown as Response
+    this.emit("request", request)
+    this.emit("response", response)
+    this.emit("requestfinished", request)
+  }
+
+  unknownLengthExchange(onBody: () => void): void {
+    const request = fakeRequest({})
+    const response = {
+      request: () => request,
+      status: () => 200,
+      statusText: () => "OK",
+      headersArray: async () => [{ name: "Content-Type", value: "application/json" }],
+      body: async () => {
+        onBody()
+        return Buffer.from('{"token":"never-read"}')
+      },
+    } as unknown as Response
+    this.emit("request", request)
+    this.emit("response", response)
+    this.emit("requestfinished", request)
+  }
+}
+
+type Header = { readonly name: string; readonly value: string }
+
+function fakeRequest(options: { readonly url?: string; readonly headers?: readonly Header[]; readonly failure?: string; readonly redirectedFrom?: string }): Request {
+  const request = {
+    method: () => "GET",
+    url: () => options.url ?? "https://example.com/api/test",
+    headersArray: async () => [...(options.headers ?? [])],
+    postDataBuffer: () => null,
+    resourceType: () => "fetch",
+    redirectedFrom: () => options.redirectedFrom ? { url: () => options.redirectedFrom } : null,
+    failure: () => options.failure ? { errorText: options.failure } : null,
+  }
+  return request as unknown as Request
+}
+
+function fakeResponse(request: Request, headers: readonly Header[] = [], body: Uint8Array = Buffer.from("ok")): Response {
+  const responseHeaders = [...headers]
+  if (!responseHeaders.some((header) => header.name.toLowerCase() === "content-length")) {
+    responseHeaders.push({ name: "Content-Length", value: String(body.byteLength) })
+  }
+  return {
+    request: () => request,
+    status: () => 200,
+    statusText: () => "OK",
+    headersArray: async () => responseHeaders,
+    body: async () => Buffer.from(body),
+  } as unknown as Response
+}
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "browser-control-network-"))
+  temporaryDirectories.push(directory)
+  return directory
+}

--- a/test/network-redaction.test.ts
+++ b/test/network-redaction.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest"
+import { redactKnownValues, SecretCollector } from "../src/network-redaction.ts"
+
+describe("SecretCollector", () => {
+  it("preserves credential placement while deduplicating values", () => {
+    const collector = new SecretCollector()
+    const headers = collector.protectHeaders([
+      { name: "Authorization", value: "Bearer token-value" },
+      { name: "Cookie", value: "session=cookie-value; theme=dark" },
+      { name: "X-CSRF-Token", value: "token-value" },
+      { name: "Accept", value: "application/json" },
+    ], "request")
+
+    expect(headers).toEqual([
+      { name: "Authorization", value: "Bearer ${BC_SECRET_1}" },
+      { name: "Cookie", value: "session=${BC_SECRET_2}; theme=${BC_SECRET_3}" },
+      { name: "X-CSRF-Token", value: "${BC_SECRET_1}" },
+      { name: "Accept", value: "application/json" },
+    ])
+    expect(collector.slots()).toEqual([
+      expect.objectContaining({ ref: "BC_SECRET_1", value: "token-value" }),
+      expect.objectContaining({ ref: "BC_SECRET_2", value: "cookie-value" }),
+      expect.objectContaining({ ref: "BC_SECRET_3", value: "dark" }),
+    ])
+  })
+
+  it("redacts token-like URL and JSON fields", () => {
+    const collector = new SecretCollector()
+    const url = collector.protectUrl("https://example.com/api?access_token=abc&limit=10")
+    const body = collector.protectBody(JSON.stringify({ user: "kit", nested: { refreshToken: "def" } }), "application/json", "response")
+
+    expect(url).toBe("https://example.com/api?access_token=${BC_SECRET_1}&limit=10")
+    expect(JSON.parse(body!)).toEqual({ user: "kit", nested: { refreshToken: "${BC_SECRET_2}" } })
+  })
+
+  it("redacts numeric and collection credentials in JSON", () => {
+    const collector = new SecretCollector()
+    const body = collector.protectBody(JSON.stringify({ otp: 123456, tokens: ["first-token", "second-token"] }), "application/json", "response")
+
+    expect(JSON.parse(body!)).toEqual({
+      otp: "${BC_SECRET_1}",
+      tokens: ["${BC_SECRET_2}", "${BC_SECRET_3}"],
+    })
+    expect(collector.slots().map((slot) => slot.value)).toEqual(["123456", "first-token", "second-token"])
+  })
+
+  it("keeps references literal in form bodies", () => {
+    const collector = new SecretCollector()
+    expect(collector.protectBody("csrf_token=abc&name=kit", "application/x-www-form-urlencoded", "request"))
+      .toBe("csrf_token=${BC_SECRET_1}&name=kit")
+  })
+
+  it("redacts multipart credential fields and preserves their placement", () => {
+    const collector = new SecretCollector()
+    const body = [
+      "--boundary",
+      'Content-Disposition: form-data; name="username"',
+      "",
+      "kit",
+      "--boundary",
+      'Content-Disposition: form-data; name="password"',
+      "",
+      "secret-password",
+      "--boundary--",
+      "",
+    ].join("\r\n")
+    expect(collector.protectBody(body, "multipart/form-data; boundary=boundary", "request"))
+      .toBe(body.replace("secret-password", "${BC_SECRET_1}"))
+    expect(collector.slots()).toEqual([
+      expect.objectContaining({ ref: "BC_SECRET_1", value: "secret-password" }),
+    ])
+  })
+
+  it("omits multipart bodies containing file parts", () => {
+    const collector = new SecretCollector()
+    const body = [
+      "--boundary",
+      'Content-Disposition: form-data; name="upload"; filename="secret.txt"',
+      "Content-Type: text/plain",
+      "",
+      "opaque content",
+      "--boundary--",
+      "",
+    ].join("\r\n")
+    expect(collector.protectBody(body, "multipart/form-data; boundary=boundary", "request")).toBeUndefined()
+  })
+
+  it("updates stable refs by source during refresh", () => {
+    const collector = new SecretCollector([{ ref: "BC_SECRET_4", value: "old", sources: ["request.header.authorization"] }])
+    expect(collector.protectHeaders([{ name: "Authorization", value: "Bearer new" }], "request")).toEqual([
+      { name: "Authorization", value: "Bearer ${BC_SECRET_4}" },
+    ])
+    expect(collector.slots()[0]).toMatchObject({ ref: "BC_SECRET_4", value: "new" })
+    expect(collector.updatedRefs()).toEqual(["BC_SECRET_4"])
+    expect(collector.observedRefs()).toEqual(["BC_SECRET_4"])
+  })
+
+  it("reports an unchanged credential as observed but not updated", () => {
+    const collector = new SecretCollector([{ ref: "BC_SECRET_1", value: "same", sources: ["request.header.authorization"] }])
+    collector.protectHeaders([{ name: "Authorization", value: "Bearer same" }], "request")
+    expect(collector.observedRefs()).toEqual(["BC_SECRET_1"])
+    expect(collector.updatedRefs()).toEqual([])
+  })
+
+  it("keeps credentials from different request sources independent", () => {
+    const collector = new SecretCollector()
+    const first = collector.protectHeaders([{ name: "Authorization", value: "Bearer first" }], "request", "GET https://one.example/api")
+    const second = collector.protectHeaders([{ name: "Authorization", value: "Bearer second" }], "request", "GET https://two.example/api")
+    expect(first[0]?.value).toBe("Bearer ${BC_SECRET_1}")
+    expect(second[0]?.value).toBe("Bearer ${BC_SECRET_2}")
+  })
+
+  it("splits shared refs when one source rotates", () => {
+    const collector = new SecretCollector([{
+      ref: "BC_SECRET_1",
+      value: "shared",
+      sources: ["GET https://one.example/api.request.header.authorization", "GET https://two.example/api.request.header.authorization"],
+    }])
+    const protectedHeaders = collector.protectHeaders(
+      [{ name: "Authorization", value: "Bearer rotated" }],
+      "request",
+      "GET https://one.example/api",
+    )
+    expect(protectedHeaders[0]?.value).toBe("Bearer ${BC_SECRET_2}")
+    expect(collector.slots()).toEqual([
+      expect.objectContaining({ ref: "BC_SECRET_1", value: "shared", sources: ["GET https://two.example/api.request.header.authorization"] }),
+      expect.objectContaining({ ref: "BC_SECRET_2", value: "rotated", sources: ["GET https://one.example/api.request.header.authorization"] }),
+    ])
+  })
+
+  it("preserves duplicate query parameters while redacting each occurrence", () => {
+    const collector = new SecretCollector()
+    expect(collector.protectUrl("https://example.com/api?token=first&token=second"))
+      .toBe("https://example.com/api?token=${BC_SECRET_1}&token=${BC_SECRET_2}")
+  })
+
+  it("redacts token-like parameters in relative redirect URLs", () => {
+    const collector = new SecretCollector()
+    expect(collector.protectHeaders([{ name: "Location", value: "/callback?code=secret#done" }], "response"))
+      .toEqual([{ name: "Location", value: "/callback?code=${BC_SECRET_1}#done" }])
+  })
+
+  it("preserves duplicate cookie names as independent references", () => {
+    const collector = new SecretCollector()
+    expect(collector.protectHeaders([{ name: "Cookie", value: "sid=first; sid=second" }], "request"))
+      .toEqual([{ name: "Cookie", value: "sid=${BC_SECRET_1}; sid=${BC_SECRET_2}" }])
+  })
+
+  it("redacts short exact values from command and execute output", () => {
+    expect(redactKnownValues("https://example.com/v1/dark-mode?limit=10", [
+      { ref: "BC_SECRET_1", value: "1", sources: ["cookie.limit"] },
+      { ref: "BC_SECRET_2", value: "dark", sources: ["cookie.theme"] },
+    ])).toBe("https://example.com/v${BC_SECRET_1}/${BC_SECRET_2}-mode?limit=${BC_SECRET_1}0")
+  })
+
+  it("does not rewrite stable placeholders during exact-value output redaction", () => {
+    expect(redactKnownValues("${BC_SECRET_1}", [
+      { ref: "BC_SECRET_2", value: "BC_SECRET_1", sources: ["request.header.authorization"] },
+    ])).toBe("${BC_SECRET_1}")
+  })
+
+  it("redacts exact known values from command output", () => {
+    expect(redactKnownValues("using secret-value twice secret-value", [
+      { ref: "BC_SECRET_1", value: "secret-value", sources: [] },
+    ])).toBe("using ${BC_SECRET_1} twice ${BC_SECRET_1}")
+  })
+})

--- a/test/relay-client.test.ts
+++ b/test/relay-client.test.ts
@@ -173,4 +173,56 @@ describe("RelayClient", () => {
       audioBitsPerSecond: 128_000,
     })
   })
+
+  it("preserves network limits and decodes capture results", async () => {
+    routes.set("POST /network/start", {
+      status: 200,
+      body: {
+        active: true,
+        startedAt: "2026-07-19T00:00:00.000Z",
+        entryCount: 0,
+        responseCount: 0,
+        failureCount: 0,
+        capturedBodyBytes: 0,
+        truncatedBodyCount: 0,
+        droppedEntryCount: 0,
+        content: "embed",
+      },
+    })
+    const result = await withClient((client) => client.networkStart({
+      sessionId: session.id,
+      urlFilter: "/api/",
+      resourceTypes: ["fetch", "xhr"],
+      maxBodyBytes: 100,
+      maxTotalBodyBytes: 1_000,
+      maxEntries: 25,
+    }))
+    expect(result.active).toBe(true)
+    expect(lastRequestBody).toMatchObject({
+      sessionId: session.id,
+      urlFilter: "/api/",
+      resourceTypes: ["fetch", "xhr"],
+      maxBodyBytes: 100,
+      maxTotalBodyBytes: 1_000,
+      maxEntries: 25,
+    })
+  })
+
+  it("decodes redacted command-run output", async () => {
+    routes.set("POST /auth/run", {
+      status: 200,
+      body: {
+        exitCode: 0,
+        signal: null,
+        stdout: "${BC_SECRET_1}\n",
+        stderr: "",
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        durationMs: 12,
+      },
+    })
+    const result = await withClient((client) => client.authRun({ name: "uber", command: "./uber-cli", args: ["restaurants"] }))
+    expect(result.stdout).toBe("${BC_SECRET_1}\n")
+    expect(lastRequestBody).toEqual({ name: "uber", command: "./uber-cli", args: ["restaurants"] })
+  })
 })

--- a/test/relay-schema.test.ts
+++ b/test/relay-schema.test.ts
@@ -6,6 +6,8 @@ import {
   ExecuteSessionSummary,
   ErrorEnvelope,
   ExtensionStatus,
+  NetworkStartRequest,
+  NetworkStopResponse,
   RecordingStartRequest,
   RecordingStartResponse,
   RecordingStatusResponse,
@@ -37,6 +39,8 @@ const decodeSessionNewRequest = Schema.decodeUnknownSync(SessionNewRequest)
 const decodeRecordingStatus = Schema.decodeUnknownSync(RecordingStatusResponse)
 const decodeRelayVersion = Schema.decodeUnknownSync(RelayVersion)
 const decodeErrorEnvelope = Schema.decodeUnknownSync(ErrorEnvelope)
+const decodeNetworkStartRequest = Schema.decodeUnknownSync(NetworkStartRequest)
+const decodeNetworkStopResponse = Schema.decodeUnknownSync(NetworkStopResponse)
 
 const session = {
   id: "rapid-otter-633",
@@ -255,6 +259,30 @@ describe("relay-schema", () => {
       tabId: 7,
       audio: "yes",
     })).toThrow()
+  })
+
+  it("decodes bounded network capture contracts", () => {
+    expect(decodeNetworkStartRequest({
+      sessionId: "rapid-otter-633",
+      content: "embed",
+      maxBodyBytes: 100,
+      maxTotalBodyBytes: 1_000,
+      maxEntries: 20,
+    }).maxTotalBodyBytes).toBe(1_000)
+    expect(() => decodeNetworkStartRequest({ sessionId: "rapid-otter-633", maxTotalBodyBytes: 0 })).toThrow()
+    expect(decodeNetworkStopResponse({
+      active: false,
+      startedAt: "2026-07-19T00:00:00.000Z",
+      stoppedAt: "2026-07-19T00:01:00.000Z",
+      entryCount: 2,
+      responseCount: 2,
+      failureCount: 0,
+      capturedBodyBytes: 100,
+      truncatedBodyCount: 0,
+      droppedEntryCount: 0,
+      updatedSecretRefs: ["BC_SECRET_1"],
+      observedSecretRefs: ["BC_SECRET_1"],
+    }).observedSecretRefs).toEqual(["BC_SECRET_1"])
   })
 
   it("decodes current coded and legacy relay error envelopes", () => {

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -18,6 +18,7 @@ const makeFakeSandbox = (options?: {
   readonly onAdopt?: ExecuteSandboxLike["adoptPage"]
   readonly onClose?: Effect.Effect<void>
   readonly defaultTargetId?: string
+  readonly redactText?: (text: string) => string
 }): FakeSandbox => {
   let closes = 0
   const adoptedSelections: unknown[] = []
@@ -48,6 +49,12 @@ const makeFakeSandbox = (options?: {
       ),
     close,
     closeSettled: close,
+    networkStart: () => Effect.succeed({ active: true, entryCount: 0, responseCount: 0, failureCount: 0, capturedBodyBytes: 0, truncatedBodyCount: 0, droppedEntryCount: 0 }),
+    networkStatus: () => ({ active: false, entryCount: 0, responseCount: 0, failureCount: 0, capturedBodyBytes: 0, truncatedBodyCount: 0, droppedEntryCount: 0 }),
+    networkStop: () => Effect.fail(new Error("network capture is not active")),
+    networkCancel: () => Effect.succeed({ cancelled: false }),
+    authRefresh: () => Effect.fail(new Error("auth refresh is not configured")),
+    redactNetworkCaptureText: (text) => options?.redactText?.(text) ?? text,
     adoptPage: (selection) => options?.onAdopt
       ? options.onAdopt(selection)
       : options?.adoptFailure
@@ -653,6 +660,23 @@ describe("BrowserControlSessions", () => {
     } finally {
       consoleError.mockRestore()
     }
+  })
+
+  it("redacts capture values before execute code reaches the session journal hook", async () => {
+    const records: string[] = []
+    const sessions = new BrowserControlSessions(
+      "http://127.0.0.1:0",
+      () => makeFakeSandbox({ redactText: (text) => text.replaceAll("live-token", "${BC_SECRET_1}") }),
+      { onExecuteRecord: (record) => records.push(record.code) },
+    )
+    sessions.createNew("alpha")
+
+    await Effect.runPromise(sessions.execute({
+      sessionId: "alpha",
+      code: "return 'live-token'",
+      createIfMissing: false,
+    }))
+    expect(records).toEqual(["return '${BC_SECRET_1}'"])
   })
 
   it("adopts a selected page while serializing on the session execute permit", async () => {


### PR DESCRIPTION
## What

Adds first-class, session-scoped authenticated network capture for deriving direct API clients and CLIs from workflows in the user's existing browser.

- `browser-control network start|status|stop|cancel` records normalized request/response exchanges across execute calls, handoffs, page adoption, and recovery.
- Redacted HAR exports preserve credential placement with stable `${BC_SECRET_N}` references.
- Restrictive named secret profiles retain the lossless values separately and preserve source-based references across refreshes.
- `browser-control secrets status|refresh|run` inspects metadata, refreshes values from the browser, and injects credentials into child commands while redacting their output.
- Equivalent execute-sandbox and MCP capabilities use the same session-owned recorder.

## How

- `src/network-capture.ts` owns normalized exchange correlation, page rebinding, bounded body retention, fail-closed artifact export, and capture lifecycle serialization.
- `src/network-redaction.ts` assigns route-scoped stable refs across headers, cookies, URLs, JSON, forms, and text-only multipart bodies. Opaque or unparseable bodies are omitted and reported as truncated.
- `src/auth-profile.ts` atomically persists mode-`0600` profiles, refreshes stable slots, injects only the selected `BC_SECRET_*` environment, bounds/redacts output, and terminates process groups on timeout or interruption.
- Relay schemas, the shared relay client, HTTP routes, CLI commands, MCP tools, and execute helpers all expose the same capability.
- `README.md`, `PLAN.md`, `CONTEXT.md`, and the Browser Control skill document the capture-to-client workflow and security model.

## Scope

- HAR is a compatibility export, not the internal capture model.
- Client generation remains an agent workflow rather than an LLM generator embedded in Browser Control.
- There is no raw/unredacted export.
- Binary, malformed, truncated, and file-bearing multipart bodies are deliberately omitted when they cannot be reliably redacted.

Closes #20.

## Testing

- `pnpm typecheck`
- `pnpm test` (`306` tests)
- `pnpm build:cli`
- `pnpm build:extension`
- `pnpm pack --dry-run`
- Packed and installed the tarball in a clean temporary consumer; verified the packaged `browser-control network stop --help` command.
- Verified built help for `network start`, `network stop`, `secrets refresh`, and `secrets run`.
- Added a deterministic `network-capture` browser smoke case covering redacted export, stable refresh, and redacted child execution.

The browser smoke was attempted but could not reach the new route because the shared detached relay was an older build and owned unrelated active sessions. It returned `404 Not found` for `/network/start`; the relay was not restarted to avoid disrupting those sessions. The stale-route lifecycle failure was recorded in the Browser Control project todo.

## Flow

```mermaid
sequenceDiagram
  participant Agent
  participant CLI as CLI / MCP / execute
  participant Relay
  participant Session as Execute Sandbox
  participant Browser
  participant Profile as Secret Profile

  Agent->>CLI: network start
  CLI->>Relay: typed request
  Relay->>Session: start recorder
  Browser-->>Session: requests and responses
  Agent->>CLI: network stop --output --secrets
  CLI->>Relay: typed request
  Relay->>Session: finalize normalized exchanges
  Session->>Profile: atomically store lossless values
  Session-->>Agent: redacted HAR + bounded summary
  Agent->>CLI: secrets run profile -- client
  CLI->>Relay: command + profile name
  Relay->>Profile: inject BC_SECRET_* values
  Relay-->>Agent: redacted stdout and stderr
```
