### PR TITLE
fix(relay): preserve sessions across lifecycle churn

### DIFF
--- a/.changeset/fuzzy-relay-identity.md
+++ b/.changeset/fuzzy-relay-identity.md
@@ -1,0 +1,7 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Reject stale relays before operational CLI and MCP calls, preserve sessions
+across same-tab target and execution-context replacement, retain bounded relay
+fault diagnostics, and safely escape snapshot attribute selectors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,10 @@ local Node relay.
   state keeps only the adopted default-page pointer. Adoption reserves,
   commits, or rolls back registry ownership transactionally and reconciles CDP
   visibility, grouping, and page status for every changed target.
+- Same-tab root target generations are explicit replacements, never map
+  overwrites. Preserve committed ownership, roll back provisional adoption
+  ownership, detach the old generation before announcing the new one, rebind
+  pending handoffs, and make the owning sandbox reacquire the exact new target.
 - Adopted targets are exclusive to one Browser Control session. Serialize
   adopts, reject competing owners, and release ownership on detach, reset, or
   delete. If adoption times out, roll back visibility immediately but retain
@@ -135,9 +139,14 @@ local Node relay.
 - Session delete/reset must acquire the session's execute permit before closing
   the sandbox, so running scripts are never yanked mid-flight.
 - The version string and build id are injected by `scripts/build-cli.ts`
-  (`src/version.ts`, `0.0.0-dev` / `dev` when running from source). The relay
+  (`src/version.ts`; source runs use `0.0.0-dev` and a deterministic source
+  and dependency-lock fingerprint). The relay
   reports both so `doctor` can detect a long-running relay left stale by a CLI
   rebuild; never hardcode version literals.
+- Relay version metadata includes an instance id, start time, and PID. Bounded
+  managed-relay process-fault diagnostics are retained with mode `0600` in
+  `~/.browser-control/relay.log` so same-build restarts and session loss are
+  diagnosable instead of appearing as eviction.
 - `dist/mcp.js` self-runs via the dedicated `src/mcp-main.ts` entrypoint. Do not
   add `process.argv[1] === import.meta.url` self-run guards to modules that get
   bundled into `dist/cli.js`; esbuild inlining makes the guard fire inside the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,6 +47,13 @@ The exclusive Browser Control session assignment stored by the Target Registry
 for a root target. It governs CDP visibility, grouping, and page status.
 _Avoid_: Adopted-page pointer, current session
 
+**Root Target Generation**:
+One CDP target/session identity for a physical attached tab. Chrome may replace
+that identity while preserving the tab; Browser Control transfers committed
+ownership, handoffs, and the default-page pointer to the new generation only
+after its CDP setup succeeds.
+_Avoid_: New tab, navigation, detach
+
 **Adoption Transaction**:
 The serialized reserve, Playwright page resolution, commit-or-rollback, and
 visibility reconciliation that makes an attached tab a session's default page.
@@ -108,6 +115,8 @@ _Avoid_: Token value, hardcoded credential
 - A **User Browser** contains zero or more **Attached Tabs**.
 - Unowned members of the **Attached-Tab Pool** are shared across sessions.
 - **Target Ownership** scopes a target to exactly one session.
+- A replacement **Root Target Generation** preserves the physical tab and its
+  committed **Target Ownership**.
 - An **Adoption Transaction** changes **Target Ownership** and the session's
   default-page pointer together.
 - A **Toolbar Control** attaches or detaches the active tab.

--- a/PLAN.md
+++ b/PLAN.md
@@ -351,6 +351,10 @@ reconciles existing client announcements, browser grouping, and page status.
   OOPIF reconnects.
 - Never announce one target id twice to the same client. Emit
   `Target.detachedFromTarget` before re-announcing it with a new session id.
+- Treat a new root target/session generation for an existing physical tab as a
+  replacement transaction: preserve committed ownership, roll back provisional
+  adoption ownership, detach old clients and children, rebind handoffs, and
+  reacquire the new Playwright page by exact target id.
 - Await HTTP and websocket close callbacks during relay shutdown so tests and
   smoke runs do not leak ports or listeners.
 - Relay shutdown closes the adoption gate and drains active or queued adoption
@@ -380,8 +384,12 @@ not contain expressions, arguments, results, headers, cookies, or form values.
 ### Builds provide runtime identity
 
 `scripts/build-cli.ts` injects the package version and build id. Source runs use
-`0.0.0-dev` and `dev`; runtime code does not hardcode release versions. The
+`0.0.0-dev` and a deterministic fingerprint of `src/*.ts`, `package.json`, and
+`pnpm-lock.yaml`; runtime code does not hardcode release versions. The
 relay reports both values so `doctor` can identify a stale long-running relay.
+It also reports an instance id, start time, and PID; bounded managed-relay
+process-fault diagnostics are retained locally so unexpected same-build
+restarts can be distinguished from session eviction.
 
 ## Known Limitations
 

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -11,6 +11,7 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 import util from "node:util"
 import { getObject } from "../src/relay-helpers.ts"
+import { browserControlBuildId } from "../src/version.ts"
 
 const endpointUrl = process.env.BROWSER_CONTROL_ENDPOINT ?? "http://127.0.0.1:19989"
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
@@ -743,6 +744,19 @@ return { driftedCount }
         if (!actionOutput.includes("continued: true")) {
           return yield* Effect.fail(new Error(`snapshot ref did not resolve across execute calls: ${actionOutput}`))
         }
+        const escapedAttributeOutput = yield* runBrowserControl([
+          "execute",
+          "--session",
+          smokeSession,
+          `
+await page.setContent('<main><button aria-label="First line&#10;Second &quot;line&quot; &#92; [draft]">Fallback</button></main>')
+const captured = await snapshot()
+return { captured, count: await ref('e1').count() }
+          `,
+        ])
+        if (!escapedAttributeOutput.includes("count: 1")) {
+          return yield* Effect.fail(new Error(`snapshot ref did not escape multiline attribute values: ${escapedAttributeOutput}`))
+        }
         const denseOutput = yield* runBrowserControl([
           "execute",
           "--session",
@@ -1374,6 +1388,7 @@ const main = Effect.fn("Smoke.main")(function* () {
   }
 
   yield* Console.log(`browser-control smoke: ${selectedCases.map((testCase) => testCase.name).join(", ")} x${repeatCount}`)
+  yield* assertCompatibleRelay()
   yield* waitForExtensionConnected()
   const before = yield* fetchStatus()
   yield* Console.log(`extension status: ${formatValue(before)}`)
@@ -2070,6 +2085,24 @@ const fetchStatus = Effect.fnUntraced(function* () {
     try: async () => parseExtensionStatus(await response.json()),
     catch: (cause) => new Error("parse extension status", { cause }),
   })
+})
+
+const assertCompatibleRelay = Effect.fnUntraced(function* () {
+  const response = yield* Effect.tryPromise({
+    try: () => fetch(new URL("/version", endpointUrl)),
+    catch: (cause) => new Error("fetch relay version", { cause }),
+  })
+  const version = yield* Effect.tryPromise({
+    try: () => response.json() as Promise<unknown>,
+    catch: (cause) => new Error("parse relay version", { cause }),
+  })
+  const object = getObject(version)
+  const buildId = typeof object?.buildId === "string" ? object.buildId : undefined
+  if (buildId !== browserControlBuildId) {
+    return yield* Effect.fail(new Error(
+      `Smoke relay build ${buildId ?? "unknown"} does not match source build ${browserControlBuildId}; restart the relay before running smoke.`,
+    ))
+  }
 })
 
 const waitForRelayCleanup = Effect.fnUntraced(function* (baseline: ExtensionStatus) {

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -614,6 +614,12 @@ language changes, update `CONTEXT.md` too.
   tabs after reconnecting, so the relay rebuilds its target registry without
   re-clicking the toolbar. If `activeTargets` stays 0 with an older shim,
   reload the unpacked extension and re-attach.
+- Stale relay build: operational CLI and MCP calls reject the relay before
+  invoking a route. `status` and `doctor` remain observational. Source runs use
+  a content fingerprint, so rebuilds and worktrees cannot silently share
+  incompatible relay code. Bounded process-fault diagnostics for managed relays
+  are retained in `~/.browser-control/relay.log`; `/version` reports the relay
+  instance id, start time, and PID.
 - All tabs suddenly detached (`activeTargets: 0`) while the browser looks fine:
   the user probably dismissed the "is being debugged" banner, which detaches
   chrome.debugger from every tab at once. Re-attach via the toolbar (or
@@ -655,9 +661,11 @@ language changes, update `CONTEXT.md` too.
   Browser Control should replay stored child target attaches and current child
   frame navigation for the current OOPIF canary.
 - Repeated `Execution context was destroyed` failures: run one short follow-up
-  execute so Browser Control can health-check the default page. A relay-owned
-  page is recreated automatically; reset or re-adopt an unhealthy user-owned
-  tab because Browser Control will not replace it. If failures continue,
+  execute so Browser Control can wait through transient context replacement and
+  health-check the default page. Same-tab root replacements preserve ownership,
+  handoffs, and the exact target id. A genuinely unhealthy relay-owned page is
+  recreated automatically; reset or re-adopt an unhealthy user-owned tab
+  because Browser Control will not replace it. If failures continue,
   restart the relay with `BROWSER_CONTROL_DEBUG=1` before reproducing. `[bc:ctx]`
   lines contain bounded metadata only: target/context IDs, ownership, loader changes, URL origin/shape
   plus fingerprint, reset outcomes, and evaluate shape/failure class. They never

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,5 +1,6 @@
 import { Effect, FileSystem, Path, Schema } from "effect"
 import * as RelayClient from "./relay-client.ts"
+import { relayBuildProblem } from "./relay-lifecycle.ts"
 import type { ExtensionStatus, RelayVersion, SessionSummary, TargetSummary } from "./relay-schema.ts"
 import * as SessionStore from "./session-store.ts"
 import { browserControlBuildId, browserControlVersion } from "./version.ts"
@@ -168,11 +169,9 @@ export const createDoctorReport = Effect.fn("Doctor.createReport")(function* (op
   ])
   const relayResult = yield* probe(relay.version)
   const relayBuildMatches = relayResult.ok
-    ? browserControlBuildId === "dev"
-      ? true
-      : relayResult.value.buildId
-        ? relayResult.value.buildId === browserControlBuildId
-        : null
+    ? relayResult.value.buildId
+      ? relayBuildProblem(relayResult.value, browserControlBuildId) === undefined
+      : null
     : null
   const [extensionResult, targetsResult, sessionsResult] = relayResult.ok
     ? yield* Effect.all([
@@ -427,14 +426,6 @@ export function relayBuildCheck(options: {
       label: "relay build",
       status: "warn",
       message: "relay unreachable; cannot compare builds",
-    }
-  }
-  if (options.cliBuildId === "dev") {
-    return {
-      id: "relay-build",
-      label: "relay build",
-      status: "ok",
-      message: "CLI is a development build; build comparison skipped",
     }
   }
   const relayBuildId = options.relayResult.value.buildId

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -18,14 +18,16 @@ import type { HandoffOutcome } from "./handoff.ts"
 import * as AuthProfile from "./auth-profile.ts"
 import * as NetworkCapture from "./network-capture.ts"
 import type { ExecuteAftermath, ExecuteLogEntry, ExecuteLogSummary, ExecuteMedia } from "./relay-schema.ts"
-import { executionContextFailureDiagnostic } from "./runtime-diagnostics.ts"
+import { executionContextFailureDiagnostic, runtimeFailureKind } from "./runtime-diagnostics.ts"
 
 const nodeModules = { fs, path, os, crypto, url, util, events, stream, buffer, http, https, zlib }
 const nodeModuleAliases = Object.keys(nodeModules).join(", ")
 
 const playwrightCloseTimeoutMs = 2_000
 const playwrightConnectTimeoutMs = 15_000
-const sessionPageHealthCheckTimeoutMs = 1_000
+const sessionPageHealthCheckTimeoutMs = 3_000
+const sessionPageHealthRetryDelayMs = 100
+const timedOut = Symbol("timed-out")
 export const downloadCapabilityErrorMessage = "Downloads are unavailable in Browser Control extension-backed tabs: Chromium blocks Browser.setDownloadBehavior and Page.setDownloadBehavior through chrome.debugger, so Playwright cannot retain an artifact for download.saveAs(). Fetch the response in the page and write the returned bytes with fs when the site exposes them."
 const downloadGuardedPages = new WeakSet<Page>()
 const downloadGuardedContexts = new WeakSet<BrowserContext>()
@@ -44,7 +46,7 @@ export class SessionPageRecoveryError extends Schema.TaggedErrorClass<SessionPag
   "Execute.SessionPageRecoveryError",
   {
     message: Schema.String,
-    reason: Schema.Literals(["adopted-unresponsive", "close-failed"]),
+    reason: Schema.Literals(["adopted-unresponsive", "close-failed", "target-unavailable"]),
     cause: Schema.Defect(),
   },
 ) {}
@@ -101,21 +103,16 @@ export const recoverSessionPage = Effect.fn("Execute.recoverSessionPage")(functi
   readonly healthCheck: () => Promise<void>
   readonly close: () => Promise<void>
 }) {
-  let healthFailure: Error | undefined
-  if (!options.url.startsWith("chrome-error://")) {
-    healthFailure = yield* runPlaywrightOperation({
-      label: "Session page health check",
-      timeoutMs: options.timeoutMs,
-      run: options.healthCheck,
-    }).pipe(
-      Effect.match({
-        onFailure: (error) => error,
-        onSuccess: () => undefined,
-      }),
-    )
-  } else {
-    healthFailure = new Error(`Session page is showing ${options.url}`)
-  }
+  const healthFailure = yield* runPlaywrightOperation({
+    label: "Session page health check",
+    timeoutMs: options.timeoutMs,
+    run: options.healthCheck,
+  }).pipe(
+    Effect.match({
+      onFailure: (error) => error,
+      onSuccess: () => undefined,
+    }),
+  )
   if (!healthFailure) {
     return "use" as const
   }
@@ -145,6 +142,53 @@ export const recoverSessionPage = Effect.fn("Execute.recoverSessionPage")(functi
   }
   return "recreate" as const
 })
+
+export async function waitForPageContext(options: {
+  readonly evaluate: () => Promise<void>
+  readonly timeoutMs: number
+  readonly retryDelayMs?: number
+  readonly delay?: (milliseconds: number) => Promise<void>
+}): Promise<void> {
+  const retryDelayMs = options.retryDelayMs ?? sessionPageHealthRetryDelayMs
+  const deadline = Date.now() + options.timeoutMs
+  let lastError: unknown
+  while (true) {
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) break
+    try {
+      const result = await withTimeout(options.evaluate(), remainingMs)
+      if (result === timedOut) break
+      return
+    } catch (error) {
+      lastError = error
+      const kind = runtimeFailureKind(error)
+      if (kind !== "context-destroyed" && kind !== "context-missing") throw error
+      const retryInMs = Math.min(retryDelayMs, Math.max(0, deadline - Date.now()))
+      if (retryInMs > 0) await (options.delay ?? delay)(retryInMs)
+    }
+  }
+  throw lastError ?? new Error(`Execution context did not become available within ${options.timeoutMs}ms`)
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | typeof timedOut> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => resolve(timedOut), timeoutMs)
+    promise.then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    )
+  })
+}
 
 type SandboxGlobals = {
   readonly browser: Browser
@@ -313,6 +357,7 @@ export type AdoptTarget = {
 export const defaultPageClosedWarning = "The session default page was closed; created a new page. References to the old page in state are stale."
 export const defaultPageRecoveredWarning = "The session default page was unresponsive; created a new page. References to the old page in state are stale."
 export const defaultPageCrashedWarning = "The session default page target crashed; checking it before the next execute."
+export const defaultPageReplacedWarning = "The session default page target was replaced; rebound to the same browser tab. References to the old page in state are stale."
 
 export const shouldCloseCurrentPageOnAdopt = (options: {
   readonly hasCurrentPage: boolean
@@ -367,6 +412,7 @@ export class ExecuteSandbox {
   private defaultPageTargetId: string | undefined
   private ownsPage = false
   private pageHealthCheckRequired = false
+  private pendingPageTarget: { readonly targetId: string; readonly warnReplaced: boolean } | undefined
   private readonly state: Record<string, unknown> = {}
   private readonly snapshotRefs: SnapshotRefRegistry = { selectors: new Map() }
   private readonly networkCapture = new NetworkCapture.Recorder()
@@ -489,6 +535,7 @@ export class ExecuteSandbox {
       sandbox.defaultPageTargetId = undefined
       sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
+      sandbox.pendingPageTarget = undefined
       yield* sandbox.networkCapture.cancel()
 
       if (ownsOpenPage) {
@@ -519,6 +566,7 @@ export class ExecuteSandbox {
       sandbox.defaultPageTargetId = undefined
       sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
+      sandbox.pendingPageTarget = undefined
       yield* sandbox.networkCapture.cancel()
 
       if (ownsOpenPage) {
@@ -559,6 +607,7 @@ export class ExecuteSandbox {
         sandbox.defaultPageTargetId = undefined
         sandbox.ownsPage = false
         sandbox.pageHealthCheckRequired = false
+        sandbox.pendingPageTarget = undefined
         sandbox.networkCapture.bindPage(undefined)
       }
       const browser = sandbox.browser
@@ -570,8 +619,8 @@ export class ExecuteSandbox {
         label: "Create a browser context for session adoption",
         run: () => browser.newContext(),
       }))
-      const selected = yield* Effect.try({
-        try: () => selectPageForAdopt({ pages: context.pages(), target }),
+      const selected = yield* Effect.tryPromise({
+        try: () => waitForPageTarget({ context, targetId: target.targetId, timeoutMs: sessionPageHealthCheckTimeoutMs }),
         catch: (cause) => cause instanceof Error ? cause : new Error("Select page for session adoption", { cause }),
       })
       if (!selected) {
@@ -593,6 +642,7 @@ export class ExecuteSandbox {
       sandbox.defaultPageTargetId = target.targetId
       sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
+      sandbox.pendingPageTarget = undefined
       sandbox.networkCapture.bindPage(selected)
       return selected.url()
     })
@@ -614,8 +664,9 @@ export class ExecuteSandbox {
         ...(this.options.sessionId ? { headers: { "Browser-Control-Session-Id": this.options.sessionId } } : {}),
       })
       this.page = undefined
-      this.defaultPageTargetId = undefined
-      this.ownsPage = false
+      if (this.defaultPageTargetId) {
+        this.pendingPageTarget = { targetId: this.defaultPageTargetId, warnReplaced: false }
+      }
       this.pageHealthCheckRequired = false
       this.networkCapture.bindPage(undefined)
       if (hadBrowser) {
@@ -711,10 +762,21 @@ export class ExecuteSandbox {
     this.defaultPageTargetId = undefined
     this.ownsPage = false
     this.pageHealthCheckRequired = false
+    this.pendingPageTarget = undefined
     this.networkCapture.bindPage(undefined)
     if (!this.pendingWarnings.includes(defaultPageClosedWarning)) {
       this.pendingWarnings.push(defaultPageClosedWarning)
     }
+    return true
+  }
+
+  markTargetReplaced(previousTargetId: string, targetId: string): boolean {
+    if (this.defaultPageTargetId !== previousTargetId) return false
+    this.page = undefined
+    this.defaultPageTargetId = targetId
+    this.pageHealthCheckRequired = false
+    this.pendingPageTarget = { targetId, warnReplaced: true }
+    this.networkCapture.bindPage(undefined)
     return true
   }
 
@@ -788,6 +850,22 @@ export class ExecuteSandbox {
       }
       return selected
     }
+    if (this.pendingPageTarget) {
+      const pendingTarget = this.pendingPageTarget
+      const targetId = pendingTarget.targetId
+      const replacement = await waitForPageTarget({ context, targetId, timeoutMs: sessionPageHealthCheckTimeoutMs })
+      if (!replacement) {
+        throw new SessionPageRecoveryError({
+          message: `Playwright did not expose session page target ${targetId} after the browser connection or target changed. Retry after the browser transition settles.`,
+          reason: "target-unavailable",
+          cause: new Error(`Session page target unavailable: ${targetId}`),
+        })
+      }
+      this.page = replacement
+      this.pendingPageTarget = undefined
+      if (pendingTarget.warnReplaced) this.pendingWarnings.push(defaultPageReplacedWarning)
+      return replacement
+    }
     if (this.page && !this.page.isClosed()) {
       if (this.pageHealthCheckRequired || this.page.url().startsWith("chrome-error://")) {
         const page = this.page
@@ -795,9 +873,12 @@ export class ExecuteSandbox {
           ownsPage: this.ownsPage,
           url: page.url(),
           timeoutMs: sessionPageHealthCheckTimeoutMs,
-          healthCheck: async () => {
-            await page.evaluate(() => true)
-          },
+          healthCheck: () => waitForPageContext({
+            timeoutMs: sessionPageHealthCheckTimeoutMs,
+            evaluate: async () => {
+              await page.evaluate(() => true)
+            },
+          }),
           close: () => page.close(),
         }))
         if (recovery === "use") {
@@ -821,6 +902,57 @@ export class ExecuteSandbox {
     this.defaultPageTargetId = await resolvePageTargetId(this.page)
     this.ownsPage = true
     return this.page
+  }
+}
+
+async function waitForPageTarget(options: {
+  readonly context: BrowserContext
+  readonly targetId: string
+  readonly timeoutMs: number
+}): Promise<Page | undefined> {
+  return await waitForExactTarget({
+    targetId: options.targetId,
+    timeoutMs: options.timeoutMs,
+    candidates: () => options.context.pages(),
+    getTargetId: resolvePageTargetId,
+  })
+}
+
+export async function waitForExactTarget<T>(options: {
+  readonly targetId: string
+  readonly timeoutMs: number
+  readonly candidates: () => readonly T[]
+  readonly getTargetId: (candidate: T) => Promise<string | undefined>
+  readonly delay?: (milliseconds: number) => Promise<void>
+}): Promise<T | undefined> {
+  const deadline = Date.now() + options.timeoutMs
+  const cachedTargetIds = new Map<T, string | undefined>()
+  const inFlightTargetIds = new Map<T, Promise<{ readonly candidate: T; readonly targetId: string | undefined }>>()
+  while (true) {
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) return undefined
+    const candidates = options.candidates()
+    for (const candidate of candidates) {
+      const cached = cachedTargetIds.get(candidate)
+      if (cached === options.targetId) return candidate
+      if (cached !== undefined || inFlightTargetIds.has(candidate)) continue
+      inFlightTargetIds.set(candidate, options.getTargetId(candidate).then(
+        (targetId) => ({ candidate, targetId }),
+        () => ({ candidate, targetId: undefined }),
+      ))
+    }
+    const retryInMs = Math.min(sessionPageHealthRetryDelayMs, Math.max(0, deadline - Date.now()))
+    if (retryInMs <= 0) return undefined
+    if (inFlightTargetIds.size > 0) {
+      const resolved = await withTimeout(Promise.race(inFlightTargetIds.values()), retryInMs)
+      if (resolved !== timedOut) {
+        inFlightTargetIds.delete(resolved.candidate)
+        if (resolved.targetId !== undefined) cachedTargetIds.set(resolved.candidate, resolved.targetId)
+        if (resolved.targetId === options.targetId) return resolved.candidate
+      }
+      continue
+    }
+    await (options.delay ?? delay)(retryInMs)
   }
 }
 
@@ -912,18 +1044,6 @@ function selectPage({ pages, selection }: { readonly pages: readonly Page[]; rea
   return selectTarget({ targets: pages, selection, getUrl: (page) => page.url() })
 }
 
-export function selectTargetById<T>({
-  targets,
-  targetId,
-  getTargetId,
-}: {
-  readonly targets: readonly T[]
-  readonly targetId: string
-  readonly getTargetId: (target: T) => string | undefined
-}): T | undefined {
-  return targets.find((target) => getTargetId(target) === targetId)
-}
-
 async function resolvePageTargetId(page: Page): Promise<string | undefined> {
   return await Effect.runPromise(
     runPlaywrightOperation({
@@ -954,30 +1074,6 @@ export async function pageTargetId(page: Page): Promise<string> {
   } finally {
     await session.detach()
   }
-}
-
-export function selectAdoptCandidateByUrl<T>({
-  candidates,
-  targetUrl,
-  getUrl,
-}: {
-  readonly candidates: readonly T[]
-  readonly targetUrl: string
-  readonly getUrl: (candidate: T) => string
-}): T | undefined {
-  const matches = candidates.filter((candidate) => getUrl(candidate) === targetUrl)
-  if (matches.length > 1) {
-    throw new Error(`Multiple Playwright pages have URL ${targetUrl}; cannot safely map the validated target to a page without a relay target-id hook`)
-  }
-  return matches[0]
-}
-
-function selectPageForAdopt({ pages, target }: { readonly pages: readonly Page[]; readonly target: AdoptTarget }): Page | undefined {
-  return selectAdoptCandidateByUrl({
-    candidates: pages.filter((page) => !page.isClosed()),
-    targetUrl: target.url,
-    getUrl: (page) => page.url(),
-  })
 }
 
 function ghostCursorOptions(options: ShowGhostCursorOptions | undefined): GhostCursorClientOptions | undefined {
@@ -1251,7 +1347,7 @@ export function createSnapshotHelpers(page: Page, registry: SnapshotRefRegistry)
         for (const attribute of ["data-testid", "data-test", "name", "aria-label", "placeholder"]) {
           const value = element.getAttribute(attribute)
           if (value) {
-            const candidate = `[${attribute}="${quote(value)}"]`
+            const candidate = `[${attribute}="${CSS.escape(value)}"]`
             if (document.querySelectorAll(candidate).length === 1) return candidate
           }
         }
@@ -1771,7 +1867,7 @@ async function showScreenshotLabels(page: Page): Promise<readonly ScreenshotLabe
     }
 
     const quoteAttribute = (value: string): string => {
-      return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+      return CSS.escape(value)
     }
 
     const selectorForElement = (element: Element): string => {

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -18,8 +18,8 @@ type PendingHandoff = {
   readonly id: string
   readonly sessionId: string
   readonly tabId: number
-  readonly targetId: string
-  readonly targetSessionId: string
+  targetId: string
+  targetSessionId: string
   readonly message: string
   readonly resolve: (outcome: HandoffOutcome) => void
 }
@@ -128,6 +128,24 @@ export class HandoffRegistry {
 
   get pendingCount(): number {
     return this.pending.size
+  }
+
+  rebindTarget(options: {
+    readonly tabId: number
+    readonly previousTargetId: string
+    readonly previousTargetSessionId: string
+    readonly targetId: string
+    readonly targetSessionId: string
+  }): boolean {
+    const pending = Array.from(this.pending.values()).find((candidate) => {
+      return candidate.tabId === options.tabId &&
+        candidate.targetId === options.previousTargetId &&
+        candidate.targetSessionId === options.previousTargetSessionId
+    })
+    if (!pending) return false
+    pending.targetId = options.targetId
+    pending.targetSessionId = options.targetSessionId
+    return true
   }
 
   cancelForTarget(options: {

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -39,6 +39,7 @@ export function createHttpRequestHandler(options: {
   readonly host: string
   readonly port: number
   readonly browserId: string
+  readonly relayInstance: { readonly id: string; readonly startedAt: string; readonly pid: number }
   readonly extensionStatus: () => { readonly connected: boolean; readonly version: string | null; readonly cdpClients?: number }
   readonly recordingRelay: RecordingRelay
   readonly registry: TargetRegistry
@@ -63,7 +64,13 @@ export function createHttpRequestHandler(options: {
     const requestUrl = new URL(request.url ?? "/", `http://${formatHostForUrl(options.host)}:${options.port}`)
     const pathname = requestUrl.pathname.replace(/\/$/, "") || "/"
     if (pathname === "/" || pathname === "/version") {
-      sendJson(response, { version: browserControlVersion, buildId: browserControlBuildId })
+      sendJson(response, {
+        version: browserControlVersion,
+        buildId: browserControlBuildId,
+        instanceId: options.relayInstance.id,
+        startedAt: options.relayInstance.startedAt,
+        pid: options.relayInstance.pid,
+      })
       return
     }
     if (pathname === "/json/version") {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -381,10 +381,7 @@ function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSess
 const relayLayer = Layer.effectDiscard(
   Effect.gen(function* () {
     const relay = yield* RelayClient.Service
-    const readiness = yield* RelayLifecycle.ensureRelay({ relay })
-    if (readiness.buildProblem) {
-      return yield* Effect.fail(new Error(readiness.buildProblem))
-    }
+    yield* RelayLifecycle.ensureRelay({ relay })
   }),
 )
 
@@ -411,7 +408,14 @@ const registerTools = Effect.gen(function* () {
       }),
       annotations: Context.empty(),
       handle: (payload: unknown) => {
-        return spec.handle(payload).pipe(
+        const operation = mcpToolRequiresRelayCompatibility(spec.name)
+          ? RelayLifecycle.ensureRelay({ relay }).pipe(
+            Effect.flatMap((readiness) => readiness.buildProblem
+              ? Effect.fail(new Error(readiness.buildProblem))
+              : spec.handle(payload)),
+          )
+          : spec.handle(payload)
+        return operation.pipe(
           Effect.match({
             onFailure: (error) => toolResult({ text: mcpErrorMessage(spec.name, error.message), isError: true }),
             onSuccess: (value) => toolResultForValue(value),
@@ -421,6 +425,10 @@ const registerTools = Effect.gen(function* () {
     })
   }, { discard: true })
 })
+
+export function mcpToolRequiresRelayCompatibility(name: string): boolean {
+  return name !== "status" && name !== "session_current" && name !== "skill"
+}
 
 export const runMcpServer: Effect.Effect<never, Error> = Layer.launch(
   Layer.mergeAll(

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -35,9 +35,6 @@ export class ExtensionDisconnected extends Schema.TaggedErrorClass<ExtensionDisc
 ) {}
 
 export function relayBuildProblem(version: RelayVersion, buildId = browserControlBuildId): string | undefined {
-  if (buildId === "dev") {
-    return undefined
-  }
   if (!version.buildId) {
     return `Running relay does not report a build id; restart it with the current CLI (${buildId}).`
   }

--- a/src/relay-log.ts
+++ b/src/relay-log.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+const maxLogBytes = 1_000_000
+const maxEntryCharacters = 64_000
+
+export function managedRelayLogPath(home = os.homedir()): string {
+  return path.join(home, ".browser-control", "relay.log")
+}
+
+export function appendManagedRelayProcessLog(message: string, home = os.homedir()): void {
+  try {
+    const logPath = managedRelayLogPath(home)
+    const directory = path.dirname(logPath)
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 })
+    fs.chmodSync(directory, 0o700)
+    const entry = `${new Date().toISOString()} ${message.slice(0, maxEntryCharacters)}\n`
+    const stat = fs.statSync(logPath, { throwIfNoEntry: false })
+    if (stat && stat.size + Buffer.byteLength(entry) > maxLogBytes) fs.truncateSync(logPath, 0)
+    fs.appendFileSync(logPath, entry, { encoding: "utf8", mode: 0o600 })
+    fs.chmodSync(logPath, 0o600)
+  } catch {
+    // Process-fault logging must never hide or replace the original fault.
+  }
+}

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -193,6 +193,9 @@ export interface ExtensionStatus extends Schema.Schema.Type<typeof ExtensionStat
 export const RelayVersion = Schema.Struct({
   version: Schema.String,
   buildId: Schema.optionalKey(Schema.String),
+  instanceId: Schema.optionalKey(Schema.String),
+  startedAt: Schema.optionalKey(Schema.String),
+  pid: Schema.optionalKey(Schema.Number),
 })
 
 export interface RelayVersion extends Schema.Schema.Type<typeof RelayVersion> {}

--- a/src/relay-types.ts
+++ b/src/relay-types.ts
@@ -57,6 +57,7 @@ export interface ExecuteSandboxLike {
   redactNetworkCaptureText(text: string): string
   markTargetCrashed(targetId: string): boolean
   markTargetDetached(targetId: string): boolean
+  markTargetReplaced(previousTargetId: string, targetId: string): boolean
   getStatus(): {
     readonly sessionId?: string
     readonly connected: boolean

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -1,6 +1,7 @@
 import http from "node:http"
 import stream from "node:stream"
-import { Config, Effect, Fiber } from "effect"
+import crypto from "node:crypto"
+import { Config, Effect, Fiber, Semaphore } from "effect"
 import { WebSocket, WebSocketServer, type RawData } from "ws"
 import {
   chromeSessionIdForClientRequest,
@@ -52,8 +53,9 @@ import { makePageStatus } from "./page-status.ts"
 import { appendJournalEntry, defaultJournalBaseDir, makeJournalEntry } from "./session-journal.ts"
 import { BrowserControlSessions } from "./session-manager.ts"
 import { RecordingRelay } from "./recording-relay.ts"
+import { appendManagedRelayProcessLog } from "./relay-log.ts"
 import { boundedToken, runtimeFailureKind, summarizeDiagnosticUrl, summarizeRuntimeEvaluate } from "./runtime-diagnostics.ts"
-import { shouldExposeChildTarget, TargetRegistry, type TargetOwnershipChange } from "./target-registry.ts"
+import { resolveTargetInfoTarget, shouldExposeChildTarget, TargetRegistry, type RootTargetChange, type TargetOwnershipChange } from "./target-registry.ts"
 
 export type { RelayServer } from "./relay-types.ts"
 
@@ -115,7 +117,9 @@ function rethrowProcessFault(cause: unknown): never {
 
 function logProcessFault(kind: RelayProcessFaultKind, cause: unknown, detail: Record<string, unknown>, disposition: string): void {
   const errorText = cause instanceof Error ? cause.stack ?? cause.message : String(cause)
-  console.error(`[browser-control relay] ${kind}; ${disposition}\n${errorText}`)
+  const message = `[browser-control relay] ${kind}; ${disposition}\n${errorText}`
+  console.error(message)
+  if (process.env.BROWSER_CONTROL_MANAGED_RELAY === "1") appendManagedRelayProcessLog(message)
   if (debugEnvironmentEnabled(process.env.BROWSER_CONTROL_DEBUG)) {
     console.error(`[browser-control relay] ${kind} detail`, detail)
   }
@@ -131,6 +135,15 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
   const browserId = crypto.randomUUID()
   const endpointUrl = `http://${formatHostForUrl(host)}:${port}`
   const registry = new TargetRegistry()
+  const rootLifecycleSemaphores = new Map<number, Semaphore.Semaphore>()
+  type RootReconciliationWorker = {
+    attachIfMissing: boolean
+    pending: boolean
+    promise: Promise<void>
+    verificationRetries: number
+  }
+  const rootReconciliationWorkers = new Map<number, RootReconciliationWorker>()
+  let relayClosing = false
   const extensionRpc = new ExtensionRpc()
   const sendToExtension = Effect.fnUntraced(function* (command: Parameters<ExtensionRpc["send"]>[0]) {
     return yield* extensionRpc.send(command)
@@ -376,6 +389,7 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     host,
     port,
     browserId,
+    relayInstance: { id: browserId, startedAt: new Date().toISOString(), pid: process.pid },
     registry,
     recordingRelay,
     sessions,
@@ -458,14 +472,19 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
   })
 
   const cleanup = Effect.fnUntraced(function* () {
+    relayClosing = true
     handoffs.cancelAll()
     extensionRpc.rejectPending(new Error("Relay closed"))
+    yield* Effect.promise(() => Promise.allSettled(
+      Array.from(rootReconciliationWorkers.values(), (worker) => worker.promise),
+    )).pipe(Effect.asVoid)
     yield* Effect.tryPromise(() => recordingRelay.cleanupAll("Relay closed")).pipe(Effect.ignore)
     yield* sessions.closeAll()
     for (const socket of cdpClients) {
       socket.close()
     }
     extensionRpc.close()
+    rootLifecycleSemaphores.clear()
     yield* closeWebSocketServer(websocketServer).pipe(logCloseError("Failed to close websocket server"))
     yield* closeHttpServer(httpServer).pipe(logCloseError("Failed to close http server"))
   })
@@ -592,10 +611,8 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     }
     if (extensionMethod === "debugger.attached") {
       const tabId = typeof message.params?.tabId === "number" ? message.params.tabId : undefined
-      if (tabId && !registry.tabTargets.has(tabId)) {
-        Effect.runPromise(attachTab({ tabId, owner: "user" })).catch((error: unknown) => {
-          console.error("Debugger re-announce failed", error)
-        })
+      if (tabId) {
+        queueRootReconciliation(tabId, true, 0, "Debugger re-announce failed")
       }
       return
     }
@@ -640,6 +657,9 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
         return
       }
       if (reason === "target_closed") {
+        if (tabId) {
+          queueRootReconciliation(tabId, false, 3, "Failed to reconcile ambiguous debugger detach")
+        }
         return
       }
       if (tabId) {
@@ -670,7 +690,7 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     if (!tabId) {
       return
     }
-    const target = registry.tabTargets.get(tabId)
+    const target = registry.routingRootTarget(tabId)
     if (!target) {
       return
     }
@@ -785,6 +805,10 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       }
       const changed = registry.updateConnectedTargetInfo({ tabId, targetInfo })
       if (!changed) {
+        const currentRoot = registry.routingRootTarget(tabId)
+        if (targetInfo.type === "page" && currentRoot && currentRoot.targetInfo.targetId !== targetInfo.targetId) {
+          queueRootReconciliation(tabId, false, 1, "Failed to reconcile changed root target info")
+        }
         return
       }
       contextDebugLog?.(`target-info-changed ${targetDiagnosticIdentity(changed.target)} ${summarizeDiagnosticUrl(targetInfo.url)}`)
@@ -1012,12 +1036,13 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       const targetId = typeof message.params?.targetId === "string" ? message.params.targetId : ""
       const sessionAlias = message.sessionId ? cdpClientSessionAliases.get(socket)?.get(message.sessionId) : undefined
       const aliasedTargetId = sessionAlias?.kind === "target" ? sessionAlias.targetId : undefined
-      const target =
-        registry.targetsByTargetId.get(targetId) ??
-        registry.childTargetsByTargetId.get(targetId) ??
-        (aliasedTargetId ? registry.targetsByTargetId.get(aliasedTargetId) ?? registry.childTargetsByTargetId.get(aliasedTargetId) : undefined) ??
-        (message.sessionId ? registry.targets.get(message.sessionId) ?? registry.childTargets.get(message.sessionId) : undefined) ??
-        firstVisibleRootTarget(socket)
+      const target = resolveTargetInfoTarget({
+        registry,
+        ...(targetId ? { targetId } : {}),
+        ...(message.sessionId ? { sessionId: message.sessionId } : {}),
+        ...(aliasedTargetId ? { aliasedTargetId } : {}),
+        fallback: () => firstVisibleRootTarget(socket),
+      })
       if (!target) {
         if (!targetId && !message.sessionId) {
           return {}
@@ -1180,13 +1205,16 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     })
   })
 
-  const attachTab = Effect.fnUntraced(function* (options: {
+  const attachTabUnlocked = Effect.fnUntraced(function* (options: {
     readonly tabId: number
     readonly owner: "relay" | "user"
     readonly browserControlSessionId?: string
+    readonly alreadyAttached?: boolean
   }) {
     const { tabId } = options
-    yield* sendToExtension({ method: "debugger.attach", params: { tabId } })
+    if (!options.alreadyAttached) {
+      yield* sendToExtension({ method: "debugger.attach", params: { tabId } })
+    }
     yield* sendDebuggerCommand({ tabId, method: "Page.enable", params: {} })
     yield* injectGhostCursor(tabId).pipe(Effect.ignore)
     const targetInfoResult = yield* sendDebuggerCommand({ tabId, method: "Target.getTargetInfo", params: {} })
@@ -1195,19 +1223,18 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       return yield* Effect.fail(new Error("Target.getTargetInfo did not return targetInfo"))
     }
     const sessionId = `bc-tab-${nextTargetSessionId++}`
-    const target: ConnectedTarget = {
+    const candidate: ConnectedTarget = {
       tabId,
       sessionId,
       targetInfo,
       owner: options.owner,
       ...(options.browserControlSessionId ? { browserControlSessionId: options.browserControlSessionId } : {}),
     }
-    registry.addRootTarget(target)
-    mainFrameIdsByTab.set(tabId, targetInfo.targetId)
-    contextDebugLog?.(`target-attached kind=root ${targetDiagnosticIdentity(target)} ${summarizeDiagnosticUrl(targetInfo.url)}`)
-    if (options.browserControlSessionId) {
-      pruneInvisibleAnnouncementsForSession(options.browserControlSessionId)
-    }
+    return yield* finishAttachedTarget(registry.stageRootTarget(candidate))
+  })
+
+  const finishAttachedTarget = Effect.fnUntraced(function* (target: ConnectedTarget) {
+    const tabId = target.tabId
     yield* sendDebuggerCommand({
       tabId,
       method: "Target.setAutoAttach",
@@ -1217,15 +1244,152 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
         flatten: true,
       },
     })
+    const currentTargetInfoResult = yield* sendDebuggerCommand({ tabId, method: "Target.getTargetInfo", params: {} })
+    const currentTargetInfo = getTargetInfo(currentTargetInfoResult.targetInfo)
+    if (!currentTargetInfo || currentTargetInfo.targetId !== target.targetInfo.targetId) {
+      return yield* Effect.fail(new Error(`Root target changed while preparing ${target.targetInfo.targetId}`))
+    }
+    const change = registry.commitStagedRootTarget(tabId, target.sessionId)
+    if (!change) return yield* Effect.fail(new Error(`Staged root target changed before commit: ${target.targetInfo.targetId}`))
+    const committedTarget = change.target
+    if (change.kind === "replaced") reconcileRootReplacement(change)
+    mainFrameIdsByTab.set(tabId, committedTarget.targetInfo.targetId)
+    contextDebugLog?.(`target-attached kind=root ${targetDiagnosticIdentity(committedTarget)} ${summarizeDiagnosticUrl(committedTarget.targetInfo.url)}`)
+    if (committedTarget.browserControlSessionId) {
+      pruneInvisibleAnnouncementsForSession(committedTarget.browserControlSessionId)
+    }
     yield* Effect.ignore(sendToExtension({
-      method: options.browserControlSessionId ? "tabs.group" : "tabs.ungroup",
+      method: committedTarget.browserControlSessionId ? "tabs.group" : "tabs.ungroup",
       params: { tabId },
     }))
     yield* Effect.ignore(sendToExtension({ method: "action.setAttached", params: { tabId, attached: true } }))
-    sendPageStatus(target, options.browserControlSessionId && sessions.isExecuting(options.browserControlSessionId) ? "running" : "attached")
-    announceAttachedTarget(target)
-    return target
+    const pendingHandoff = handoffs.pendingForTab(tabId)
+    if (pendingHandoff) {
+      setActivityForTarget(committedTarget, "waiting", waitingBadge(pendingHandoff.message), {
+        sessionId: pendingHandoff.sessionId,
+        message: pendingHandoff.message,
+        handoffId: pendingHandoff.id,
+      })
+    } else {
+      sendPageStatus(committedTarget, committedTarget.browserControlSessionId && sessions.isExecuting(committedTarget.browserControlSessionId) ? "running" : "attached")
+    }
+    announceAttachedTarget(committedTarget)
+    for (const child of registry.childTargets.values()) {
+      if (child.tabId === tabId && child.parentSessionId === committedTarget.sessionId && shouldExposeChildTarget(child)) {
+        announceAttachedChildTarget(committedTarget.sessionId, child)
+      }
+    }
+    return committedTarget
   })
+
+  const attachTab = Effect.fnUntraced(function* (options: {
+    readonly tabId: number
+    readonly owner: "relay" | "user"
+    readonly browserControlSessionId?: string
+    readonly alreadyAttached?: boolean
+  }) {
+    const semaphore = rootLifecycleSemaphores.get(options.tabId) ?? Semaphore.makeUnsafe(1)
+    rootLifecycleSemaphores.set(options.tabId, semaphore)
+    return yield* semaphore.withPermit(Effect.gen(function* () {
+      if (relayClosing) return yield* Effect.fail(new Error("Relay is closing"))
+      return yield* attachTabUnlocked(options)
+    }))
+  })
+
+  const reconcileAttachedRootUnlocked = Effect.fnUntraced(function* (tabId: number) {
+    const expected = registry.tabTargets.get(tabId)
+    const staged = registry.stagedRootTarget(tabId)
+    if (!expected && !staged) return
+    let targetInfo: ReturnType<typeof getTargetInfo> | undefined
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const result = yield* Effect.result(sendDebuggerCommand({ tabId, method: "Target.getTargetInfo", params: {} }))
+      if (result._tag === "Success") {
+        targetInfo = getTargetInfo(result.success.targetInfo)
+        break
+      }
+      if (attempt === 0) yield* Effect.sleep("50 millis")
+    }
+    if (relayClosing) return
+    if (!targetInfo) return
+    if (
+      registry.tabTargets.get(tabId)?.sessionId !== expected?.sessionId ||
+      registry.stagedRootTarget(tabId)?.sessionId !== staged?.sessionId
+    ) return
+    if (staged?.targetInfo.targetId === targetInfo.targetId) {
+      yield* finishAttachedTarget(staged)
+      return
+    }
+    if (!staged && expected?.targetInfo.targetId === targetInfo.targetId) return
+    const ownerSource = expected ?? staged
+    if (!ownerSource) return
+    yield* attachTabUnlocked({
+      tabId,
+      owner: ownerSource.owner,
+      alreadyAttached: true,
+      ...(ownerSource.browserControlSessionId ? { browserControlSessionId: ownerSource.browserControlSessionId } : {}),
+    })
+  })
+
+  const reconcileAttachedRoot = Effect.fnUntraced(function* (tabId: number) {
+    const semaphore = rootLifecycleSemaphores.get(tabId) ?? Semaphore.makeUnsafe(1)
+    rootLifecycleSemaphores.set(tabId, semaphore)
+    yield* semaphore.withPermit(Effect.gen(function* () {
+      if (relayClosing) return
+      yield* reconcileAttachedRootUnlocked(tabId)
+    }))
+  })
+
+  function queueRootReconciliation(tabId: number, attachIfMissing: boolean, verificationRetries: number, errorMessage: string): void {
+    if (relayClosing) return
+    const existing = rootReconciliationWorkers.get(tabId)
+    if (existing) {
+      existing.pending = true
+      existing.attachIfMissing ||= attachIfMissing
+      existing.verificationRetries = Math.max(existing.verificationRetries, verificationRetries)
+      return
+    }
+    const worker: RootReconciliationWorker = {
+      attachIfMissing,
+      pending: false,
+      promise: Promise.resolve(),
+      verificationRetries,
+    }
+    worker.promise = (async () => {
+      let retries = 0
+      do {
+        worker.pending = false
+        const mayAttach = worker.attachIfMissing
+        worker.attachIfMissing = false
+        try {
+          if (registry.tabTargets.has(tabId)) {
+            await Effect.runPromise(reconcileAttachedRoot(tabId))
+          } else if (mayAttach && !relayClosing) {
+            await Effect.runPromise(attachTab({ tabId, owner: "user", alreadyAttached: true }))
+          }
+          retries = 0
+          if (worker.verificationRetries > 0 && !relayClosing) {
+            const retryDelayMs = 50 * (4 - worker.verificationRetries)
+            worker.verificationRetries -= 1
+            await new Promise((resolve) => setTimeout(resolve, retryDelayMs))
+            worker.pending = true
+          }
+        } catch (error) {
+          console.error(errorMessage, error)
+          if (registry.stagedRootTarget(tabId) && retries < 2 && !relayClosing) {
+            retries += 1
+            await new Promise((resolve) => setTimeout(resolve, 100 * retries))
+            worker.pending = true
+          }
+        }
+      } while (worker.pending && !relayClosing)
+    })().finally(() => {
+      if (rootReconciliationWorkers.get(tabId) === worker) {
+        rootReconciliationWorkers.delete(tabId)
+      }
+      if (!registry.tabTargets.has(tabId)) rootLifecycleSemaphores.delete(tabId)
+    })
+    rootReconciliationWorkers.set(tabId, worker)
+  }
 
   const injectGhostCursor = Effect.fnUntraced(function* (tabId: number) {
     yield* sendDebuggerCommand({
@@ -1308,6 +1472,28 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
         removeAnnouncedSession(announcements, childSessionId)
       }
     }
+  }
+
+  function reconcileRootReplacement(change: Extract<RootTargetChange, { readonly kind: "replaced" }>): void {
+    handoffs.rebindTarget({
+      tabId: change.target.tabId,
+      previousTargetId: change.previous.targetInfo.targetId,
+      previousTargetSessionId: change.previous.sessionId,
+      targetId: change.target.targetInfo.targetId,
+      targetSessionId: change.target.sessionId,
+    })
+    sessions.markTargetReplaced(change.previous.targetInfo.targetId, change.target.targetInfo.targetId)
+    removeClientTargetAliases(cdpClientSessionAliases.values(), (alias) => alias.tabId === change.target.tabId)
+    mainFrameIdsByTab.delete(change.target.tabId)
+    ghostCursorPositionsByTab.delete(change.target.tabId)
+    for (const [sessionId, childTabId] of suppressedChildSessions) {
+      if (childTabId === change.target.tabId) suppressedChildSessions.delete(sessionId)
+    }
+    for (const client of cdpClients) {
+      for (const childSessionId of change.childSessionIds) detachAnnouncedSession(client, childSessionId)
+      detachAnnouncedSession(client, change.previous.sessionId)
+    }
+    contextDebugLog?.(`target-replaced kind=root old=${targetDiagnosticIdentity(change.previous)} new=${targetDiagnosticIdentity(change.target)}`)
   }
 
   function detachChildTargetState(sessionId: string, notifyClients = false): void {
@@ -1408,15 +1594,7 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       }
     }
     for (const tabId of change.tabIds) {
-      const target = registry.tabTargets.get(tabId)
-      if (!target) {
-        continue
-      }
-      Effect.runPromise(Effect.ignore(sendToExtension({
-        method: target.browserControlSessionId ? "tabs.group" : "tabs.ungroup",
-        params: { tabId },
-      }))).catch(() => {})
-      refreshPageStatus(tabId)
+      refreshTabPresentation(tabId)
     }
   }
 

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -156,6 +156,17 @@ export class BrowserControlSessions {
     return affectedSessionIds
   }
 
+  markTargetReplaced(previousTargetId: string, targetId: string): string[] {
+    const affected: string[] = []
+    for (const session of this.sessions.values()) {
+      if (session.adoptedTargetId === previousTargetId) session.adoptedTargetId = targetId
+      if (session.sandbox.markTargetReplaced(previousTargetId, targetId)) {
+        affected.push(session.id)
+      }
+    }
+    return affected
+  }
+
   delete(id: string): Effect.Effect<boolean, Error> {
     const manager = this
     return Effect.gen(function* () {
@@ -389,7 +400,6 @@ export class BrowserControlSessions {
             }
             return yield* Effect.fail(timeoutError)
           }
-          const previousAdoptedTargetId = session.adoptedTargetId
           reservation = yield* Effect.try({
             try: () => manager.targetOwnership.reserveTargetOwnership(options.targetId, session.id),
             catch: (cause) => cause instanceof Error ? cause : new Error("Reserve target ownership", { cause }),
@@ -405,6 +415,7 @@ export class BrowserControlSessions {
           return yield* Effect.try({
             try: () => {
               state = "committed"
+              const previousAdoptedTargetId = session.adoptedTargetId
               manager.notifyTargetOwnershipChange(manager.targetOwnership.commitTargetOwnership({
                 reservation: activeReservation,
                 ...(previousAdoptedTargetId ? { previousAdoptedTargetId } : {}),

--- a/src/target-registry.ts
+++ b/src/target-registry.ts
@@ -91,8 +91,37 @@ export type ConnectedTargetInfoUpdate =
   | { readonly kind: "root"; readonly target: ConnectedTarget }
   | { readonly kind: "child"; readonly target: ChildTarget }
 
+export type RootTargetChange =
+  | { readonly kind: "added" | "updated"; readonly target: ConnectedTarget }
+  | {
+      readonly kind: "replaced"
+      readonly target: ConnectedTarget
+      readonly previous: ConnectedTarget
+      readonly childSessionIds: readonly string[]
+    }
+
 export function shouldExposeChildTarget(target: ChildTarget): boolean {
   return target.targetInfo.type !== "page" || target.targetInfo.url !== ""
+}
+
+export function resolveTargetInfoTarget(options: {
+  readonly registry: TargetRegistry
+  readonly targetId?: string
+  readonly sessionId?: string
+  readonly aliasedTargetId?: string
+  readonly fallback?: () => ConnectedTarget | undefined
+}): ConnectedTarget | ChildTarget | undefined {
+  const explicit = Boolean(options.targetId || options.sessionId || options.aliasedTargetId)
+  return (options.targetId
+    ? options.registry.targetsByTargetId.get(options.targetId) ?? options.registry.childTargetsByTargetId.get(options.targetId)
+    : undefined) ??
+    (options.aliasedTargetId
+      ? options.registry.targetsByTargetId.get(options.aliasedTargetId) ?? options.registry.childTargetsByTargetId.get(options.aliasedTargetId)
+      : undefined) ??
+    (options.sessionId
+      ? options.registry.targets.get(options.sessionId) ?? options.registry.childTargets.get(options.sessionId)
+      : undefined) ??
+    (explicit ? undefined : options.fallback?.())
 }
 
 export class TargetRegistry {
@@ -103,6 +132,8 @@ export class TargetRegistry {
   readonly childTargets = new Map<string, ChildTarget>()
   readonly childTargetsByTargetId = new Map<string, ChildTarget>()
   readonly tabFrameEvents = new Map<number, Map<string, StoredFrameEvents>>()
+  private readonly pendingOwnershipReservations = new Map<string, TargetOwnershipReservation>()
+  private readonly stagedRootTargets = new Map<number, ConnectedTarget>()
 
   clear(): void {
     this.targets.clear()
@@ -112,22 +143,93 @@ export class TargetRegistry {
     this.childTargets.clear()
     this.childTargetsByTargetId.clear()
     this.tabFrameEvents.clear()
+    this.pendingOwnershipReservations.clear()
+    this.stagedRootTargets.clear()
   }
 
-  addRootTarget(target: ConnectedTarget): void {
+  addRootTarget(target: ConnectedTarget, options: {
+    readonly preserveChildParentSessionId?: string
+    readonly preserveFrameEvents?: boolean
+  } = {}): RootTargetChange {
     const existingForTab = this.tabTargets.get(target.tabId)
-    if (existingForTab) {
+    const generationChanged = existingForTab !== undefined && (
+      existingForTab.sessionId !== target.sessionId ||
+      existingForTab.targetInfo.targetId !== target.targetInfo.targetId
+    )
+    const pendingReservation = existingForTab
+      ? this.pendingOwnershipReservations.get(existingForTab.targetInfo.targetId)
+      : undefined
+    const inheritedBrowserControlSessionId = pendingReservation
+      ? pendingReservation.previousBrowserControlSessionId
+      : existingForTab?.browserControlSessionId
+    const { browserControlSessionId: _incomingOwner, ...targetWithoutOwner } = target
+    const nextTarget = generationChanged
+      ? {
+          ...targetWithoutOwner,
+          owner: existingForTab.owner,
+          ...(inheritedBrowserControlSessionId
+            ? { browserControlSessionId: inheritedBrowserControlSessionId }
+            : {}),
+        }
+      : target
+    const detached = generationChanged
+      ? this.detachRootTargetState(target.tabId, options)
+      : undefined
+    const childSessionIds = detached?.childSessionIds ?? []
+    if (existingForTab && !generationChanged) {
       this.targets.delete(existingForTab.sessionId)
       this.targetsByTargetId.delete(existingForTab.targetInfo.targetId)
     }
-    const existingForTargetId = this.targetsByTargetId.get(target.targetInfo.targetId)
+    const existingForTargetId = this.targetsByTargetId.get(nextTarget.targetInfo.targetId)
     if (existingForTargetId) {
       this.targets.delete(existingForTargetId.sessionId)
       this.tabTargets.delete(existingForTargetId.tabId)
     }
-    this.targets.set(target.sessionId, target)
-    this.tabTargets.set(target.tabId, target)
-    this.targetsByTargetId.set(target.targetInfo.targetId, target)
+    this.targets.set(nextTarget.sessionId, nextTarget)
+    this.tabTargets.set(nextTarget.tabId, nextTarget)
+    this.targetsByTargetId.set(nextTarget.targetInfo.targetId, nextTarget)
+    return generationChanged
+      ? { kind: "replaced", target: nextTarget, previous: existingForTab, childSessionIds }
+      : { kind: existingForTab ? "updated" : "added", target: nextTarget }
+  }
+
+  stageRootTarget(target: ConnectedTarget): ConnectedTarget {
+    const existing = this.tabTargets.get(target.tabId)
+    const pendingReservation = existing
+      ? this.pendingOwnershipReservations.get(existing.targetInfo.targetId)
+      : undefined
+    const inheritedBrowserControlSessionId = pendingReservation
+      ? pendingReservation.previousBrowserControlSessionId
+      : existing?.browserControlSessionId
+    const { browserControlSessionId: _incomingOwner, ...targetWithoutOwner } = target
+    const staged = existing
+      ? {
+          ...targetWithoutOwner,
+          owner: existing.owner,
+          ...(inheritedBrowserControlSessionId ? { browserControlSessionId: inheritedBrowserControlSessionId } : {}),
+        }
+      : target
+    this.stagedRootTargets.set(target.tabId, staged)
+    this.tabFrameEvents.delete(target.tabId)
+    return staged
+  }
+
+  stagedRootTarget(tabId: number): ConnectedTarget | undefined {
+    return this.stagedRootTargets.get(tabId)
+  }
+
+  routingRootTarget(tabId: number): ConnectedTarget | undefined {
+    return this.stagedRootTargets.get(tabId) ?? this.tabTargets.get(tabId)
+  }
+
+  commitStagedRootTarget(tabId: number, sessionId: string): RootTargetChange | undefined {
+    const staged = this.stagedRootTargets.get(tabId)
+    if (!staged || staged.sessionId !== sessionId) return undefined
+    this.stagedRootTargets.delete(tabId)
+    return this.addRootTarget(staged, {
+      preserveChildParentSessionId: staged.sessionId,
+      preserveFrameEvents: true,
+    })
   }
 
   addChildTarget(target: ChildTarget): void {
@@ -173,16 +275,19 @@ export class TargetRegistry {
       throw targetOwnedError(owner)
     }
     this.addRootTarget({ ...target, browserControlSessionId: sessionId })
-    return {
+    const reservation = {
       targetId,
       targetSessionId: target.sessionId,
       tabId: target.tabId,
       sessionId,
       ...(owner ? { previousBrowserControlSessionId: owner } : {}),
     }
+    this.pendingOwnershipReservations.set(targetId, reservation)
+    return reservation
   }
 
   rollbackTargetOwnership(reservation: TargetOwnershipReservation): TargetOwnershipChange {
+    this.pendingOwnershipReservations.delete(reservation.targetId)
     const target = this.targetsByTargetId.get(reservation.targetId)
     if (!target || target.sessionId !== reservation.targetSessionId || target.browserControlSessionId !== reservation.sessionId) {
       return emptyOwnershipChange
@@ -198,6 +303,7 @@ export class TargetRegistry {
     readonly reservation: TargetOwnershipReservation
     readonly previousAdoptedTargetId?: string
   }): TargetOwnershipChange {
+    this.pendingOwnershipReservations.delete(options.reservation.targetId)
     const target = this.targetsByTargetId.get(options.reservation.targetId)
     if (!target || target.sessionId !== options.reservation.targetSessionId || target.browserControlSessionId !== options.reservation.sessionId) {
       throw new TargetOwnershipError({
@@ -225,7 +331,11 @@ export class TargetRegistry {
     return ownershipChange(target.targetInfo.targetId, target.tabId)
   }
 
-  detachRootTargetState(tabId: number): { readonly target: ConnectedTarget; readonly childSessionIds: string[] } | undefined {
+  detachRootTargetState(tabId: number, options: {
+    readonly preserveChildParentSessionId?: string
+    readonly preserveFrameEvents?: boolean
+  } = {}): { readonly target: ConnectedTarget; readonly childSessionIds: string[] } | undefined {
+    this.stagedRootTargets.delete(tabId)
     const target = this.tabTargets.get(tabId)
     if (!target) {
       return undefined
@@ -233,10 +343,14 @@ export class TargetRegistry {
     this.targets.delete(target.sessionId)
     this.tabTargets.delete(tabId)
     this.targetsByTargetId.delete(target.targetInfo.targetId)
-    this.tabFrameEvents.delete(tabId)
+    this.pendingOwnershipReservations.delete(target.targetInfo.targetId)
+    if (!options.preserveFrameEvents) this.tabFrameEvents.delete(tabId)
     const childSessionIds = Array.from(this.childSessionTabs.entries())
       .filter(([, childTabId]) => {
         return childTabId === tabId
+      })
+      .filter(([sessionId]) => {
+        return this.childTargets.get(sessionId)?.parentSessionId !== options.preserveChildParentSessionId
       })
       .map(([sessionId]) => {
         this.detachChildTargetState(sessionId)
@@ -256,6 +370,11 @@ export class TargetRegistry {
   }
 
   updateTargetUrl(tabId: number, url: string): void {
+    const staged = this.stagedRootTargets.get(tabId)
+    if (staged) {
+      this.stagedRootTargets.set(tabId, { ...staged, targetInfo: { ...staged.targetInfo, title: url, url }, crashed: false })
+      return
+    }
     const target = this.tabTargets.get(tabId)
     if (!target) {
       return
@@ -264,6 +383,12 @@ export class TargetRegistry {
   }
 
   markRootTargetCrashed(tabId: number): ConnectedTarget | undefined {
+    const staged = this.stagedRootTargets.get(tabId)
+    if (staged) {
+      const crashed = { ...staged, crashed: true }
+      this.stagedRootTargets.set(tabId, crashed)
+      return crashed
+    }
     const target = this.tabTargets.get(tabId)
     if (!target) {
       return undefined
@@ -279,7 +404,7 @@ export class TargetRegistry {
       const target = this.childTargetsByTargetId.get(options.targetInfo.targetId)
       return target ? { kind: "child", target } : undefined
     }
-    const root = this.tabTargets.get(options.tabId)
+    const root = this.stagedRootTargets.get(options.tabId) ?? this.tabTargets.get(options.tabId)
     if (root?.targetInfo.targetId !== options.targetInfo.targetId) {
       return undefined
     }
@@ -289,6 +414,11 @@ export class TargetRegistry {
   }
 
   updateRootTargetInfo(tabId: number, targetInfo: TargetInfo): void {
+    const staged = this.stagedRootTargets.get(tabId)
+    if (staged?.targetInfo.targetId === targetInfo.targetId) {
+      this.stagedRootTargets.set(tabId, { ...staged, targetInfo })
+      return
+    }
     const target = this.tabTargets.get(tabId)
     if (!target) {
       return

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,8 @@
+import crypto from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
 declare global {
   // Injected by scripts/build-cli.ts at build time.
   var __BROWSER_CONTROL_VERSION__: string | undefined
@@ -5,4 +10,27 @@ declare global {
 }
 
 export const browserControlVersion: string = globalThis.__BROWSER_CONTROL_VERSION__ ?? "0.0.0-dev"
-export const browserControlBuildId: string = globalThis.__BROWSER_CONTROL_BUILD_ID__ ?? "dev"
+export const browserControlBuildId: string = globalThis.__BROWSER_CONTROL_BUILD_ID__ ?? sourceBuildId()
+
+export function sourceBuildIdForFiles(files: readonly { readonly name: string; readonly content: string | Buffer }[]): string {
+  const hash = crypto.createHash("sha256")
+  for (const file of [...files].sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)) {
+    hash.update(file.name)
+    hash.update("\0")
+    hash.update(file.content)
+    hash.update("\0")
+  }
+  return `source-${hash.digest("hex").slice(0, 16)}`
+}
+
+function sourceBuildId(): string {
+  const srcDir = path.dirname(fileURLToPath(import.meta.url))
+  const rootDir = path.join(srcDir, "..")
+  const files = fs.readdirSync(srcDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => ({ name: `src/${entry.name}`, content: fs.readFileSync(path.join(srcDir, entry.name)) }))
+  for (const name of ["package.json", "pnpm-lock.yaml"]) {
+    files.push({ name, content: fs.readFileSync(path.join(rootDir, name)) })
+  }
+  return sourceBuildIdForFiles(files)
+}

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -60,10 +60,10 @@ describe("relayBuildCheck", () => {
     })).toMatchObject({ status: "warn", message: "running relay does not report a build id" })
   })
 
-  it("skips relay build comparison for a development CLI", () => {
+  it("compares legacy development build ids instead of treating them as wildcards", () => {
     expect(relayBuildCheck({
       cliBuildId: "dev",
       relayResult: { ok: true, value: { version: "0.1.0", buildId: "build-from-dist" } },
-    })).toMatchObject({ status: "ok", message: "CLI is a development build; build comparison skipped" })
+    })).toMatchObject({ status: "warn", message: "runtime build-from-dist does not match CLI dev" })
   })
 })

--- a/test/execute-lifecycle.test.ts
+++ b/test/execute-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { Effect } from "effect"
-import { recoverSessionPage, runPlaywrightOperation } from "../src/execute.ts"
+import { recoverSessionPage, runPlaywrightOperation, waitForPageContext } from "../src/execute.ts"
 
 describe("execute lifecycle", () => {
   it("bounds a Playwright operation that never settles", async () => {
@@ -13,13 +13,30 @@ describe("execute lifecycle", () => {
     expect(error.message).toBe("Close test page timed out after 20ms")
   })
 
-  it("recreates an unhealthy relay-owned page", async () => {
+  it("keeps a navigable relay-owned error document", async () => {
     let closed = false
     const result = await Effect.runPromise(recoverSessionPage({
       ownsPage: true,
       url: "chrome-error://chromewebdata/",
       timeoutMs: 20,
       healthCheck: () => Promise.resolve(),
+      close: () => {
+        closed = true
+        return Promise.resolve()
+      },
+    }))
+
+    expect(result).toBe("use")
+    expect(closed).toBe(false)
+  })
+
+  it("recreates a relay-owned error document whose context is unavailable", async () => {
+    let closed = false
+    const result = await Effect.runPromise(recoverSessionPage({
+      ownsPage: true,
+      url: "chrome-error://chromewebdata/",
+      timeoutMs: 20,
+      healthCheck: () => Promise.reject(new Error("Execution context was destroyed")),
       close: () => {
         closed = true
         return Promise.resolve()
@@ -35,7 +52,7 @@ describe("execute lifecycle", () => {
       ownsPage: true,
       url: "chrome-error://chromewebdata/",
       timeoutMs: 20,
-      healthCheck: () => Promise.resolve(),
+      healthCheck: () => Promise.reject(new Error("Execution context was destroyed")),
       close: () => Promise.reject(new Error("target did not close")),
     })).then(
       () => undefined,
@@ -76,5 +93,41 @@ describe("execute lifecycle", () => {
     }))
 
     expect(result).toBe("use")
+  })
+
+  it("waits through transient execution-context replacement", async () => {
+    let attempts = 0
+    await expect(waitForPageContext({
+      timeoutMs: 30,
+      retryDelayMs: 10,
+      delay: () => Promise.resolve(),
+      evaluate: () => ++attempts < 3
+        ? Promise.reject(new Error("Execution context was destroyed"))
+        : Promise.resolve(),
+    })).resolves.toBeUndefined()
+    expect(attempts).toBe(3)
+  })
+
+  it("does not retry non-context page failures", async () => {
+    let attempts = 0
+    await expect(waitForPageContext({
+      timeoutMs: 30,
+      retryDelayMs: 10,
+      delay: () => Promise.resolve(),
+      evaluate: () => {
+        attempts += 1
+        return Promise.reject(new Error("Permission denied"))
+      },
+    })).rejects.toThrow("Permission denied")
+    expect(attempts).toBe(1)
+  })
+
+  it("bounds a context evaluation that never settles", async () => {
+    const startedAt = Date.now()
+    await expect(waitForPageContext({
+      timeoutMs: 20,
+      evaluate: () => new Promise<void>(() => {}),
+    })).rejects.toThrow("did not become available within 20ms")
+    expect(Date.now() - startedAt).toBeLessThan(100)
   })
 })

--- a/test/execute-target-selection.test.ts
+++ b/test/execute-target-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { selectAdoptCandidateByUrl, selectTarget, shouldCloseCurrentPageOnAdopt } from "../src/execute.ts"
+import { selectTarget, shouldCloseCurrentPageOnAdopt, waitForExactTarget } from "../src/execute.ts"
 import { TargetRegistry } from "../src/target-registry.ts"
 
 describe("target selection", () => {
@@ -17,46 +17,78 @@ describe("target selection", () => {
     expect(selectTarget({ targets, selection: { index: 1 }, getUrl: (target) => target.url })?.url).toBe("https://kit.example/b")
   })
 
+  it("waits for the exact replacement target instead of selecting a same-URL decoy", async () => {
+    const old = { id: "old", url: "https://example.com/same" }
+    const decoy = { id: "decoy", url: "https://example.com/same" }
+    const replacement = { id: "replacement", url: "https://example.com/same" }
+    let attempts = 0
+
+    await expect(waitForExactTarget({
+      targetId: "replacement",
+      timeoutMs: 20,
+      candidates: () => ++attempts < 2 ? [old, decoy] : [old, decoy, replacement],
+      getTargetId: async (candidate) => candidate.id,
+      delay: () => Promise.resolve(),
+    })).resolves.toBe(replacement)
+  })
+
+  it("bounds a target id resolver that never settles", async () => {
+    const startedAt = Date.now()
+    await expect(waitForExactTarget({
+      targetId: "replacement",
+      timeoutMs: 20,
+      candidates: () => [{ id: "stale" }],
+      getTargetId: () => new Promise<string>(() => {}),
+    })).resolves.toBeUndefined()
+    expect(Date.now() - startedAt).toBeLessThan(100)
+  })
+
+  it("returns an exact match without waiting for a stale candidate", async () => {
+    const stale = { id: "stale" }
+    const replacement = { id: "replacement" }
+    await expect(waitForExactTarget({
+      targetId: "replacement",
+      timeoutMs: 20,
+      candidates: () => [stale, replacement],
+      getTargetId: (candidate) => candidate === stale
+        ? new Promise<string>(() => {})
+        : Promise.resolve(candidate.id),
+    })).resolves.toBe(replacement)
+  })
+
+  it("discovers a replacement that appears while a stale probe is pending", async () => {
+    const stale = { id: "stale" }
+    const replacement = { id: "replacement" }
+    let polls = 0
+    await expect(waitForExactTarget({
+      targetId: "replacement",
+      timeoutMs: 250,
+      candidates: () => ++polls === 1 ? [stale] : [stale, replacement],
+      getTargetId: (candidate) => candidate === stale
+        ? new Promise<string>(() => {})
+        : Promise.resolve(candidate.id),
+    })).resolves.toBe(replacement)
+    expect(polls).toBeGreaterThan(1)
+  })
+
+  it("retries a candidate whose target id was temporarily unavailable", async () => {
+    const candidate = { id: "replacement" }
+    let attempts = 0
+    await expect(waitForExactTarget({
+      targetId: "replacement",
+      timeoutMs: 20,
+      candidates: () => [candidate],
+      getTargetId: async () => ++attempts === 1 ? undefined : candidate.id,
+      delay: () => Promise.resolve(),
+    })).resolves.toBe(candidate)
+    expect(attempts).toBe(2)
+  })
+
   it("explains that target selectors do not navigate or create pages", () => {
     expect(() => selectTarget({ targets, selection: { urlIncludes: "missing.example" }, getUrl: (target) => target.url }))
       .toThrow("Target selectors do not navigate or open pages")
     expect(() => selectTarget({ targets, selection: { index: 4 }, getUrl: (target) => target.url }))
       .toThrow("Target selectors do not create pages")
-  })
-
-  it("threads the validation target URL so adoption agrees when page order differs", () => {
-    const registryTargets = [
-      { targetId: "target-a", url: "https://first.example" },
-      { targetId: "target-b", url: "https://second.example" },
-    ]
-    const selectedByHttpValidation = selectTarget({
-      targets: registryTargets,
-      selection: { index: 1 },
-      getUrl: (target) => target.url,
-    })
-    const playwrightPagesInDifferentOrder = [
-      { targetId: "target-b", url: "https://second.example" },
-      { targetId: "target-a", url: "https://first.example" },
-    ]
-
-    const adoptedBySandbox = selectAdoptCandidateByUrl({
-      candidates: playwrightPagesInDifferentOrder,
-      targetUrl: selectedByHttpValidation?.url ?? "",
-      getUrl: (page) => page.url,
-    })
-
-    expect(selectedByHttpValidation?.url).toBe("https://second.example")
-    expect(adoptedBySandbox?.url).toBe("https://second.example")
-  })
-
-  it("refuses URL-based adopt mapping when multiple Playwright pages have the validated URL", () => {
-    expect(() =>
-      selectAdoptCandidateByUrl({
-        candidates: [{ url: "https://same.example" }, { url: "https://same.example" }],
-        targetUrl: "https://same.example",
-        getUrl: (page) => page.url,
-      })
-    ).toThrow("cannot safely map")
   })
 
   it("closes only a different open relay-owned page when adopting", () => {

--- a/test/handoff.test.ts
+++ b/test/handoff.test.ts
@@ -100,6 +100,22 @@ describe("HandoffRegistry", () => {
     expect(registry.complete({ id: wait.id, tabId: 7, targetId: "target-7", targetSessionId: "bc-tab-new" })).toBe(true)
     await expect(wait.outcome).resolves.toBe("resolved")
   })
+
+  it("rebinds a pending handoff to a replacement root generation", async () => {
+    const registry = registryWithIds("handoff-1")
+    const wait = registry.wait({ sessionId: "alpha", tabId: 7, targetId: "target-old", targetSessionId: "bc-tab-old", message: "m", timeoutMs: 5_000 })
+
+    expect(registry.rebindTarget({
+      tabId: 7,
+      previousTargetId: "target-old",
+      previousTargetSessionId: "bc-tab-old",
+      targetId: "target-new",
+      targetSessionId: "bc-tab-new",
+    })).toBe(true)
+    expect(registry.complete({ id: wait.id, tabId: 7, targetId: "target-old", targetSessionId: "bc-tab-old" })).toBe(false)
+    expect(registry.complete({ id: wait.id, tabId: 7, targetId: "target-new", targetSessionId: "bc-tab-new" })).toBe(true)
+    await expect(wait.outcome).resolves.toBe("resolved")
+  })
 })
 
 describe("resolveExactHandoffTarget", () => {

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -37,6 +37,7 @@ describe("HTTP request schemas", () => {
     const sessions = new BrowserControlSessions(`http://127.0.0.1:${port}`, undefined, undefined, registry)
     sessions.createNew("beta")
     handler = createHttpRequestHandler({
+      relayInstance: { id: "relay-test", startedAt: "2026-07-19T00:00:00.000Z", pid: 123 },
       host: "127.0.0.1",
       port,
       browserId: "test-browser",
@@ -51,6 +52,12 @@ describe("HTTP request schemas", () => {
     })
 
     try {
+      const version = await fetch(`http://127.0.0.1:${port}/version`).then((response) => response.json())
+      expect(version).toMatchObject({
+        instanceId: "relay-test",
+        startedAt: "2026-07-19T00:00:00.000Z",
+        pid: 123,
+      })
       await expect(postJson(port, "/cli/session/new", { id: "alpha", readOnly: "yes" })).resolves.toMatchObject({
         status: 400,
         body: { error: expect.stringContaining("Invalid session new request"), code: "invalid-request" },

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from "vitest"
-import { mcpErrorMessage, toolResultForValue } from "../src/mcp.ts"
+import { mcpErrorMessage, mcpToolRequiresRelayCompatibility, toolResultForValue } from "../src/mcp.ts"
 
 describe("MCP tool results", () => {
+  it("rechecks relay compatibility for operational tools", () => {
+    expect(mcpToolRequiresRelayCompatibility("execute")).toBe(true)
+    expect(mcpToolRequiresRelayCompatibility("network_start")).toBe(true)
+    expect(mcpToolRequiresRelayCompatibility("secrets_run")).toBe(true)
+    expect(mcpToolRequiresRelayCompatibility("status")).toBe(false)
+    expect(mcpToolRequiresRelayCompatibility("session_current")).toBe(false)
+    expect(mcpToolRequiresRelayCompatibility("skill")).toBe(false)
+  })
+
   it("marks execute script failures as failed MCP tool calls", () => {
     const result = toolResultForValue({
       text: "locator.click: Timeout 30000ms exceeded",

--- a/test/relay-child-dedupe.test.ts
+++ b/test/relay-child-dedupe.test.ts
@@ -47,9 +47,15 @@ describe("relay child target announce dedupe", () => {
       yield* Effect.tryPromise(async () => {
         const extension = await openSocket(`${relay.url.replace("http://", "ws://")}/extension`)
         const extensionCommands: Array<{ readonly method: string; readonly params?: JsonObject }> = []
+        let targetInfoFailures = 0
         extension.on("message", (data) => {
           const command = JSON.parse(data.toString()) as { readonly id: number; readonly method: string; readonly params?: JsonObject }
           extensionCommands.push(command)
+          if (command.method === "debugger.sendCommand" && command.params?.method === "Target.getTargetInfo" && targetInfoFailures > 0) {
+            targetInfoFailures -= 1
+            extension.send(JSON.stringify({ id: command.id, error: "transient target probe failure" }))
+            return
+          }
           const result = command.method === "debugger.sendCommand" && command.params?.method === "Target.getTargetInfo"
             ? { targetInfo: targetInfo("root-target") }
             : {}
@@ -127,10 +133,12 @@ describe("relay child target announce dedupe", () => {
           method: "debugger.detached",
           params: { tabId: 1, reason: "target_closed", sessionId: "password-manager-child-session" },
         }))
+        targetInfoFailures = 2
         extension.send(JSON.stringify({
           method: "debugger.detached",
           params: { tabId: 1, reason: "target_closed" },
         }))
+        await waitFor(() => targetInfoFailures === 0)
 
         client.send(JSON.stringify({ id: 2, sessionId: rootSessionId, method: "Target.getTargetInfo", params: {} }))
         client.send(JSON.stringify({ id: 3, sessionId: rootSessionId, method: "Page.navigate", params: { url: "https://example.com/after-focus" } }))
@@ -159,6 +167,81 @@ describe("relay child target announce dedupe", () => {
         }))
         const navigateCommand = extensionCommands.find((command) => command.method === "debugger.sendCommand" && command.params?.method === "Page.navigate")
         expect(navigateCommand?.params?.sessionId).toBeUndefined()
+        expect(extensionCommands.some((command) => {
+          return command.method === "action.setAttached" && command.params?.attached === false
+        })).toBe(false)
+
+        client.close()
+        extension.close()
+      })
+    })))
+  })
+
+  it("commits one replacement generation after setup retries", async () => {
+    const port = await freePort()
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port })
+      yield* Effect.tryPromise(async () => {
+        const extension = await openSocket(`${relay.url.replace("http://", "ws://")}/extension`)
+        let currentTargetId = "root-old"
+        let autoAttachFailures = 0
+        const extensionCommands: Array<{ readonly method: string; readonly params?: JsonObject }> = []
+        extension.on("message", (data) => {
+          const command = JSON.parse(data.toString()) as { readonly id: number; readonly method: string; readonly params?: JsonObject }
+          extensionCommands.push(command)
+          if (command.method === "debugger.sendCommand" && command.params?.method === "Target.setAutoAttach" && autoAttachFailures > 0) {
+            autoAttachFailures -= 1
+            currentTargetId = "root-final"
+            extension.send(JSON.stringify({ id: command.id, error: "transient auto-attach failure" }))
+            extension.send(JSON.stringify({ method: "debugger.attached", params: { tabId: 1 } }))
+            return
+          }
+          const result = command.method === "debugger.sendCommand" && command.params?.method === "Target.getTargetInfo"
+            ? { targetInfo: targetInfo(currentTargetId) }
+            : {}
+          extension.send(JSON.stringify({ id: command.id, result }))
+        })
+        extension.send(JSON.stringify({ method: "hello", params: { version: "0.0.17" } }))
+        extension.send(JSON.stringify({ method: "toolbar.clicked", params: { tabId: 1 } }))
+        await waitFor(() => extensionCommands.some((command) => command.method === "action.setAttached"))
+
+        const client = await openSocket(`${relay.url.replace("http://", "ws://")}/devtools/browser/test`)
+        const messages: CdpEvent[] = []
+        client.on("message", (data) => {
+          const message = JSON.parse(data.toString()) as CdpEvent | { readonly id: number }
+          if ("method" in message) messages.push(message)
+        })
+        client.send(JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true, waitForDebuggerOnStart: false, flatten: true } }))
+        await waitFor(() => messages.some((message) => message.method === "Target.attachedToTarget"))
+        const oldAttach = messages.find((message) => message.method === "Target.attachedToTarget")
+        const oldSessionId = typeof oldAttach?.params?.sessionId === "string" ? oldAttach.params.sessionId : undefined
+        expect(oldSessionId).toBeDefined()
+
+        currentTargetId = "root-new"
+        autoAttachFailures = 1
+        extension.send(JSON.stringify({ method: "debugger.attached", params: { tabId: 1 } }))
+        extension.send(JSON.stringify({ method: "debugger.attached", params: { tabId: 1 } }))
+
+        await waitFor(() => messages.some((message) => {
+          return message.method === "Target.attachedToTarget" && message.params?.targetInfo &&
+            typeof message.params.targetInfo === "object" && !Array.isArray(message.params.targetInfo) &&
+            message.params.targetInfo.targetId === "root-final"
+        }))
+        const detachIndex = messages.findIndex((message) => message.method === "Target.detachedFromTarget" && message.params?.sessionId === oldSessionId)
+        const replacementAttachIndexes = messages.flatMap((message, index) => {
+          const info = message.method === "Target.attachedToTarget" ? message.params?.targetInfo : undefined
+          return info && typeof info === "object" && !Array.isArray(info) && info.targetId === "root-final" ? [index] : []
+        })
+        expect(detachIndex).toBeGreaterThanOrEqual(0)
+        expect(replacementAttachIndexes).toHaveLength(1)
+        expect(detachIndex).toBeLessThan(replacementAttachIndexes[0]!)
+        expect(messages.some((message) => {
+          const info = message.method === "Target.attachedToTarget" ? message.params?.targetInfo : undefined
+          return info && typeof info === "object" && !Array.isArray(info) && info.targetId === "root-new"
+        })).toBe(false)
+        expect(extensionCommands.filter((command) => {
+          return command.method === "debugger.sendCommand" && command.params?.method === "Target.setAutoAttach"
+        }).length).toBeGreaterThanOrEqual(3)
 
         client.close()
         extension.close()

--- a/test/relay-lifecycle.test.ts
+++ b/test/relay-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   statusCollections,
   stoppedRelayStatus,
 } from "../src/relay-lifecycle.ts"
+import { sourceBuildIdForFiles } from "../src/version.ts"
 
 const version = { version: "0.1.0", buildId: "build-current" }
 
@@ -110,12 +111,24 @@ describe("relay lifecycle", () => {
       targets: [],
     })).toEqual({ sessions: [], targets: [] })
     expect(relayBuildProblem(version, "build-current")).toBeUndefined()
-    expect(relayBuildProblem({ ...version, buildId: "build-old" }, "dev")).toBeUndefined()
+    expect(relayBuildProblem({ ...version, buildId: "build-old" }, "dev")).toContain("does not match CLI build")
   })
 
   it("starts a managed relay through the CLI entrypoint from MCP builds and source", () => {
     expect(managedRelayEntrypoint("/package/dist/mcp.js")).toBe("/package/dist/cli.js")
     expect(managedRelayEntrypoint("/package/src/mcp-main.ts")).toBe("/package/src/cli.ts")
     expect(managedRelayEntrypoint("/package/dist/cli.js")).toBe("/package/dist/cli.js")
+  })
+
+  it("gives source processes a deterministic content-sensitive build id", () => {
+    const files = [
+      { name: "src/relay.ts", content: "relay" },
+      { name: "src/cli.ts", content: "cli" },
+    ]
+    expect(sourceBuildIdForFiles(files)).toBe(sourceBuildIdForFiles([...files].reverse()))
+    expect(sourceBuildIdForFiles(files)).not.toBe(sourceBuildIdForFiles([
+      files[0]!,
+      { name: "src/cli.ts", content: "changed" },
+    ]))
   })
 })

--- a/test/relay-log.test.ts
+++ b/test/relay-log.test.ts
@@ -1,0 +1,28 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { appendManagedRelayProcessLog, managedRelayLogPath } from "../src/relay-log.ts"
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true })
+})
+
+describe("managed relay process log", () => {
+  it("repairs permissions and bounds retained process-fault diagnostics", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-relay-log-"))
+    temporaryDirectories.push(home)
+    const logPath = managedRelayLogPath(home)
+    fs.mkdirSync(path.dirname(logPath), { recursive: true, mode: 0o755 })
+    fs.writeFileSync(logPath, "x".repeat(999_990), { mode: 0o644 })
+
+    appendManagedRelayProcessLog("fatal relay failure", home)
+
+    expect(fs.readFileSync(logPath, "utf8")).toContain("fatal relay failure")
+    expect(fs.statSync(logPath).size).toBeLessThan(100_000)
+    expect(fs.statSync(path.dirname(logPath)).mode & 0o777).toBe(0o700)
+    expect(fs.statSync(logPath).mode & 0o777).toBe(0o600)
+  })
+})

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -9,6 +9,7 @@ type FakeSandbox = ExecuteSandboxLike & {
   readonly adoptedSelections: () => unknown[]
   readonly crashedTargets: () => string[]
   readonly detachedTargets: () => string[]
+  readonly replacedTargets: () => Array<readonly [string, string]>
 }
 
 const makeFakeSandbox = (options?: {
@@ -24,6 +25,7 @@ const makeFakeSandbox = (options?: {
   const adoptedSelections: unknown[] = []
   const crashedTargets: string[] = []
   const detachedTargets: string[] = []
+  const replacedTargets: Array<readonly [string, string]> = []
   const close = () => Effect.sync(() => {
     closes += 1
   }).pipe(Effect.andThen(options?.onClose ?? Effect.void))
@@ -71,11 +73,16 @@ const makeFakeSandbox = (options?: {
       detachedTargets.push(targetId)
       return options?.defaultTargetId === undefined || options.defaultTargetId === targetId
     },
+    markTargetReplaced: (previousTargetId, targetId) => {
+      replacedTargets.push([previousTargetId, targetId])
+      return options?.defaultTargetId === undefined || options.defaultTargetId === previousTargetId
+    },
     getStatus: () => ({ connected: false, pageUrl: null, stateKeys: [] }),
     closes: () => closes,
     adoptedSelections: () => adoptedSelections,
     crashedTargets: () => crashedTargets,
     detachedTargets: () => detachedTargets,
+    replacedTargets: () => replacedTargets,
   }
 }
 
@@ -160,6 +167,19 @@ describe("BrowserControlSessions", () => {
     expect(sessions.markTargetDetached("target-1")).toEqual(["alpha"])
     expect(first.detachedTargets()).toEqual(["target-1"])
     expect(second.detachedTargets()).toEqual(["target-1"])
+  })
+
+  it("rebinds only the session page backed by a replaced root target", () => {
+    const first = makeFakeSandbox({ defaultTargetId: "target-1" })
+    const second = makeFakeSandbox({ defaultTargetId: "target-2" })
+    const sandboxes = [first, second]
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => sandboxes.shift()!)
+    sessions.createNew("alpha")
+    sessions.createNew("beta")
+
+    expect(sessions.markTargetReplaced("target-1", "target-new")).toEqual(["alpha"])
+    expect(first.replacedTargets()).toEqual([["target-1", "target-new"]])
+    expect(second.replacedTargets()).toEqual([["target-1", "target-new"]])
   })
 
   it("delete waits for a running execute before closing the sandbox", async () => {
@@ -843,6 +863,53 @@ describe("BrowserControlSessions", () => {
       expect(sessions.adoptedTargetId("alpha")).toBeUndefined()
       expect(registry.targetsByTargetId.get("target-1")?.browserControlSessionId).toBeUndefined()
     }))
+  })
+
+  it("releases a replacement generation of the previously adopted target", async () => {
+    const registry = new TargetRegistry()
+    const addTarget = (tabId: number, sessionId: string, targetId: string) => registry.addRootTarget({
+      tabId,
+      sessionId,
+      owner: "user" as const,
+      targetInfo: {
+        targetId,
+        type: "page" as const,
+        title: targetId,
+        url: `https://example.com/${targetId}`,
+        attached: true,
+        canAccessOpener: false,
+      },
+    })
+    addTarget(1, "bc-tab-a", "target-a")
+    addTarget(2, "bc-tab-b", "target-b")
+    let sessions: BrowserControlSessions
+    sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox({
+      onAdopt: (target) => Effect.sync(() => {
+        if (target.targetId === "target-b") {
+          addTarget(1, "bc-tab-a2", "target-a2")
+          sessions.markTargetReplaced("target-a", "target-a2")
+        }
+        return target.url
+      }),
+    }), undefined, registry)
+    sessions.createNew("alpha")
+
+    await Effect.runPromise(sessions.adopt({
+      sessionId: "alpha",
+      createIfMissing: false,
+      targetId: "target-a",
+      targetUrl: "https://example.com/target-a",
+    }))
+    await Effect.runPromise(sessions.adopt({
+      sessionId: "alpha",
+      createIfMissing: false,
+      targetId: "target-b",
+      targetUrl: "https://example.com/target-b",
+    }))
+
+    expect(sessions.adoptedTargetId("alpha")).toBe("target-b")
+    expect(registry.targetsByTargetId.get("target-a2")?.browserControlSessionId).toBeUndefined()
+    expect(registry.targetsByTargetId.get("target-b")?.browserControlSessionId).toBe("alpha")
   })
 
   it("preserves an existing sandbox when adoption times out before starting", async () => {

--- a/test/target-registry.test.ts
+++ b/test/target-registry.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+import { resolveTargetInfoTarget, TargetRegistry } from "../src/target-registry.ts"
+import type { ConnectedTarget } from "../src/relay-types.ts"
+
+function root(options: {
+  readonly tabId?: number
+  readonly sessionId: string
+  readonly targetId: string
+  readonly browserControlSessionId?: string
+}): ConnectedTarget {
+  return {
+    tabId: options.tabId ?? 7,
+    sessionId: options.sessionId,
+    owner: "relay",
+    ...(options.browserControlSessionId ? { browserControlSessionId: options.browserControlSessionId } : {}),
+    targetInfo: {
+      targetId: options.targetId,
+      type: "page",
+      title: options.targetId,
+      url: "https://example.test/",
+      attached: true,
+      canAccessOpener: false,
+    },
+  }
+}
+
+describe("TargetRegistry root generations", () => {
+  it("preserves ownership and reports same-tab root replacement", () => {
+    const registry = new TargetRegistry()
+    registry.addRootTarget(root({ sessionId: "bc-tab-1", targetId: "target-1", browserControlSessionId: "alpha" }))
+    registry.addChildTarget({
+      tabId: 7,
+      sessionId: "child-1",
+      parentSessionId: "bc-tab-1",
+      waitingForDebugger: false,
+      targetInfo: {
+        targetId: "child-target-1",
+        type: "iframe",
+        title: "",
+        url: "https://child.example.test/",
+        attached: true,
+        canAccessOpener: false,
+      },
+    })
+
+    const change = registry.addRootTarget(root({ sessionId: "bc-tab-2", targetId: "target-2" }))
+
+    expect(change).toMatchObject({
+      kind: "replaced",
+      previous: { sessionId: "bc-tab-1", targetInfo: { targetId: "target-1" } },
+      target: { sessionId: "bc-tab-2", browserControlSessionId: "alpha", targetInfo: { targetId: "target-2" } },
+      childSessionIds: ["child-1"],
+    })
+    expect(registry.targets.has("bc-tab-1")).toBe(false)
+    expect(registry.targetsByTargetId.has("target-1")).toBe(false)
+    expect(registry.childTargets.size).toBe(0)
+  })
+
+  it("never falls back to an unrelated root for an explicit stale identity", () => {
+    const registry = new TargetRegistry()
+    const visible = root({ sessionId: "bc-tab-1", targetId: "target-1" })
+    registry.addRootTarget(visible)
+
+    expect(resolveTargetInfoTarget({ registry, targetId: "missing", fallback: () => visible })).toBeUndefined()
+    expect(resolveTargetInfoTarget({ registry, sessionId: "missing", fallback: () => visible })).toBeUndefined()
+    expect(resolveTargetInfoTarget({ registry, fallback: () => visible })).toBe(visible)
+  })
+
+  it("does not preserve provisional adoption ownership across replacement", () => {
+    const registry = new TargetRegistry()
+    registry.addRootTarget(root({ sessionId: "bc-tab-1", targetId: "target-1" }))
+    const reservation = registry.reserveTargetOwnership("target-1", "alpha")
+
+    const change = registry.addRootTarget(root({ sessionId: "bc-tab-2", targetId: "target-2" }))
+
+    expect(change.target.browserControlSessionId).toBeUndefined()
+    expect(registry.rollbackTargetOwnership(reservation)).toEqual({ targetIds: [], tabIds: [] })
+  })
+
+  it("keeps a staged replacement non-authoritative and commits current ownership", () => {
+    const registry = new TargetRegistry()
+    registry.addRootTarget(root({ sessionId: "bc-tab-1", targetId: "target-1", browserControlSessionId: "alpha" }))
+
+    const staged = registry.stageRootTarget(root({ sessionId: "bc-tab-2", targetId: "target-2", browserControlSessionId: "alpha" }))
+    expect(registry.tabTargets.get(7)?.targetInfo.targetId).toBe("target-1")
+    expect(registry.targetsByTargetId.has("target-2")).toBe(false)
+    expect(registry.routingRootTarget(7)).toBe(staged)
+
+    registry.releaseTargetOwnership("target-1", "alpha")
+    const change = registry.commitStagedRootTarget(7, "bc-tab-2")
+
+    expect(change?.target.targetInfo.targetId).toBe("target-2")
+    expect(change?.target.browserControlSessionId).toBeUndefined()
+  })
+
+  it("preserves children attached to a staged generation when it commits", () => {
+    const registry = new TargetRegistry()
+    registry.addRootTarget(root({ sessionId: "bc-tab-1", targetId: "target-1" }))
+    registry.addChildTarget({
+      tabId: 7,
+      sessionId: "old-child",
+      parentSessionId: "bc-tab-1",
+      waitingForDebugger: false,
+      targetInfo: { ...root({ sessionId: "unused", targetId: "old-child-target" }).targetInfo, type: "iframe" },
+    })
+    registry.stageRootTarget(root({ sessionId: "bc-tab-2", targetId: "target-2" }))
+    registry.addChildTarget({
+      tabId: 7,
+      sessionId: "new-child",
+      parentSessionId: "bc-tab-2",
+      waitingForDebugger: false,
+      targetInfo: { ...root({ sessionId: "unused", targetId: "new-child-target" }).targetInfo, type: "iframe" },
+    })
+
+    const change = registry.commitStagedRootTarget(7, "bc-tab-2")
+
+    expect(change).toMatchObject({ kind: "replaced", childSessionIds: ["old-child"] })
+    expect(registry.childTargets.has("old-child")).toBe(false)
+    expect(registry.childTargets.get("new-child")?.parentSessionId).toBe("bc-tab-2")
+  })
+})


### PR DESCRIPTION
## What

Preserve Browser Control session continuity across stale relay builds, transient execution-context replacement, and same-tab root target replacement.

This PR also fixes multiline snapshot attribute selectors and adds relay-instance diagnostics for otherwise opaque session disappearance.

Closes #23.

## Before / After

**Before**

- Source commands identified as wildcard build `dev`, so a new command could invoke a route on an older relay and fail as `RelayDecodeFailed` after the stale route returned plain-text `404 Not found`.
- Context churn could make a healthy visible tab look dead; recovery closed `chrome-error://` pages or matched an adopted page by URL rather than exact target identity.
- A new CDP root generation for the same tab silently overwrote registry state, losing ownership, handoffs, child routing, client detach ordering, and the sandbox's page identity.
- Session disappearance after a relay restart had no instance identity or retained process-fault evidence.
- Snapshot selectors embedded multiline `aria-label` values without CSS escaping.

**After**

- Source CLI and relay processes share a deterministic source/lockfile fingerprint. Operational CLI and MCP calls reject incompatible relays before domain routes; observational MCP tools remain available.
- Context health checks wait through bounded transient replacement, preserve usable browser-error documents, and reacquire pages by exact CDP target ID without being blocked by stale candidates.
- Root candidates stay provisional for event routing until CDP setup succeeds. Commit then atomically transfers current ownership, rebinds handoffs, detaches the old generation before announcing the new one, preserves new children, and makes only the owning sandbox reacquire the exact page.
- Ambiguous `target_closed` probes fail closed without destructive detach, use bounded follow-up probes, serialize per tab, retry setup churn, and drain during relay shutdown.
- `/version` reports instance ID, start time, and PID; managed process faults are retained in a bounded mode-`0600` log.
- Snapshot and screenshot-label attribute selectors use native CSS escaping.

## How

- `src/version.ts`, `src/relay-lifecycle.ts`, `src/mcp.ts`: deterministic source identity and per-operation relay compatibility.
- `src/target-registry.ts`, `src/relay.ts`, `src/handoff.ts`: provisional root generations, transactional commit, serialized reconciliation, handoff/child/client migration, and exact explicit target routing.
- `src/execute.ts`, `src/session-manager.ts`: bounded context readiness, exact page reacquisition, non-destructive error-page health checks, and current-generation adoption release.
- `src/http-api.ts`, `src/relay-schema.ts`, `src/relay-log.ts`: relay instance metadata and bounded process-fault diagnostics.
- `scripts/smoke.ts`: compatibility preflight before direct relay/CDP setup and a multiline snapshot-ref regression.
- `CONTEXT.md`, `PLAN.md`, `AGENTS.md`, and the Browser Control skill document the root-generation and troubleshooting invariants.

## Scope

- Incompatible relays are rejected, not automatically restarted. This deliberately avoids terminating unrelated active sessions.
- Session JavaScript state is not serialized across a real process crash. Instance metadata and bounded fault logs make such a restart attributable; this PR fixes the known target/context paths that left sessions stale or triggered unsafe reconciliation.
- Site-specific React rerenders, overlays, WebAuthn prompts, and anti-bot challenges remain page-level automation concerns.

## Testing

- `pnpm run ci` (`325` tests, typecheck, CLI build, extension build)
- `pnpm pack --dry-run`
- `pnpm changeset status --since=origin/main`
- Source CLI against the stale shared relay: rejected before `/network/start` with the build-mismatch diagnostic.
- Isolated source relay on port `19990`: matching source CLI reused it successfully; `/version` returned matching fingerprint, instance ID, start time, and PID.
- Source MCP against the stale shared relay: remained available for observational tools instead of exiting at startup.
- Installed OpenCode Browser Control skill synchronized with `skills/browser-control/SKILL.md`.

Live browser smoke was not run: the only extension-connected relay is the intentionally preserved stale shared relay, and it still owns two unrelated sessions. The new smoke preflight rejects that relay before creating or mutating test sessions.

## Flow

```mermaid
sequenceDiagram
    participant Chrome
    participant Relay
    participant Registry
    participant Session
    participant Playwright

    Chrome->>Relay: root generation changed for same tab
    Relay->>Registry: stage candidate (routing only)
    Relay->>Chrome: Target.setAutoAttach
    Relay->>Chrome: verify current target ID
    alt setup succeeds and generation is current
        Relay->>Registry: commit staged generation
        Registry-->>Relay: old/new ownership change
        Relay->>Session: rebind target and handoff
        Relay-->>Playwright: detach old, announce new
        Session->>Playwright: reacquire exact target ID
    else transient failure or newer generation
        Relay->>Relay: bounded serialized retry
        Note over Registry,Session: old ownership and session pointer remain authoritative
    end
```
