### PR TITLE
fix(relay): persist sessions across restarts

### DIFF
--- a/.changeset/calm-session-catalog.md
+++ b/.changeset/calm-session-catalog.md
@@ -1,0 +1,8 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Persist named session identity and exact target ownership across relay process
+restarts while clearly resetting process-local JavaScript state and snapshot
+references. Allow handoffs to register before starting actions that may block on
+native WebAuthn or payment prompts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,9 @@ local Node relay.
   `ErrorEnvelope`; keep the relay message top-level while mapping tagged domain
   errors to stable codes and HTTP statuses.
 - Tie relay HTTP effects to the response lifetime with an `AbortSignal`.
-  Browser execute itself is uninterruptible at the underlying Playwright
-  Promise boundary so interruption cannot release its session permit while the
-  script still mutates the page.
+  Execute workers outlive an interrupted request once browser work starts;
+  retain the session permit through final journal and catalog writes so aborted
+  clients cannot lose aftermath bookkeeping or overlap later page mutations.
 - The CLI and MCP server talk to the relay only through the shared
   `src/relay-client.ts` service (`RelayClient.Service`), never through ad-hoc
   fetch/node:http calls. Failures are tagged errors that keep the relay's own
@@ -67,6 +67,13 @@ local Node relay.
   `~/.browser-control/session.json`; execute and adopt never use it implicitly.
   Invalid persisted session JSON is reported and preserved, never treated as an
   empty store that a later write may overwrite.
+- Relay session descriptors persist per port under
+  `~/.browser-control/relays/<port>/sessions.json`. After a relay restart,
+  restore session ids, read-only mode, and exact target ownership when that tab
+  reappears; JavaScript `state` and snapshot refs intentionally reset and warn.
+  Win the endpoint port before loading or writing this catalog. Successful
+  durable lifecycle operations await atomic replacement plus file and directory
+  sync. Corrupt catalogs fail relay startup and are never overwritten.
 - An extension RPC timeout fails only that command; the extension socket is
   closed only when a websocket-level ping probe also fails.
 - CDP guardrails are pure logic in `src/cdp-guardrails.ts`, enforced at the top
@@ -80,8 +87,14 @@ local Node relay.
   status directly from `chrome.debugger.onDetach`: the relay owns root-detach
   classification, and ambiguous `target_closed` events from extension child
   targets must preserve the handoff UI.
-- `TargetRegistry` is the sole production target-ownership authority. Session
-  state keeps only the adopted default-page pointer. Adoption reserves,
+- Handoff `start` actions run only after the waiter and WAIT UI are registered.
+  Require extension acknowledgement of WAIT before invoking `start`. Human
+  completion waits for the action to settle. Timeout or target cancellation
+  disconnects the sandbox before releasing its execute permit, preventing a
+  non-settling prompt action from mutating the page later. Cancel the waiter if
+  WAIT presentation or action startup fails.
+- `TargetRegistry` is the sole production live target-ownership authority.
+  Session state keeps one durable default-target identity and owner. Adoption reserves,
   commits, or rolls back registry ownership transactionally and reconciles CDP
   visibility, grouping, and page status for every changed target.
 - Same-tab root target generations are explicit replacements, never map
@@ -225,7 +238,7 @@ browser-control skill
 
 - Load `extension/dist` as the unpacked extension.
 - The relay listens on `127.0.0.1:19989` by default.
-- Current shim version is `0.0.17`.
+- Current shim version is `0.0.18`.
 - On socket open the shim sends `hello` and then re-announces every tab it still
   has `chrome.debugger` attached to (`debugger.attached` events), so a restarted
   relay rebuilds its target registry without the user re-clicking the toolbar.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,6 +83,13 @@ _Avoid_: Security sandbox, permission boundary
 The per-session `state` object that survives across multiple execute calls.
 _Avoid_: Browser storage, tab state
 
+**Session Catalog**:
+The endpoint-scoped, private relay file that preserves session identity,
+read-only mode, and the exact default-target pointer across relay processes.
+Lifecycle operations acknowledge only after its atomic replacement is durable.
+It does not serialize Execute Sandbox JavaScript state or snapshot refs.
+_Avoid_: Current-session store, session journal, sandbox snapshot
+
 **MCP Process Session**:
 The implicit persistent execute sandbox owned by one running MCP server process.
 _Avoid_: Explicit MCP session id
@@ -124,6 +131,8 @@ _Avoid_: Token value, hardcoded credential
 - An **Agent** controls the browser by running code in an **Execute Sandbox**.
 - An **Execute Sandbox** owns **Persistent State**; the Target Registry owns
   target assignment.
+- A **Session Catalog** restores session and target identity after relay restart;
+  the restored **Execute Sandbox** starts with empty **Persistent State**.
 - An **Execute Sandbox** owns at most one active **Network Capture**.
 - A **Capture Artifact** refers to values in a **Secret Profile** through
   **Stable Secret References**.

--- a/PLAN.md
+++ b/PLAN.md
@@ -167,7 +167,7 @@ require a new extension capture protocol and permission model.
   link`.
 - The browser extension remains unpacked for v1 and is loaded from
   the npm package's `extension/dist` directory or a source build. Its current
-  shim version is `0.0.17`.
+  shim version is `0.0.18`.
 - Extension source changes require rebuilding and reloading the unpacked
   extension. Relay-only changes do not.
 - Chrome Web Store distribution is deferred until behavior stabilizes. A
@@ -189,6 +189,10 @@ arbitrary tab from the attached pool.
 - The CLI never infers an agent's session from human-shell current state.
 - Human session-management commands store their endpoint-scoped current id in
   `~/.browser-control/session.json`.
+- The relay stores private session descriptors under
+  `~/.browser-control/relays/<port>/sessions.json`. Relay restart restores ids,
+  read-only mode, and exact target ownership when the tab reappears; JavaScript
+  `state` and snapshot refs reset with an explicit warning.
 - A session owns one default page. Relay-created pages persist across
   short-lived CLI connections.
 - `session adopt` makes an attached user tab the session's default page and
@@ -203,6 +207,10 @@ arbitrary tab from the attached pool.
 - Reset, delete, or detach releases an adopted tab without closing it.
 - Reset and delete acquire the execute permit before closing a sandbox, so they
   cannot interrupt a running script.
+- Corrupt session catalogs fail relay startup without being overwritten.
+- The relay wins the endpoint port before loading the catalog or enabling
+  catalog writes. Lifecycle responses wait for atomic file replacement, file
+  sync, and directory sync before acknowledging durable state.
 - Session-owned tabs share a purple `control` group within each browser window.
   Merely attached, unowned tabs stay in their existing location.
 - Explicit URL selection must match exactly one page. URL and index selectors
@@ -277,11 +285,17 @@ reconciles existing client announcements, browser grouping, and page status.
 
 - The extension toolbar attaches or detaches the active tab. A toolbar click
   cannot detach a tab while its session is executing or waiting for a handoff.
-- `handoff(message, { timeoutMs })` binds a waiter to the exact page target,
+- `handoff(message, { timeoutMs, start? })` binds a waiter to the exact page target,
   survives top-level navigation, and resumes only from the matching in-page
   completion control. The relay ignores ambiguous `target_closed` events from
   extension child targets, so the extension preserves the WAIT UI until the
   relay confirms a root detach or the tab is removed.
+- `start` registers WAIT state before invoking a prompt-triggering action, so
+  native WebAuthn or payment UI cannot block the script before handoff exists.
+  It runs only after the extension acknowledges WAIT. Human completion waits
+  for the action to settle; timeout or target cancellation disconnects the
+  sandbox's Playwright connection before releasing the execute permit, so a
+  non-settling action cannot mutate the page later.
 - Destructive browser-state CDP methods such as `Browser.close` and cookie or
   cache clearing are always blocked.
 - Read-only sessions additionally reject `Input.*`. They reduce trusted

--- a/README.md
+++ b/README.md
@@ -216,9 +216,24 @@ await page.getByRole("heading", { name: "Dashboard" }).waitFor()
 return page.url()
 ```
 
+If the click itself can block on native WebAuthn or payment UI, register the
+handoff before triggering it:
+
+```js
+await handoff("Complete the security-key prompt, then continue", {
+  timeoutMs: 600_000,
+  start: () => page.getByRole("button", { name: "Use security key" }).click({ timeout: 600_000 }),
+})
+```
+
 The page displays an accessible completion control and the script waits. Always
 verify the expected URL or element after the handoff; human acknowledgment does
-not prove that the requested step succeeded.
+not prove that the requested step succeeded. Browser Control waits for the
+extension to acknowledge WAIT before calling `start`. If the handoff times out
+or its target disappears first, it disconnects that sandbox's Playwright
+connection before releasing the execute permit, preventing a still-pending
+prompt action from mutating the page later. Keep `start` limited to the bounded
+browser action that opens the native prompt.
 
 ## Use Read-Only Sessions
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Browser Control",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Attach visible browser tabs to the local browser-control relay.",
   "permissions": ["activeTab", "alarms", "debugger", "offscreen", "tabs", "tabCapture", "tabGroups"],
   "host_permissions": ["<all_urls>"],

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -12,7 +12,7 @@ import { debuggerDetachedEvent } from "./debugger-detach.ts"
 
 const relayHost = "127.0.0.1"
 const relayPort = 19989
-const shimVersion = "0.0.17"
+const shimVersion = "0.0.18"
 const offscreenDocumentPath = "offscreen.html"
 
 let socket: WebSocket | undefined
@@ -276,7 +276,7 @@ async function handleCommand(command: ShimCommand): Promise<JsonObject> {
     if (!status) {
       throw new Error("Invalid page status")
     }
-    await sendPageStatusMessage(tabId, { action: "page-status.set", status })
+    await sendPageStatusMessage(tabId, { action: "page-status.set", status }, true)
     return {}
   }
   if (command.method === "pageStatus.clear") {
@@ -516,10 +516,11 @@ function handleRuntimeMessage(message: unknown, sender: chrome.runtime.MessageSe
   }
 }
 
-async function sendPageStatusMessage(tabId: number, message: JsonObject): Promise<void> {
+async function sendPageStatusMessage(tabId: number, message: JsonObject, required = false): Promise<void> {
   try {
     await chrome.tabs.sendMessage(tabId, message)
-  } catch {
+  } catch (error) {
+    if (required) throw error
     // Restricted pages do not accept content scripts. Visibility is best-effort
     // and must never interfere with debugger attachment or detachment.
   }

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -881,8 +881,8 @@ return { result: await page.locator('#class-result').textContent() }
     name: "handoff-navigation",
     run: Effect.fnUntraced(function* (page) {
       const extension = yield* fetchStatus()
-      if (extension.version !== "0.0.17") {
-        return yield* Effect.fail(new Error(`handoff-navigation requires the built 0.0.17 shim; connected extension is ${extension.version ?? "unknown"}`))
+      if (extension.version !== "0.0.18") {
+        return yield* Effect.fail(new Error(`handoff-navigation requires the built 0.0.18 shim; connected extension is ${extension.version ?? "unknown"}`))
       }
       const marker = `bc-handoff-${Date.now()}`
       const smokeSession = `${marker}-session`
@@ -926,8 +926,8 @@ return { result: await page.locator('#class-result').textContent() }
     name: "handoff-cross-tab",
     run: Effect.fnUntraced(function* (page) {
       const extension = yield* fetchStatus()
-      if (extension.version !== "0.0.17") {
-        return yield* Effect.fail(new Error(`handoff-cross-tab requires the built 0.0.17 shim; connected extension is ${extension.version ?? "unknown"}`))
+      if (extension.version !== "0.0.18") {
+        return yield* Effect.fail(new Error(`handoff-cross-tab requires the built 0.0.18 shim; connected extension is ${extension.version ?? "unknown"}`))
       }
       const marker = `bc-handoff-a-${Date.now()}`
       const peerMarker = `bc-handoff-b-${Date.now()}`

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -210,7 +210,7 @@ the page via JavaScript; read-only guards trusted mistakes, not malicious code.
 ## Human Handoff
 
 When a flow hits 2FA, CAPTCHAs, payment confirmation, or anything the user must
-do personally, call `handoff(message, { timeoutMs })` inside execute code. It
+do personally, call `handoff(message, { timeoutMs, start? })` inside execute code. It
 shows the message and an accessible **I'm done, continue** control in the page,
 blocks the script, and resumes only when the user activates that control. The
 WAIT UI survives top-level navigation and ambiguous extension child-target
@@ -228,6 +228,24 @@ if (!page.url().startsWith("https://app.example.com/")) {
 await page.getByRole("heading", { name: "Dashboard" }).waitFor()
 return await page.title()
 ```
+
+When the action itself may block on native WebAuthn, pass it as `start` so WAIT
+state is registered and acknowledged by the extension before the click. Keep
+the action timeout aligned with the handoff timeout and keep `start` limited to
+the browser action that opens the prompt:
+
+```js
+await handoff("Complete the security-key prompt, then continue", {
+  timeoutMs: 600_000,
+  start: () => page.getByRole("button", { name: "Use security key" }).click({ timeout: 600_000 }),
+})
+```
+
+After human completion, Browser Control waits for the action to settle before
+resuming. If the handoff times out or its target disappears while the action is
+still pending, Browser Control disconnects that session's Playwright connection
+before releasing the execute permit; the exact target remains the session
+default and is reacquired on the next execute.
 
 Tell the user what you need before or while the handoff is pending. Handoffs are
 counted in the result aftermath and recorded in the session journal. Human
@@ -341,6 +359,12 @@ same browser state. Use `browser-control session reset` or
 `browser-control session delete` to close a session-owned page and clear its
 state. Close manually attached tabs normally, call `await page.close()`, or detach
 with the toolbar when you want to release them.
+
+Named sessions survive relay process restarts. Browser Control restores the
+session id, read-only mode, and exact default tab when it reappears, but
+JavaScript `state` and snapshot refs are process-local and reset with a warning.
+Successful create, reset, delete, adopt, and execute responses wait for their
+session catalog update to commit.
 
 For multi-step UI tasks, prefer one `execute` block when the steps depend on
 transient page state such as selected rows, open menus, dialogs, hover state, or
@@ -609,11 +633,12 @@ language changes, update `CONTEXT.md` too.
 - Extension changes not taking effect: rebuild `extension/dist` and reload the
   unpacked extension once.
 - Repeated `hello` messages or in-flight RPC timeouts: check for duplicate shim
-  websocket reconnects. The current shim version is `0.0.17`.
+  websocket reconnects. The current shim version is `0.0.18`.
 - Relay restarted while tabs were attached: shim `0.0.7`+ re-announces attached
   tabs after reconnecting, so the relay rebuilds its target registry without
-  re-clicking the toolbar. If `activeTargets` stays 0 with an older shim,
-  reload the unpacked extension and re-attach.
+  re-clicking the toolbar. Named sessions reclaim the exact persisted target;
+  JavaScript state and snapshot refs reset. If `activeTargets` stays 0 with an
+  older shim, reload the unpacked extension and re-attach.
 - Stale relay build: operational CLI and MCP calls reject the relay before
   invoking a route. `status` and `doctor` remain observational. Source runs use
   a content fingerprint, so rebuilds and worktrees cannot silently share

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -18,6 +18,7 @@ import type { HandoffOutcome } from "./handoff.ts"
 import * as AuthProfile from "./auth-profile.ts"
 import * as NetworkCapture from "./network-capture.ts"
 import type { ExecuteAftermath, ExecuteLogEntry, ExecuteLogSummary, ExecuteMedia } from "./relay-schema.ts"
+import type { SessionTarget } from "./relay-types.ts"
 import { executionContextFailureDiagnostic, runtimeFailureKind } from "./runtime-diagnostics.ts"
 
 const nodeModules = { fs, path, os, crypto, url, util, events, stream, buffer, http, https, zlib }
@@ -221,6 +222,7 @@ type SandboxGlobals = {
 type HandoffCallOptions = {
   readonly timeoutMs?: number
   readonly page?: Page
+  readonly start?: () => unknown | Promise<unknown>
 }
 
 export type HandoffPageTarget = {
@@ -231,6 +233,8 @@ export type RequestHandoff = (options: {
   readonly message: string
   readonly timeoutMs: number
   readonly target: HandoffPageTarget
+  readonly start?: () => unknown | Promise<unknown>
+  readonly cancelStart?: () => Promise<void>
 }) => Promise<HandoffOutcome>
 
 const defaultHandoffTimeoutMs = 10 * 60 * 1_000
@@ -372,6 +376,7 @@ type ExecuteSandboxOptions = {
   readonly endpointUrl: string
   readonly sessionId?: string
   readonly requestHandoff?: RequestHandoff
+  readonly onDefaultTargetChange?: (target: SessionTarget | undefined) => void
 }
 
 export type ExecuteResult = {
@@ -417,6 +422,7 @@ export class ExecuteSandbox {
   private readonly snapshotRefs: SnapshotRefRegistry = { selectors: new Map() }
   private readonly networkCapture = new NetworkCapture.Recorder()
   private pendingWarnings: string[] = []
+  private boundPageClose: { readonly page: Page; readonly listener: () => void } | undefined
 
   constructor(readonly options: ExecuteSandboxOptions) {}
 
@@ -532,10 +538,12 @@ export class ExecuteSandbox {
       const ownsOpenPage = page !== undefined && sandbox.ownsPage && !page.isClosed()
       sandbox.browser = undefined
       sandbox.page = undefined
+      sandbox.clearPageListeners()
       sandbox.defaultPageTargetId = undefined
       sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
       sandbox.pendingPageTarget = undefined
+      sandbox.notifyDefaultTargetChange()
       yield* sandbox.networkCapture.cancel()
 
       if (ownsOpenPage) {
@@ -555,6 +563,49 @@ export class ExecuteSandbox {
     })
   }
 
+  disconnect(): Effect.Effect<void, Error> {
+    const sandbox = this
+    return Effect.gen(function* () {
+      const browser = sandbox.browser
+      sandbox.browser = undefined
+      sandbox.page = undefined
+      sandbox.clearPageListeners()
+      sandbox.pageHealthCheckRequired = false
+      if (sandbox.defaultPageTargetId) {
+        sandbox.pendingPageTarget = { targetId: sandbox.defaultPageTargetId, warnReplaced: false }
+      }
+      yield* sandbox.networkCapture.cancel()
+      if (browser) {
+        yield* runPlaywrightOperation({
+          label: "Disconnect sandbox browser during relay shutdown",
+          timeoutMs: playwrightCloseTimeoutMs,
+          run: () => browser.close(),
+        }).pipe(Effect.ignore)
+      }
+    })
+  }
+
+  disconnectSettled(): Effect.Effect<void, Error> {
+    const sandbox = this
+    return Effect.gen(function* () {
+      const browser = sandbox.browser
+      sandbox.browser = undefined
+      sandbox.page = undefined
+      sandbox.clearPageListeners()
+      sandbox.pageHealthCheckRequired = false
+      if (sandbox.defaultPageTargetId) {
+        sandbox.pendingPageTarget = { targetId: sandbox.defaultPageTargetId, warnReplaced: false }
+      }
+      yield* sandbox.networkCapture.cancel()
+      if (browser) {
+        yield* runSettledPlaywrightOperation({
+          label: "Disconnect sandbox browser after handoff cancellation",
+          run: () => browser.close(),
+        }).pipe(Effect.ignore)
+      }
+    })
+  }
+
   closeSettled(): Effect.Effect<void, Error> {
     const sandbox = this
     return Effect.gen(function* () {
@@ -563,10 +614,12 @@ export class ExecuteSandbox {
       const ownsOpenPage = page !== undefined && sandbox.ownsPage && !page.isClosed()
       sandbox.browser = undefined
       sandbox.page = undefined
+      sandbox.clearPageListeners()
       sandbox.defaultPageTargetId = undefined
       sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
       sandbox.pendingPageTarget = undefined
+      sandbox.notifyDefaultTargetChange()
       yield* sandbox.networkCapture.cancel()
 
       if (ownsOpenPage) {
@@ -633,14 +686,13 @@ export class ExecuteSandbox {
         currentPageIsSelected: currentPage === selected,
         currentPageIsClosed: currentPage?.isClosed() ?? true,
       }) && currentPage) {
+        sandbox.page = undefined
         yield* runSettledPlaywrightOperation({
           label: "Close the previous session page during adoption",
           run: () => currentPage.close(),
         }).pipe(Effect.ignore)
       }
-      sandbox.page = selected
-      sandbox.defaultPageTargetId = target.targetId
-      sandbox.ownsPage = false
+      sandbox.bindDefaultPage(selected, target.targetId, false, false)
       sandbox.pageHealthCheckRequired = false
       sandbox.pendingPageTarget = undefined
       sandbox.networkCapture.bindPage(selected)
@@ -704,6 +756,8 @@ export class ExecuteSandbox {
         message: handoffMessage,
         timeoutMs,
         target: { targetId },
+        ...(options?.start ? { start: options.start } : {}),
+        ...(options?.start ? { cancelStart: () => Effect.runPromise(this.disconnectSettled()) } : {}),
       })
       if (outcome === "timeout") {
         throw new Error(`Handoff timed out after ${timeoutMs}ms waiting for the user: ${handoffMessage}`)
@@ -758,6 +812,7 @@ export class ExecuteSandbox {
     if (this.defaultPageTargetId !== targetId) {
       return false
     }
+    this.clearPageListeners()
     this.page = undefined
     this.defaultPageTargetId = undefined
     this.ownsPage = false
@@ -772,12 +827,70 @@ export class ExecuteSandbox {
 
   markTargetReplaced(previousTargetId: string, targetId: string): boolean {
     if (this.defaultPageTargetId !== previousTargetId) return false
+    this.clearPageListeners()
     this.page = undefined
     this.defaultPageTargetId = targetId
     this.pageHealthCheckRequired = false
     this.pendingPageTarget = { targetId, warnReplaced: true }
     this.networkCapture.bindPage(undefined)
     return true
+  }
+
+  restore(target: SessionTarget | undefined): void {
+    if (target) {
+      this.defaultPageTargetId = target.id
+      this.ownsPage = target.owner === "relay"
+      this.pendingPageTarget = { targetId: target.id, warnReplaced: false }
+    }
+    this.pendingWarnings.push("The relay restarted; session JavaScript state and snapshot refs were reset.")
+  }
+
+  private notifyDefaultTargetChange(): void {
+    this.options.onDefaultTargetChange?.(this.defaultPageTargetId
+      ? { id: this.defaultPageTargetId, owner: this.ownsPage ? "relay" : "user" }
+      : undefined)
+  }
+
+  private bindDefaultPage(page: Page, targetId: string | undefined, ownsPage: boolean, notify: boolean): void {
+    this.clearPageListeners()
+    this.page = page
+    this.defaultPageTargetId = targetId
+    this.ownsPage = ownsPage
+    const listener = () => {
+      if (this.boundPageClose?.page === page) this.boundPageClose = undefined
+      if (this.page !== page) return
+      this.page = undefined
+      this.defaultPageTargetId = undefined
+      this.ownsPage = false
+      this.pendingPageTarget = undefined
+      this.networkCapture.bindPage(undefined)
+      this.clearSnapshotRefs()
+      this.notifyDefaultTargetChange()
+    }
+    this.boundPageClose = { page, listener }
+    page.once("close", listener)
+    if (notify) this.notifyDefaultTargetChange()
+  }
+
+  private clearBoundPageClose(): void {
+    const bound = this.boundPageClose
+    if (!bound) return
+    bound.page.off("close", bound.listener)
+    this.boundPageClose = undefined
+  }
+
+  private clearSnapshotRefs(): void {
+    this.snapshotRefs.removeNavigationListener?.()
+    delete this.snapshotRefs.removeNavigationListener
+    this.snapshotRefs.selectors.clear()
+    delete this.snapshotRefs.page
+    delete this.snapshotRefs.url
+    delete this.snapshotRefs.previousSnapshot
+  }
+
+  private clearPageListeners(): void {
+    this.clearBoundPageClose()
+    this.clearSnapshotRefs()
   }
 
   getStatus(): { readonly sessionId?: string; readonly connected: boolean; readonly pageUrl: string | null; readonly stateKeys: string[] } {
@@ -861,7 +974,7 @@ export class ExecuteSandbox {
           cause: new Error(`Session page target unavailable: ${targetId}`),
         })
       }
-      this.page = replacement
+      this.bindDefaultPage(replacement, targetId, this.ownsPage, false)
       this.pendingPageTarget = undefined
       if (pendingTarget.warnReplaced) this.pendingWarnings.push(defaultPageReplacedWarning)
       return replacement
@@ -889,6 +1002,7 @@ export class ExecuteSandbox {
         this.defaultPageTargetId = undefined
         this.ownsPage = false
         this.pageHealthCheckRequired = false
+        this.notifyDefaultTargetChange()
         this.pendingWarnings.push(defaultPageRecoveredWarning)
       } else {
         return this.page
@@ -896,12 +1010,14 @@ export class ExecuteSandbox {
     }
     if (this.page?.isClosed()) {
       this.defaultPageTargetId = undefined
+      this.ownsPage = false
+      this.notifyDefaultTargetChange()
       this.pendingWarnings.push(defaultPageClosedWarning)
     }
-    this.page = await context.newPage()
-    this.defaultPageTargetId = await resolvePageTargetId(this.page)
-    this.ownsPage = true
-    return this.page
+    const page = await context.newPage()
+    const targetId = await resolvePageTargetId(page)
+    this.bindDefaultPage(page, targetId, true, true)
+    return page
   }
 }
 

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -29,6 +29,46 @@ export type HandoffWait = {
   readonly outcome: Promise<HandoffOutcome>
 }
 
+export async function awaitHandoffAction(options: {
+  readonly outcome: Promise<HandoffOutcome>
+  readonly present?: () => Promise<void>
+  readonly start?: () => unknown | Promise<unknown>
+  readonly cancel: () => void
+  readonly cancelStart?: () => Promise<void>
+}): Promise<HandoffOutcome> {
+  const outcome = options.outcome.then((value) => ({ type: "handoff-completed" as const, value }))
+  if (options.present) {
+    const presentation = options.present().then(
+      () => ({ type: "presented" as const }),
+      (error: unknown) => ({ type: "presentation-failed" as const, error }),
+    )
+    const first = await Promise.race([presentation, outcome])
+    if (first.type === "handoff-completed") return first.value
+    if (first.type === "presentation-failed") {
+      options.cancel()
+      throw first.error
+    }
+  }
+  if (!options.start) return await options.outcome
+  const action = Promise.resolve().then(options.start).then(
+    () => ({ type: "action-completed" as const }),
+    (error: unknown) => ({ type: "action-failed" as const, error }),
+  )
+  const first = await Promise.race([action, outcome])
+  if (first.type === "action-failed") {
+    options.cancel()
+    throw first.error
+  }
+  if (first.type === "action-completed") return await options.outcome
+  if (first.value === "resolved" || !options.cancelStart) {
+    const actionResult = await action
+    if (actionResult.type === "action-failed") throw actionResult.error
+  } else {
+    await options.cancelStart()
+  }
+  return first.value
+}
+
 export type PendingHandoffView = {
   readonly id: string
   readonly sessionId: string
@@ -115,6 +155,13 @@ export class HandoffRegistry {
       return false
     }
     pending.resolve("resolved")
+    return true
+  }
+
+  cancel(id: string): boolean {
+    const pending = Array.from(this.pending.values()).find((candidate) => candidate.id === id)
+    if (!pending) return false
+    pending.resolve("timeout")
     return true
   }
 

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -302,7 +302,7 @@ function handleCliRequest(options: {
     if (options.pathname === "/cli/session/new" && options.request.method === "POST") {
       const body = yield* readJsonBody(options.request)
       const request = yield* decodeRequest(SessionNewRequest, body, "session new")
-      const session = options.sessions.createNew(optionalSessionId(request.id), { readOnly: request.readOnly === true })
+      const session = yield* options.sessions.create(optionalSessionId(request.id), { readOnly: request.readOnly === true })
       sendJson(options.response, { session: options.sessions.summary(session.id) })
       return
     }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -44,7 +44,7 @@ function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSess
       name: "execute",
       description: "Execute trusted Playwright JavaScript against the Browser Control session. The result includes console logs, warnings, a bounded execution-context diagnostic when relevant, and an aftermath summary (URL movement, navigations, error counts, handoffs).",
       inputSchema: objectSchema({
-        code: { type: "string", description: "JavaScript code to execute. It receives browser, context, page, state, modules, fillInput, fillInputs, snapshot(options?) for a compact semantic outline or explicit diff against the previous snapshot, ref(id) for the latest snapshot's locator, screenshotWithLabels, ariaSnapshot(target?, { timeout }), ghostCursor (show/hide), and handoff(message, { timeoutMs })." },
+        code: { type: "string", description: "JavaScript code to execute. It receives browser, context, page, state, modules, fillInput, fillInputs, snapshot(options?) for a compact semantic outline or explicit diff against the previous snapshot, ref(id) for the latest snapshot's locator, screenshotWithLabels, ariaSnapshot(target?, { timeout }), ghostCursor (show/hide), and handoff(message, { timeoutMs, start? })." },
         session: { type: "string", description: "Optional existing Browser Control session id. Explicit ids must already exist; omit this field to use the MCP server's current session, which is created when needed." },
         targetUrl: { type: "string", description: "Optional URL substring selecting an existing attached page. This does not navigate or open a URL; use page.goto() for that." },
         targetIndex: { type: "integer", minimum: 0, description: "Optional zero-based attached page index selector." },

--- a/src/relay-helpers.ts
+++ b/src/relay-helpers.ts
@@ -278,7 +278,7 @@ export function optionalSessionId(value: JsonObject[string] | undefined): string
     return undefined
   }
   const id = value.trim()
-  if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(id)) {
+  if (!isValidSessionId(id)) {
     throw new HttpRouteError({
       message: "Session ids must use lowercase letters, numbers, and dashes, and be at most 63 characters",
       status: 400,
@@ -286,6 +286,10 @@ export function optionalSessionId(value: JsonObject[string] | undefined): string
     })
   }
   return id
+}
+
+export function isValidSessionId(id: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{0,62}$/.test(id)
 }
 
 export function requiredSessionId(value: JsonObject[string] | undefined): string {

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -52,18 +52,19 @@ export const ensureRelay = Effect.fn("RelayLifecycle.ensureRelay")(function* (op
     const buildProblem = relayBuildProblem(initial.success, buildId)
     return { version: initial.success, started: false, ...(buildProblem ? { buildProblem } : {}) } satisfies RelayReadiness
   }
-  if (!isRelayUnreachable(initial.failure)) {
+  const relayWasAbsent = isRelayUnreachable(initial.failure)
+  if (!relayWasAbsent && !isRelayStarting(initial.failure)) {
     return yield* Effect.fail(initial.failure)
   }
 
-  yield* options.start ?? spawnManagedRelay()
+  if (relayWasAbsent) yield* options.start ?? spawnManagedRelay()
   const version = yield* probe.pipe(
     Effect.retry({
       times: options.retryTimes ?? 40,
       schedule: Schedule.spaced(options.retryDelayMs ?? 50),
-      while: isRelayUnreachable,
+      while: isRelayStartingOrUnreachable,
     }),
-    Effect.mapError((error) => isRelayUnreachable(error)
+    Effect.mapError((error) => isRelayStartingOrUnreachable(error)
       ? new RelayStartFailed({
         message: `Browser Control relay did not start at ${options.relay.endpoint}`,
         endpoint: options.relay.endpoint,
@@ -72,7 +73,7 @@ export const ensureRelay = Effect.fn("RelayLifecycle.ensureRelay")(function* (op
       : error),
   )
   const buildProblem = relayBuildProblem(version, buildId)
-  return { version, started: true, ...(buildProblem ? { buildProblem } : {}) } satisfies RelayReadiness
+  return { version, started: relayWasAbsent, ...(buildProblem ? { buildProblem } : {}) } satisfies RelayReadiness
 })
 
 export const ensureExtensionConnected = Effect.fn("RelayLifecycle.ensureExtensionConnected")(function* (options: {
@@ -95,7 +96,7 @@ export const ensureExtensionConnected = Effect.fn("RelayLifecycle.ensureExtensio
     Effect.retry({
       times: options.retryTimes ?? 40,
       schedule: Schedule.spaced(options.retryDelayMs ?? 50),
-      while: (error) => error instanceof ExtensionDisconnected || isRelayUnreachable(error),
+      while: (error) => error instanceof ExtensionDisconnected || isRelayStartingOrUnreachable(error),
     }),
   )
 })
@@ -148,4 +149,12 @@ export function managedRelayEntrypoint(entrypoint: string): string {
 
 function isRelayUnreachable(error: unknown): error is RelayClient.RelayUnreachable {
   return error instanceof RelayClient.RelayUnreachable
+}
+
+function isRelayStarting(error: unknown): error is RelayClient.RelayRejected {
+  return error instanceof RelayClient.RelayRejected && error.code === "relay-starting"
+}
+
+function isRelayStartingOrUnreachable(error: unknown): error is RelayClient.RelayRejected | RelayClient.RelayUnreachable {
+  return isRelayStarting(error) || isRelayUnreachable(error)
 }

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -373,6 +373,7 @@ export interface RecordingCancelResponse extends Schema.Schema.Type<typeof Recor
 
 export const RelayErrorCode = Schema.Literals([
   "invalid-request",
+  "relay-starting",
   "auth-profile-not-found",
   "capture-conflict",
   "session-already-exists",

--- a/src/relay-types.ts
+++ b/src/relay-types.ts
@@ -3,6 +3,10 @@ import type { AdoptTarget, ExecuteOptions, ExecuteResult } from "./execute.ts"
 import type { NetworkCaptureOptions, NetworkCaptureResult, NetworkCaptureStatus, NetworkCaptureStopOptions } from "./network-capture.ts"
 import type { JsonObject, TargetInfo } from "./protocol.ts"
 import type { SessionSummary } from "./relay-schema.ts"
+export type SessionTarget = {
+  readonly id: string
+  readonly owner: "relay" | "user"
+}
 
 export type ConnectedTarget = {
   readonly tabId: number
@@ -47,6 +51,10 @@ export interface ExecuteSandboxLike {
   execute(code: string, options?: ExecuteOptions): Effect.Effect<ExecuteResult>
   adoptPage(target: AdoptTarget): Effect.Effect<string, Error>
   close(): Effect.Effect<void, Error>
+  /** Relay shutdown disconnects Playwright without closing or forgetting the default tab. */
+  disconnect(): Effect.Effect<void, Error>
+  /** Handoff cancellation waits for Playwright disconnection before releasing the execute permit. */
+  disconnectSettled(): Effect.Effect<void, Error>
   /** Adoption rollback cleanup does not settle before started Playwright close promises settle. */
   closeSettled(): Effect.Effect<void, Error>
   networkStart(options?: NetworkCaptureOptions): Effect.Effect<NetworkCaptureStatus, Error>
@@ -58,6 +66,7 @@ export interface ExecuteSandboxLike {
   markTargetCrashed(targetId: string): boolean
   markTargetDetached(targetId: string): boolean
   markTargetReplaced(previousTargetId: string, targetId: string): boolean
+  restore(target: SessionTarget | undefined): void
   getStatus(): {
     readonly sessionId?: string
     readonly connected: boolean
@@ -72,8 +81,8 @@ export type BrowserControlSession = {
   readonly readOnly: boolean
   readonly sandbox: ExecuteSandboxLike
   readonly executeSemaphore: Semaphore.Semaphore
-  /** The adopted default-page pointer. Target ownership lives in TargetRegistry. */
-  adoptedTargetId?: string
+  /** Durable default-target identity. Authoritative live ownership remains in TargetRegistry. */
+  target?: SessionTarget
   updatedAt: string
 }
 

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -42,6 +42,7 @@ import type { ChildTarget, ConnectedTarget } from "./relay-types.ts"
 import { ghostCursorClientSource, ghostCursorMouseActionExpression, ghostCursorRestoreExpression, inputDispatchMouseEventToGhostCursorAction } from "./ghost-cursor.ts"
 import { guardCdpMethod } from "./cdp-guardrails.ts"
 import {
+  awaitHandoffAction,
   HandoffRegistry,
   resolveExactHandoffTarget,
   toolbarClickAction,
@@ -51,6 +52,7 @@ import {
 import { ExecuteSandbox, type HandoffPageTarget } from "./execute.ts"
 import { makePageStatus } from "./page-status.ts"
 import { appendJournalEntry, defaultJournalBaseDir, makeJournalEntry } from "./session-journal.ts"
+import { defaultSessionCatalogPath, SessionCatalog } from "./session-catalog.ts"
 import { BrowserControlSessions } from "./session-manager.ts"
 import { RecordingRelay } from "./recording-relay.ts"
 import { appendManagedRelayProcessLog } from "./relay-log.ts"
@@ -59,7 +61,11 @@ import { resolveTargetInfoTarget, shouldExposeChildTarget, TargetRegistry, type 
 
 export type { RelayServer } from "./relay-types.ts"
 
-export const startRelay = Effect.fn("Relay.start")(function* (options: { readonly host?: string; readonly port?: number } = {}) {
+export const startRelay = Effect.fn("Relay.start")(function* (options: {
+  readonly host?: string
+  readonly port?: number
+  readonly sessionCatalogPath?: string | null
+} = {}) {
   yield* installRelayProcessGuard
   return yield* Effect.acquireRelease(makeRelay(options), (server) => {
     return server.close()
@@ -129,11 +135,19 @@ function debugEnvironmentEnabled(value: string | undefined): boolean {
   return value !== undefined && ["1", "true", "yes", "on"].includes(value.toLowerCase())
 }
 
-const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string; readonly port?: number } = {}) {
+const makeRelay = Effect.fnUntraced(function* (options: {
+  readonly host?: string
+  readonly port?: number
+  readonly sessionCatalogPath?: string | null
+} = {}) {
   const host = options.host ?? defaultHost
   const port = options.port ?? defaultPort
   const browserId = crypto.randomUUID()
   const endpointUrl = `http://${formatHostForUrl(host)}:${port}`
+  const sessionCatalog = options.sessionCatalogPath === null
+    ? undefined
+    : new SessionCatalog(options.sessionCatalogPath ?? defaultSessionCatalogPath(port))
+  let catalogWritesEnabled = false
   const registry = new TargetRegistry()
   const rootLifecycleSemaphores = new Map<number, Semaphore.Semaphore>()
   type RootReconciliationWorker = {
@@ -205,6 +219,15 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     Effect.runPromise(Effect.ignore(sendToExtension({ method: "action.setBadge", params: { tabId: target.tabId, ...badge } }))).catch(() => {})
     sendPageStatus(target, state, options)
   }
+  const setActivityForTargetAcknowledged = async (
+    target: ConnectedTarget,
+    state: PageStatus["state"],
+    badge: { readonly text: string; readonly color: string; readonly title: string },
+    options: { readonly sessionId?: string; readonly message?: string; readonly handoffId?: string } = {},
+  ): Promise<void> => {
+    Effect.runPromise(Effect.ignore(sendToExtension({ method: "action.setBadge", params: { tabId: target.tabId, ...badge } }))).catch(() => {})
+    await Effect.runPromise(sendPageStatusEffect(target, state, options))
+  }
   const removeActiveHandoffTab = (sessionId: string, tabId: number): void => {
     const tabIds = activeHandoffTabs.get(sessionId)
     if (!tabIds) {
@@ -230,6 +253,8 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     readonly message: string
     readonly timeoutMs: number
     readonly target: HandoffPageTarget
+    readonly start?: () => unknown | Promise<unknown>
+    readonly cancelStart?: () => Promise<void>
   }): Promise<HandoffOutcome> => {
     const target = resolveHandoffTarget(options.sessionId, options.target)
     const sessionTabs = activeHandoffTabs.get(options.sessionId) ?? new Set<number>()
@@ -243,15 +268,26 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       message: options.message,
       timeoutMs: options.timeoutMs,
     })
-    setActivityForTarget(target, "waiting", waitingBadge(options.message), {
-      sessionId: options.sessionId,
-      message: options.message,
-      handoffId: wait.id,
-    })
     let outcome: HandoffOutcome | undefined
     try {
-      outcome = await wait.outcome
+      outcome = await awaitHandoffAction({
+        outcome: wait.outcome,
+        present: () => setActivityForTargetAcknowledged(target, "waiting", waitingBadge(options.message), {
+          sessionId: options.sessionId,
+          message: options.message,
+          handoffId: wait.id,
+        }),
+        ...(options.start ? { start: options.start } : {}),
+        ...(options.cancelStart ? { cancelStart: options.cancelStart } : {}),
+        cancel: () => {
+          handoffs.cancel(wait.id)
+        },
+      })
       return outcome
+    } catch (error) {
+      handoffs.cancel(wait.id)
+      removeActiveHandoffTab(options.sessionId, target.tabId)
+      throw error
     } finally {
       if (outcome !== undefined && outcome !== "resolved" && outcome !== "timeout") {
         removeActiveHandoffTab(options.sessionId, target.tabId)
@@ -273,7 +309,17 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       new ExecuteSandbox({
         endpointUrl,
         sessionId: id,
-        requestHandoff: ({ message, timeoutMs, target }) => requestHandoff({ sessionId: id, message, timeoutMs, target }),
+        onDefaultTargetChange: (target) => {
+          sessions.updateTarget(id, target)
+        },
+        requestHandoff: ({ message, timeoutMs, target, start, cancelStart }) => requestHandoff({
+          sessionId: id,
+          message,
+          timeoutMs,
+          target,
+          ...(start ? { start } : {}),
+          ...(cancelStart ? { cancelStart } : {}),
+        }),
       }),
     {
       onExecuteStateChange: (sessionId, executing) => {
@@ -303,17 +349,23 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
           diagnostic: record.result.diagnostic,
           handoffs: record.result.aftermath?.handoffs,
         })
-        void appendJournalEntry({ baseDir: journalBaseDir, entry }).catch((error: unknown) => {
-          console.error("Failed to append session journal entry", error)
-        })
+        return appendJournalEntry({ baseDir: journalBaseDir, entry })
       },
       onTargetOwnershipChange: (change) => {
         reconcileTargetOwnership(change)
       },
+      onReleaseRelayTarget: (targetId) => {
+        const target = registry.targetsByTargetId.get(targetId)
+        return target
+          ? sendToExtension({ method: "tabs.remove", params: { tabId: target.tabId } }).pipe(Effect.asVoid)
+          : Effect.fail(new Error(`Relay-owned target ${targetId} has not re-announced yet; retry after the extension reconnects`))
+      },
+      onSessionsChanged: async (entries) => {
+        if (catalogWritesEnabled) await sessionCatalog?.save(entries)
+      },
     },
     registry,
   )
-
   function pageStatusSessionId(target: ConnectedTarget): string | undefined {
     return target.browserControlSessionId
   }
@@ -336,11 +388,11 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     })
   }
 
-  function sendPageStatus(
+  function sendPageStatusEffect(
     target: ConnectedTarget,
     state: PageStatus["state"],
     options: { readonly sessionId?: string; readonly message?: string; readonly handoffId?: string } = {},
-  ): void {
+  ): Effect.Effect<void, Error> {
     const sessionId = options.sessionId ?? pageStatusSessionId(target)
     const status = makePageStatus({
       state,
@@ -349,7 +401,7 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       ...(options.message ? { message: options.message } : {}),
       ...(options.handoffId ? { handoffId: options.handoffId } : {}),
     })
-    Effect.runPromise(Effect.ignore(sendToExtension({
+    return sendToExtension({
       method: "pageStatus.set",
       params: {
         tabId: target.tabId,
@@ -362,7 +414,15 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
           ...(status.handoffId ? { handoffId: status.handoffId } : {}),
         },
       },
-    }))).catch(() => {})
+    }).pipe(Effect.asVoid)
+  }
+
+  function sendPageStatus(
+    target: ConnectedTarget,
+    state: PageStatus["state"],
+    options: { readonly sessionId?: string; readonly message?: string; readonly handoffId?: string } = {},
+  ): void {
+    Effect.runPromise(Effect.ignore(sendPageStatusEffect(target, state, options))).catch(() => {})
   }
 
   function refreshPageStatus(tabId: number): void {
@@ -385,7 +445,7 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     const method = target && pageStatusSessionId(target) ? "tabs.group" : "tabs.ungroup"
     Effect.runPromise(Effect.ignore(sendToExtension({ method, params: { tabId } }))).catch(() => {})
   }
-  const httpServer = http.createServer(createHttpRequestHandler({
+  const relayRequestHandler = createHttpRequestHandler({
     host,
     port,
     browserId,
@@ -396,7 +456,16 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     extensionStatus: () => {
       return { connected: extensionRpc.connected, version: extensionRpc.version ?? null, cdpClients: cdpClients.size }
     },
-  }))
+  })
+  let relayReady = false
+  const httpServer = http.createServer((request, response) => {
+    if (!relayReady) {
+      response.writeHead(503, { "content-type": "application/json; charset=utf-8", "retry-after": "1" })
+      response.end(JSON.stringify({ error: "Browser Control relay is starting", code: "relay-starting" }))
+      return
+    }
+    relayRequestHandler(request, response)
+  })
 
   const debugEnabled = yield* Config.boolean("BROWSER_CONTROL_DEBUG").pipe(Config.withDefault(false))
   const debugLog = debugEnabled ? (line: string) => console.error(`[bc ${new Date().toISOString().slice(11, 23)}] ${line}`) : undefined
@@ -490,6 +559,10 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
   })
 
   httpServer.on("upgrade", (request, socket, head) => {
+    if (!relayReady) {
+      sendUpgradeError({ socket, status: 404, message: "Browser Control relay is starting" })
+      return
+    }
     const hostError = validateHostHeader({ hostHeader: request.headers.host, host, port })
     if (hostError) {
       sendUpgradeError({ socket, status: 403, message: hostError })
@@ -542,7 +615,6 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
           void recordingRelay.cleanupAll("Extension disconnected").catch(() => {})
           for (const target of registry.listRootTargets()) {
             cancelTargetHandoffs(target, "target-detached")
-            sessions.releaseAdoptedTarget(target.targetInfo.targetId)
           }
           registry.clear()
           suppressedChildSessions.clear()
@@ -1222,13 +1294,17 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     if (!targetInfo) {
       return yield* Effect.fail(new Error("Target.getTargetInfo did not return targetInfo"))
     }
+    const restoredTarget = options.browserControlSessionId
+      ? undefined
+      : sessions.persistedTargetOwner(targetInfo.targetId)
+    const browserControlSessionId = options.browserControlSessionId ?? restoredTarget?.sessionId
     const sessionId = `bc-tab-${nextTargetSessionId++}`
     const candidate: ConnectedTarget = {
       tabId,
       sessionId,
       targetInfo,
-      owner: options.owner,
-      ...(options.browserControlSessionId ? { browserControlSessionId: options.browserControlSessionId } : {}),
+      owner: restoredTarget?.owner ?? options.owner,
+      ...(browserControlSessionId ? { browserControlSessionId } : {}),
     }
     return yield* finishAttachedTarget(registry.stageRootTarget(candidate))
   })
@@ -1448,7 +1524,6 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
     }
     cancelTargetHandoffs(detached.target, "target-detached")
     sessions.markTargetDetached(detached.target.targetInfo.targetId)
-    sessions.releaseAdoptedTarget(detached.target.targetInfo.targetId)
     removeClientTargetAliases(cdpClientSessionAliases.values(), (alias) => alias.tabId === tabId)
     mainFrameIdsByTab.delete(tabId)
     ghostCursorPositionsByTab.delete(tabId)
@@ -1682,6 +1757,25 @@ const makeRelay = Effect.fnUntraced(function* (options: { readonly host?: string
       return yield* Effect.fail(error)
     })
   })
+
+  yield* Effect.catch(
+    Effect.gen(function* () {
+      const restoredSessions = yield* Effect.tryPromise({
+        try: () => sessionCatalog?.load() ?? Promise.resolve([]),
+        catch: (cause) => cause instanceof Error ? cause : new Error("Load Browser Control session catalog", { cause }),
+      })
+      yield* Effect.try({
+        try: () => sessions.restore(restoredSessions),
+        catch: (cause) => cause instanceof Error ? cause : new Error("Restore Browser Control sessions", { cause }),
+      })
+      catalogWritesEnabled = true
+      relayReady = true
+    }),
+    (error) => Effect.gen(function* () {
+      yield* cleanup()
+      return yield* Effect.fail(error)
+    }),
+  )
 
   return {
     url: endpointUrl,

--- a/src/session-catalog.ts
+++ b/src/session-catalog.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import crypto from "node:crypto"
+import { Schema } from "effect"
+import { isValidSessionId } from "./relay-helpers.ts"
+
+export const PersistedSession = Schema.Struct({
+  id: Schema.String,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  readOnly: Schema.Boolean,
+  target: Schema.optionalKey(Schema.Struct({
+    id: Schema.String,
+    owner: Schema.Literals(["relay", "user"]),
+  })),
+})
+
+export type PersistedSession = Schema.Schema.Type<typeof PersistedSession>
+
+const Catalog = Schema.Struct({
+  version: Schema.Literal(1),
+  sessions: Schema.Array(PersistedSession),
+})
+
+export function defaultSessionCatalogPath(port: number, home = os.homedir()): string {
+  return path.join(home, ".browser-control", "relays", String(port), "sessions.json")
+}
+
+export class SessionCatalog {
+  constructor(readonly filePath: string) {}
+
+  async load(): Promise<readonly PersistedSession[]> {
+    let text: string
+    try {
+      text = await fs.readFile(this.filePath, "utf8")
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") return []
+      throw new Error(`Could not read Browser Control session catalog at ${this.filePath}`, { cause: error })
+    }
+    try {
+      const sessions = Schema.decodeUnknownSync(Catalog)(JSON.parse(text)).sessions
+      const invalid = sessions.find((session) => !isValidSessionId(session.id))
+      if (invalid) throw new Error(`Invalid persisted session id: ${invalid.id}`)
+      return sessions
+    } catch (error) {
+      const detail = error instanceof Error && error.message ? `: ${error.message}` : ""
+      throw new Error(`Could not decode Browser Control session catalog at ${this.filePath}${detail}`, { cause: error })
+    }
+  }
+
+  async save(sessions: readonly PersistedSession[]): Promise<void> {
+    const directory = path.dirname(this.filePath)
+    const temporaryPath = `${this.filePath}.${process.pid}.${crypto.randomUUID()}.tmp`
+    const contents = `${JSON.stringify({ version: 1, sessions }, null, 2)}\n`
+    let temporaryFile: fs.FileHandle | undefined
+    let renamed = false
+    try {
+      await fs.mkdir(directory, { recursive: true, mode: 0o700 })
+      await fs.chmod(directory, 0o700)
+      temporaryFile = await fs.open(temporaryPath, "wx", 0o600)
+      await temporaryFile.writeFile(contents, "utf8")
+      await temporaryFile.sync()
+      await temporaryFile.close()
+      temporaryFile = undefined
+      await fs.rename(temporaryPath, this.filePath)
+      renamed = true
+      const directoryHandle = await fs.open(directory, "r")
+      try {
+        await directoryHandle.sync()
+      } finally {
+        await directoryHandle.close()
+      }
+    } catch (error) {
+      if (renamed) {
+        try {
+          if (await fs.readFile(this.filePath, "utf8") === contents) return
+        } catch {}
+      }
+      try {
+        await temporaryFile?.close()
+        await fs.rm(temporaryPath, { force: true })
+      } catch {}
+      throw new Error(`Could not write Browser Control session catalog at ${this.filePath}`, { cause: error })
+    }
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error
+}

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1,8 +1,9 @@
-import { Deferred, Effect, Option, Schema, Semaphore } from "effect"
+import { Deferred, Effect, Fiber, Option, Schema, Semaphore } from "effect"
 import { defaultPageClosedWarning, ExecuteSandbox, hasExplicitTargetSelection, type ExecuteResult, type ExecuteTargetSelection } from "./execute.ts"
 import type { NetworkCaptureOptions, NetworkCaptureResult, NetworkCaptureStatus, NetworkCaptureStopOptions } from "./network-capture.ts"
 import { generateSessionId } from "./relay-helpers.ts"
-import type { BrowserControlSession, ExecuteSandboxLike, SessionSummary } from "./relay-types.ts"
+import type { BrowserControlSession, ExecuteSandboxLike, SessionSummary, SessionTarget } from "./relay-types.ts"
+import type { PersistedSession } from "./session-catalog.ts"
 import {
   MemoryTargetOwnership,
   type TargetOwnership,
@@ -20,14 +21,20 @@ export type SessionExecuteRecord = {
 export type SessionHooks = {
   /** Called when a session starts (true) or finishes (false) an execute. */
   readonly onExecuteStateChange?: (sessionId: string, executing: boolean) => void
-  /** Called after each execute completes, for journaling. Must not throw. */
-  readonly onExecuteRecord?: (record: SessionExecuteRecord) => void
+  /** Called after each execute completes, for journaling. Failure is logged and ignored. */
+  readonly onExecuteRecord?: (record: SessionExecuteRecord) => unknown | Promise<unknown>
   /** How long lifecycle commands wait for a permit or sandbox operation. */
   readonly lifecycleTimeoutMs?: number
+  /** Maximum time best-effort journal I/O may retain an execute permit. */
+  readonly journalTimeoutMs?: number
   /** Current user-owned attached page URLs, used for relay-side adoption hints. */
   readonly getUserAttachedPageUrls?: () => readonly string[]
   /** Reconcile relay visibility and presentation after authoritative ownership changes. */
   readonly onTargetOwnershipChange?: (change: TargetOwnershipChange) => void
+  /** Close a live relay-owned target by its durable target id. */
+  readonly onReleaseRelayTarget?: (targetId: string) => Effect.Effect<void, Error>
+  /** Persist session identity and target continuity after durable lifecycle changes. */
+  readonly onSessionsChanged?: (sessions: readonly PersistedSession[]) => unknown | Promise<unknown>
 }
 
 export class SessionError extends Schema.TaggedErrorClass<SessionError>()(
@@ -77,6 +84,7 @@ export class BrowserControlSessions {
   private readonly executing = new Set<string>()
   private readonly adoptSemaphore = Semaphore.makeUnsafe(1)
   private readonly targetOwnership: TargetOwnership
+  private persistenceTail = Promise.resolve()
   private closing = false
   private userAttachedPageUrlsProvider: (() => readonly string[]) | undefined
 
@@ -102,6 +110,47 @@ export class BrowserControlSessions {
     })
   }
 
+  restore(entries: readonly PersistedSession[]): void {
+    if (this.sessions.size > 0) throw new Error("Cannot restore sessions after session management has started")
+    const ids = new Set<string>()
+    const targetOwners = new Set<string>()
+    for (const entry of entries) {
+      if (ids.has(entry.id)) throw new Error(`Duplicate persisted session: ${entry.id}`)
+      ids.add(entry.id)
+      if (entry.target && targetOwners.has(entry.target.id)) {
+        throw new Error(`Duplicate persisted target owner: ${entry.target.id}`)
+      }
+      if (entry.target) targetOwners.add(entry.target.id)
+    }
+    for (const entry of entries) {
+      const session = this.createBrowserControlSession(entry.id, entry.readOnly, {
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      })
+      if (entry.target) session.target = entry.target
+      session.sandbox.restore(entry.target)
+      this.sessions.set(entry.id, session)
+    }
+  }
+
+  persistedTargetOwner(targetId: string): { readonly sessionId: string; readonly owner: "relay" | "user" } | undefined {
+    for (const session of this.sessions.values()) {
+      const target = session.target
+      if (target?.id === targetId) return { sessionId: session.id, owner: target.owner }
+    }
+    return undefined
+  }
+
+  updateTarget(id: string, target: SessionTarget | undefined): void {
+    const session = this.sessions.get(id)
+    if (!session) return
+    if (session.target?.id === target?.id && session.target?.owner === target?.owner) return
+    if (target) session.target = target
+    else delete session.target
+    session.updatedAt = new Date().toISOString()
+    this.schedulePersistence()
+  }
+
   createNew(id: string | undefined, options?: { readonly readOnly?: boolean }): BrowserControlSession {
     if (this.closing) {
       throw sessionError("inactive", "Browser Control sessions are closing")
@@ -112,7 +161,23 @@ export class BrowserControlSessions {
     }
     const session = this.createBrowserControlSession(sessionId, options?.readOnly === true)
     this.sessions.set(sessionId, session)
+    this.schedulePersistence()
     return session
+  }
+
+  create(id: string | undefined, options?: { readonly readOnly?: boolean }): Effect.Effect<BrowserControlSession, Error> {
+    const manager = this
+    return Effect.gen(function* () {
+      const session = manager.createNew(id, options)
+      yield* manager.flushPersistence().pipe(Effect.catch((error) => Effect.gen(function* () {
+        if (manager.sessions.get(session.id) === session) manager.sessions.delete(session.id)
+        yield* manager.closeBrowserControlSession(session)
+        manager.schedulePersistence()
+        yield* manager.flushPersistence().pipe(Effect.ignore)
+        return yield* Effect.fail(error)
+      })))
+      return session
+    })
   }
 
   getOrCreate(id: string): { readonly session: BrowserControlSession; readonly created: boolean } {
@@ -125,6 +190,7 @@ export class BrowserControlSessions {
     }
     const session = this.createBrowserControlSession(id, false)
     this.sessions.set(id, session)
+    this.schedulePersistence()
     return { session, created: true }
   }
 
@@ -152,6 +218,12 @@ export class BrowserControlSessions {
       if (session.sandbox.markTargetDetached(targetId)) {
         affectedSessionIds.push(session.id)
       }
+      if (session.target?.id === targetId && session.target.owner === "user") {
+        this.notifyTargetOwnershipChange(this.targetOwnership.releaseTargetOwnership(targetId, session.id))
+      }
+      if (session.target?.id === targetId) {
+        this.updateTarget(session.id, undefined)
+      }
     }
     return affectedSessionIds
   }
@@ -159,7 +231,7 @@ export class BrowserControlSessions {
   markTargetReplaced(previousTargetId: string, targetId: string): string[] {
     const affected: string[] = []
     for (const session of this.sessions.values()) {
-      if (session.adoptedTargetId === previousTargetId) session.adoptedTargetId = targetId
+      if (session.target?.id === previousTargetId) this.updateTarget(session.id, { ...session.target, id: targetId })
       if (session.sandbox.markTargetReplaced(previousTargetId, targetId)) {
         affected.push(session.id)
       }
@@ -181,9 +253,17 @@ export class BrowserControlSessions {
         if (manager.sessions.get(id) !== session) {
           return false
         }
-        yield* manager.closeBrowserControlSession(session)
-        manager.releaseSessionTargetOwnership(session)
+        if (session.target?.owner === "relay") yield* manager.closeRelayTarget(session.target.id)
         manager.sessions.delete(id)
+        manager.schedulePersistence()
+        yield* manager.flushPersistence().pipe(Effect.catch((error) => Effect.gen(function* () {
+          manager.sessions.set(id, session)
+          manager.schedulePersistence()
+          yield* manager.flushPersistence().pipe(Effect.ignore)
+          return yield* Effect.fail(error)
+        })))
+        yield* manager.releaseSessionTargetOwnership(session)
+        yield* manager.closeBrowserControlSession(session)
         return true
       }))
     })
@@ -203,28 +283,26 @@ export class BrowserControlSessions {
         if (manager.sessions.get(id) !== existing) {
           return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
         }
-        yield* manager.closeBrowserControlSession(existing)
-        manager.releaseSessionTargetOwnership(existing)
+        if (existing.target?.owner === "relay") yield* manager.closeRelayTarget(existing.target.id)
         const session = manager.createBrowserControlSession(id, existing.readOnly)
         manager.sessions.set(id, session)
+        manager.schedulePersistence()
+        yield* manager.flushPersistence().pipe(Effect.catch((error) => Effect.gen(function* () {
+          manager.sessions.set(id, existing)
+          manager.schedulePersistence()
+          yield* manager.flushPersistence().pipe(Effect.ignore)
+          return yield* Effect.fail(error)
+        })))
+        yield* manager.releaseSessionTargetOwnership(existing)
+        yield* manager.closeBrowserControlSession(existing)
         return manager.sessionSummary(session)
       }))
     })
   }
 
   adoptedTargetId(id: string): string | undefined {
-    return this.sessions.get(id)?.adoptedTargetId
-  }
-
-  releaseAdoptedTarget(targetId: string): string | undefined {
-    for (const session of this.sessions.values()) {
-      if (session.adoptedTargetId === targetId) {
-        this.notifyTargetOwnershipChange(this.targetOwnership.releaseTargetOwnership(targetId, session.id))
-        delete session.adoptedTargetId
-        return session.id
-      }
-    }
-    return undefined
+    const target = this.sessions.get(id)?.target
+    return target?.owner === "user" ? target.id : undefined
   }
 
   networkStart(id: string, options: NetworkCaptureOptions = {}): Effect.Effect<NetworkCaptureStatus, Error> {
@@ -305,11 +383,18 @@ export class BrowserControlSessions {
       if (!session) {
         return yield* Effect.fail(sessionError("not-found", `Session not found: ${options.sessionId}`, options.sessionId))
       }
-      const execution = session.executeSemaphore.withPermit(
-        Effect.gen(function* () {
+      type ExecutionResponse = { readonly result: ExecuteResult; readonly session: SessionSummary & { readonly created?: boolean } }
+      const response = yield* Deferred.make<ExecutionResponse, Error>()
+      let started = false
+      let cancelled = false
+      const operation = Effect.gen(function* () {
+          if (cancelled) {
+            return yield* Effect.fail(sessionError("inactive", `Session execute was cancelled before starting: ${session.id}`, session.id))
+          }
           if (manager.sessions.get(session.id) !== session) {
             return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${session.id}`, session.id))
           }
+          started = true
           session.updatedAt = new Date().toISOString()
           manager.setExecuting(session.id, true)
           const startedAt = Date.now()
@@ -329,20 +414,34 @@ export class BrowserControlSessions {
             ? { ...result, warnings: [...result.warnings, adoptionTipForUrl(userAttachedPageUrls[0] ?? "about:blank")] }
             : result
           session.updatedAt = new Date().toISOString()
-          manager.recordExecute({
+          yield* manager.recordExecute({
             sessionId: session.id,
             code: session.sandbox.redactNetworkCaptureText(options.code),
             durationMs: Date.now() - startedAt,
             result: resultWithHint,
           })
+          manager.schedulePersistence()
+          yield* manager.flushPersistence()
           const summary = manager.sessionSummary(session)
           return { result: resultWithHint, session: { ...summary, ...(resolved.created ? { created: true } : {}) } }
-        }),
-      )
-      return yield* execution.pipe(
-        Effect.catch((error) => resolved.created
-          ? manager.delete(session.id).pipe(Effect.ignore, Effect.andThen(Effect.fail(error)))
-          : Effect.fail(error)),
+        })
+      const transaction = session.executeSemaphore.withPermit(operation)
+      const worker = transaction.pipe(Effect.matchEffect({
+        onFailure: (error) => (resolved.created
+          ? manager.cleanupCreatedSession(session)
+          : Effect.void).pipe(Effect.andThen(Deferred.fail(response, error))),
+        onSuccess: (value) => Deferred.succeed(response, value),
+      }))
+      const workerFiber = yield* worker.pipe(Effect.forkDetach({ startImmediately: true }))
+      return yield* Deferred.await(response).pipe(
+        Effect.onInterrupt(() => Effect.suspend(() => {
+          if (started) return Effect.void
+          cancelled = true
+          return Fiber.interrupt(workerFiber).pipe(
+            Effect.asVoid,
+            Effect.andThen(resolved.created ? manager.delete(session.id).pipe(Effect.ignore) : Effect.void),
+          )
+        })),
       )
     })
   }
@@ -376,17 +475,20 @@ export class BrowserControlSessions {
         readonly releasedTargetIds: readonly string[]
       }
       const result = yield* Deferred.make<AdoptionResult, Error>()
-      let state: "pending" | "cancelled" | "committed" = "pending"
+      let state: "pending" | "reserved" | "committed" = "pending"
+      let cancelled = false
       let reservation: TargetOwnershipReservation | undefined
+      let previousTarget: SessionTarget | undefined
+      let previousRelayClosed = false
       const timeoutMs = manager.hooks.lifecycleTimeoutMs ?? 10_000
       const timeoutError = sessionError("timeout", `Session adopt for ${session.id} timed out after ${timeoutMs}ms`, session.id)
-      const adoptionCancelled = () => state === "cancelled"
+      const adoptionCancelled = () => cancelled
       const cancel = Effect.sync(() => {
-        if (state !== "pending") {
+        if (cancelled) {
           return
         }
-        state = "cancelled"
-        if (reservation) {
+        cancelled = true
+        if (reservation && state === "reserved") {
           manager.notifyTargetOwnershipChange(manager.targetOwnership.rollbackTargetOwnership(reservation))
         }
       })
@@ -395,56 +497,60 @@ export class BrowserControlSessions {
             return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${session.id}`, session.id))
           }
           if (adoptionCancelled()) {
-            if (resolved.created) {
-              yield* manager.cleanupSettledAdoption(session, true)
-            }
             return yield* Effect.fail(timeoutError)
           }
           reservation = yield* Effect.try({
             try: () => manager.targetOwnership.reserveTargetOwnership(options.targetId, session.id),
             catch: (cause) => cause instanceof Error ? cause : new Error("Reserve target ownership", { cause }),
           })
+          state = "reserved"
           manager.notifyTargetOwnershipChange({ targetIds: [options.targetId], tabIds: reservation.tabId < 0 ? [] : [reservation.tabId] })
+          previousTarget = session.target
           const adoptedUrl = yield* session.sandbox.adoptPage({ targetId: options.targetId, url: options.targetUrl })
           if (adoptionCancelled()) {
-            manager.notifyTargetOwnershipChange(manager.targetOwnership.rollbackTargetOwnership(reservation))
-            yield* manager.cleanupSettledAdoption(session, resolved.created)
             return yield* Effect.fail(timeoutError)
           }
           const activeReservation = reservation
-          return yield* Effect.try({
+          previousTarget = session.target ?? previousTarget
+          const previousTargetId = previousTarget?.id
+          if (previousTarget?.owner === "relay" && previousTarget.id !== options.targetId) {
+            yield* manager.closeRelayTarget(previousTarget.id)
+            previousRelayClosed = true
+          }
+          session.target = { id: options.targetId, owner: "user" }
+          session.updatedAt = new Date().toISOString()
+          manager.schedulePersistence()
+          yield* manager.flushPersistence()
+          if (adoptionCancelled()) {
+            return yield* Effect.fail(timeoutError)
+          }
+          yield* Effect.try({
             try: () => {
-              state = "committed"
-              const previousAdoptedTargetId = session.adoptedTargetId
               manager.notifyTargetOwnershipChange(manager.targetOwnership.commitTargetOwnership({
                 reservation: activeReservation,
-                ...(previousAdoptedTargetId ? { previousAdoptedTargetId } : {}),
+                ...(previousTargetId ? { previousAdoptedTargetId: previousTargetId } : {}),
               }))
-              session.adoptedTargetId = options.targetId
-              session.updatedAt = new Date().toISOString()
-              const summary = manager.sessionSummary(session)
-              const releasedTargetIds = previousAdoptedTargetId && previousAdoptedTargetId !== options.targetId
-                ? [previousAdoptedTargetId]
-                : []
-              const value = { adoptedUrl, releasedTargetIds, session: { ...summary, ...(resolved.created ? { created: true } : {}) } }
-              Deferred.doneUnsafe(result, Effect.succeed(value))
-              return value
+              state = "committed"
             },
             catch: (cause) => cause instanceof Error ? cause : new Error("Commit target ownership", { cause }),
-          }).pipe(
-            Effect.catch((error) => manager.cleanupSettledAdoption(session, resolved.created).pipe(
-              Effect.andThen(Effect.fail(error)),
-            )),
-          )
+          })
+          const summary = manager.sessionSummary(session)
+          const releasedTargetIds = previousTargetId && previousTargetId !== options.targetId ? [previousTargetId] : []
+          const value = { adoptedUrl, releasedTargetIds, session: { ...summary, ...(resolved.created ? { created: true } : {}) } }
+          yield* Deferred.succeed(result, value)
+          return value
         })
       const transaction = session.executeSemaphore.withPermit(operation.pipe(Effect.matchEffect({
         onFailure: (error) => Effect.gen(function* () {
-          if (reservation) {
+          if (reservation && state !== "committed") {
             manager.notifyTargetOwnershipChange(manager.targetOwnership.rollbackTargetOwnership(reservation))
           }
-          if (resolved.created && manager.sessions.get(session.id) === session) {
-            yield* manager.closeBrowserControlSessionSettled(session)
-            manager.sessions.delete(session.id)
+          if (manager.sessions.get(session.id) === session && (resolved.created || state !== "pending")) {
+            const cleanup = yield* Effect.result(manager.cleanupSettledAdoption(session, resolved.created, previousTarget, previousRelayClosed))
+            if (cleanup._tag === "Failure") {
+              yield* Deferred.fail(result, cleanup.failure)
+              return
+            }
           }
           yield* Deferred.fail(result, error)
         }),
@@ -471,19 +577,17 @@ export class BrowserControlSessions {
           return manager.withLifecyclePermit(
             session,
             "close",
-            manager.closeBrowserControlSession(session),
+            manager.disconnectBrowserControlSession(session),
           ).pipe(
             Effect.match({
               onFailure: () => undefined,
               onSuccess: () => session.id,
             }),
           )
-        })
+        }, { concurrency: "unbounded" })
+        yield* manager.flushPersistence().pipe(Effect.ignore)
         for (const id of closedSessionIds) {
           if (!id) continue
-          const session = manager.sessions.get(id)
-          if (!session) continue
-          manager.releaseSessionTargetOwnership(session)
           manager.sessions.delete(id)
         }
       }))
@@ -511,20 +615,33 @@ export class BrowserControlSessions {
     }
   }
 
-  private recordExecute(record: SessionExecuteRecord): void {
-    try {
-      this.hooks.onExecuteRecord?.(record)
-    } catch (error) {
-      console.error("Session execute-record hook failed", error)
-    }
+  private recordExecute(record: SessionExecuteRecord): Effect.Effect<void> {
+    const hook = this.hooks.onExecuteRecord
+    if (!hook) return Effect.void
+    return Effect.tryPromise({
+      try: async () => hook(record),
+      catch: (cause) => cause,
+    }).pipe(
+      Effect.timeoutOrElse({
+        duration: this.hooks.journalTimeoutMs ?? 2_000,
+        orElse: () => Effect.fail(new Error(`Session journal write timed out after ${this.hooks.journalTimeoutMs ?? 2_000}ms`)),
+      }),
+      Effect.catch((error) => Effect.sync(() => {
+        console.error("Session execute-record hook failed", error)
+      })),
+      Effect.asVoid,
+    )
   }
 
-  private createBrowserControlSession(id: string, readOnly: boolean): BrowserControlSession {
+  private createBrowserControlSession(id: string, readOnly: boolean, timestamps?: {
+    readonly createdAt: string
+    readonly updatedAt: string
+  }): BrowserControlSession {
     const now = new Date().toISOString()
     return {
       id,
-      createdAt: now,
-      updatedAt: now,
+      createdAt: timestamps?.createdAt ?? now,
+      updatedAt: timestamps?.updatedAt ?? now,
       readOnly,
       sandbox: this.createSandbox(id),
       executeSemaphore: Semaphore.makeUnsafe(1),
@@ -548,15 +665,25 @@ export class BrowserControlSessions {
     return this.withLifecycleTimeout(session.sandbox.close(), `Close session ${session.id}`).pipe(Effect.ignore)
   }
 
+  private disconnectBrowserControlSession(session: BrowserControlSession): Effect.Effect<void> {
+    return this.withLifecycleTimeout(session.sandbox.disconnect(), `Disconnect session ${session.id}`).pipe(Effect.ignore)
+  }
+
   private closeBrowserControlSessionSettled(session: BrowserControlSession): Effect.Effect<void> {
     return session.sandbox.closeSettled().pipe(Effect.ignore)
   }
 
-  private releaseSessionTargetOwnership(session: BrowserControlSession): void {
-    if (session.adoptedTargetId) {
-      this.notifyTargetOwnershipChange(this.targetOwnership.releaseTargetOwnership(session.adoptedTargetId, session.id))
-      delete session.adoptedTargetId
-    }
+  private releaseSessionTargetOwnership(session: BrowserControlSession): Effect.Effect<void> {
+    const target = session.target
+    if (!target) return Effect.void
+    this.notifyTargetOwnershipChange(this.targetOwnership.releaseTargetOwnership(target.id, session.id))
+    delete session.target
+    return Effect.void
+  }
+
+  private closeRelayTarget(targetId: string): Effect.Effect<void, Error> {
+    const close = this.hooks.onReleaseRelayTarget?.(targetId)
+    return close ?? Effect.void
   }
 
   private notifyTargetOwnershipChange(change: TargetOwnershipChange): void {
@@ -570,23 +697,88 @@ export class BrowserControlSessions {
     }
   }
 
-  private cleanupSettledAdoption(session: BrowserControlSession, created: boolean): Effect.Effect<void> {
+  private persistedSession(session: BrowserControlSession): PersistedSession {
+    const target = session.target
+    return {
+      id: session.id,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      readOnly: session.readOnly,
+      ...(target ? { target } : {}),
+    }
+  }
+
+  private persistedSessions(): PersistedSession[] {
+    return Array.from(this.sessions.values(), (session) => this.persistedSession(session))
+  }
+
+  private schedulePersistence(sessions = this.persistedSessions()): void {
+    const hook = this.hooks.onSessionsChanged
+    if (!hook) return
+    const previous = this.persistenceTail
+    this.persistenceTail = previous.catch(() => {}).then(async () => {
+      await hook(sessions)
+    })
+    void this.persistenceTail.catch((error) => {
+      console.error("Failed to persist Browser Control sessions", error)
+    })
+  }
+
+  private flushPersistence(): Effect.Effect<void, Error> {
+    const pending = this.persistenceTail
+    return Effect.tryPromise({
+      try: () => pending,
+      catch: (cause) => cause instanceof Error ? cause : new Error("Persist Browser Control sessions", { cause }),
+    })
+  }
+
+  persist(): Effect.Effect<void, Error> {
+    return this.flushPersistence()
+  }
+
+  private cleanupSettledAdoption(
+    session: BrowserControlSession,
+    created: boolean,
+    previousTarget?: SessionTarget,
+    previousRelayClosed = false,
+  ): Effect.Effect<void, Error> {
     const manager = this
     return Effect.gen(function* () {
+      const activeTarget = session.target
+      yield* manager.releaseSessionTargetOwnership(session)
+      if (previousTarget && previousTarget.id !== activeTarget?.id) {
+        manager.notifyTargetOwnershipChange(manager.targetOwnership.releaseTargetOwnership(previousTarget.id, session.id))
+        if (previousTarget.owner === "relay" && !previousRelayClosed) yield* manager.closeRelayTarget(previousTarget.id)
+      }
       yield* manager.closeBrowserControlSessionSettled(session)
       if (manager.sessions.get(session.id) !== session) {
         return
       }
       if (created) {
         manager.sessions.delete(session.id)
+        manager.schedulePersistence()
+        yield* manager.flushPersistence()
         return
       }
       const replacement = manager.createBrowserControlSession(session.id, session.readOnly)
       manager.sessions.set(session.id, {
         ...replacement,
         createdAt: session.createdAt,
-        ...(session.adoptedTargetId ? { adoptedTargetId: session.adoptedTargetId } : {}),
       })
+      manager.schedulePersistence()
+      yield* manager.flushPersistence()
+    })
+  }
+
+  private cleanupCreatedSession(session: BrowserControlSession): Effect.Effect<void> {
+    const manager = this
+    return Effect.gen(function* () {
+      if (manager.sessions.get(session.id) !== session) return
+      manager.sessions.delete(session.id)
+      yield* manager.releaseSessionTargetOwnership(session)
+      yield* manager.closeBrowserControlSession(session)
+      manager.schedulePersistence()
+      yield* manager.flushPersistence().pipe(Effect.ignore)
     })
   }
 

--- a/test/execute-lifecycle.test.ts
+++ b/test/execute-lifecycle.test.ts
@@ -98,7 +98,7 @@ describe("execute lifecycle", () => {
   it("waits through transient execution-context replacement", async () => {
     let attempts = 0
     await expect(waitForPageContext({
-      timeoutMs: 30,
+      timeoutMs: 1_000,
       retryDelayMs: 10,
       delay: () => Promise.resolve(),
       evaluate: () => ++attempts < 3

--- a/test/handoff.test.ts
+++ b/test/handoff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { HandoffRegistry, resolveExactHandoffTarget, toolbarClickAction } from "../src/handoff.ts"
+import { awaitHandoffAction, HandoffRegistry, resolveExactHandoffTarget, toolbarClickAction } from "../src/handoff.ts"
 
 function registryWithIds(...ids: string[]): HandoffRegistry {
   return new HandoffRegistry(() => ids.shift() ?? "unexpected-id")
@@ -115,6 +115,131 @@ describe("HandoffRegistry", () => {
     expect(registry.complete({ id: wait.id, tabId: 7, targetId: "target-old", targetSessionId: "bc-tab-old" })).toBe(false)
     expect(registry.complete({ id: wait.id, tabId: 7, targetId: "target-new", targetSessionId: "bc-tab-new" })).toBe(true)
     await expect(wait.outcome).resolves.toBe("resolved")
+  })
+
+  it("cancels a registered handoff when its start action fails", async () => {
+    const registry = registryWithIds("handoff-1")
+    const wait = registry.wait({ sessionId: "alpha", tabId: 7, targetId: "target-1", targetSessionId: "bc-tab-1", message: "m", timeoutMs: 5_000 })
+
+    await expect(awaitHandoffAction({
+      outcome: wait.outcome,
+      start: () => Promise.reject(new Error("prompt action failed")),
+      cancel: () => {
+        registry.cancel(wait.id)
+      },
+    })).rejects.toThrow("prompt action failed")
+    expect(registry.cancel(wait.id)).toBe(false)
+    await expect(wait.outcome).resolves.toBe("timeout")
+    expect(registry.pendingCount).toBe(0)
+  })
+
+  it("does not start the prompt action until WAIT presentation is acknowledged", async () => {
+    const registry = registryWithIds("handoff-1")
+    const wait = registry.wait({ sessionId: "alpha", tabId: 7, targetId: "target-1", targetSessionId: "bc-tab-1", message: "m", timeoutMs: 5_000 })
+    let acknowledgePresentation: (() => void) | undefined
+    const presented = new Promise<void>((resolve) => {
+      acknowledgePresentation = resolve
+    })
+    let markStarted: (() => void) | undefined
+    const startCalled = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    let started = false
+    const result = awaitHandoffAction({
+      outcome: wait.outcome,
+      present: () => presented,
+      start: () => {
+        started = true
+        markStarted?.()
+      },
+      cancel: () => {
+        registry.cancel(wait.id)
+      },
+    })
+
+    await Promise.resolve()
+    expect(started).toBe(false)
+    acknowledgePresentation?.()
+    await startCalled
+    expect(started).toBe(true)
+    expect(registry.complete({ id: wait.id, tabId: 7, targetId: "target-1", targetSessionId: "bc-tab-1" })).toBe(true)
+    await expect(result).resolves.toBe("resolved")
+  })
+
+  it("does not start the prompt action when the handoff ends before WAIT is acknowledged", async () => {
+    const registry = registryWithIds("handoff-1")
+    const wait = registry.wait({ sessionId: "alpha", tabId: 7, targetId: "target-1", targetSessionId: "bc-tab-1", message: "m", timeoutMs: 5_000 })
+    let acknowledgePresentation: (() => void) | undefined
+    const presented = new Promise<void>((resolve) => {
+      acknowledgePresentation = resolve
+    })
+    let started = false
+    const result = awaitHandoffAction({
+      outcome: wait.outcome,
+      present: () => presented,
+      start: () => {
+        started = true
+      },
+      cancel: () => {
+        registry.cancel(wait.id)
+      },
+    })
+
+    expect(registry.cancel(wait.id)).toBe(true)
+    await expect(result).resolves.toBe("timeout")
+    acknowledgePresentation?.()
+    await Promise.resolve()
+    expect(started).toBe(false)
+  })
+
+  it("starts a blocking action after registration and waits for both outcomes", async () => {
+    const registry = registryWithIds("handoff-1")
+    const wait = registry.wait({ sessionId: "alpha", tabId: 7, targetId: "target-1", targetSessionId: "bc-tab-1", message: "m", timeoutMs: 5_000 })
+    let finishAction: (() => void) | undefined
+    const action = new Promise<void>((resolve) => {
+      finishAction = resolve
+    })
+    let settled = false
+    const result = awaitHandoffAction({
+      outcome: wait.outcome,
+      start: () => {
+        expect(registry.pendingCount).toBe(1)
+        return action
+      },
+      cancel: () => {
+        registry.cancel(wait.id)
+      },
+    }).finally(() => {
+      settled = true
+    })
+
+    await Promise.resolve()
+    expect(registry.pendingCount).toBe(1)
+    registry.complete({ id: wait.id, tabId: 7, targetId: "target-1", targetSessionId: "bc-tab-1" })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    finishAction?.()
+    await expect(result).resolves.toBe("resolved")
+  })
+
+  it("disconnects a non-settling start action after the handoff times out", async () => {
+    const registry = registryWithIds("handoff-1")
+    const wait = registry.wait({ sessionId: "alpha", tabId: 7, targetId: "target-1", targetSessionId: "bc-tab-1", message: "m", timeoutMs: 5_000 })
+    let cancelled = false
+    const result = awaitHandoffAction({
+      outcome: wait.outcome,
+      start: () => new Promise(() => {}),
+      cancel: () => {
+        registry.cancel(wait.id)
+      },
+      cancelStart: async () => {
+        cancelled = true
+      },
+    })
+
+    expect(registry.cancel(wait.id)).toBe(true)
+    await expect(result).resolves.toBe("timeout")
+    expect(cancelled).toBe(true)
   })
 })
 

--- a/test/relay-child-dedupe.test.ts
+++ b/test/relay-child-dedupe.test.ts
@@ -43,7 +43,7 @@ describe("relay child target announce dedupe", () => {
   it("keeps an extension-owned child from replacing the tab root", async () => {
     const port = await freePort()
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
-      const relay = yield* startRelay({ port })
+      const relay = yield* startRelay({ port, sessionCatalogPath: null })
       yield* Effect.tryPromise(async () => {
         const extension = await openSocket(`${relay.url.replace("http://", "ws://")}/extension`)
         const extensionCommands: Array<{ readonly method: string; readonly params?: JsonObject }> = []
@@ -180,7 +180,7 @@ describe("relay child target announce dedupe", () => {
   it("commits one replacement generation after setup retries", async () => {
     const port = await freePort()
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
-      const relay = yield* startRelay({ port })
+      const relay = yield* startRelay({ port, sessionCatalogPath: null })
       yield* Effect.tryPromise(async () => {
         const extension = await openSocket(`${relay.url.replace("http://", "ws://")}/extension`)
         let currentTargetId = "root-old"
@@ -252,7 +252,7 @@ describe("relay child target announce dedupe", () => {
   it("suppresses service workers while preserving dedicated worker routing", async () => {
     const port = await freePort()
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
-      yield* startRelay({ port })
+      yield* startRelay({ port, sessionCatalogPath: null })
       yield* Effect.tryPromise(async () => {
         const extension = await openSocket(`ws://127.0.0.1:${port}/extension`)
         const extensionCommands: Array<{ readonly method: string; readonly params?: JsonObject }> = []
@@ -370,7 +370,7 @@ describe("relay child target announce dedupe", () => {
   it("detaches the old child session before broadcasting a live re-attach for the same child target id", async () => {
     const port = await freePort()
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
-      const relay = yield* startRelay({ port })
+      const relay = yield* startRelay({ port, sessionCatalogPath: null })
       yield* Effect.tryPromise(async () => {
         const extension = await openSocket(`${relay.url.replace("http://", "ws://")}/extension`)
         const extensionCommands: string[] = []

--- a/test/relay-lifecycle.test.ts
+++ b/test/relay-lifecycle.test.ts
@@ -14,7 +14,7 @@ import { sourceBuildIdForFiles } from "../src/version.ts"
 const version = { version: "0.1.0", buildId: "build-current" }
 
 function relay(options: {
-  readonly version: Effect.Effect<typeof version, RelayClient.RelayUnreachable>
+  readonly version: Effect.Effect<typeof version, RelayClient.RelayClientError>
   readonly extensionStatus?: RelayClient.Interface["extensionStatus"]
 }): RelayClient.Interface {
   return {
@@ -22,6 +22,15 @@ function relay(options: {
     version: options.version,
     extensionStatus: options.extensionStatus ?? Effect.succeed({ connected: true, version: "0.0.11", activeTargets: 0 }),
   } as RelayClient.Interface
+}
+
+function starting(): RelayClient.RelayRejected {
+  return new RelayClient.RelayRejected({
+    message: "Browser Control relay is starting",
+    status: 503,
+    path: "/version",
+    code: "relay-starting",
+  })
 }
 
 function unreachable(): RelayClient.RelayUnreachable {
@@ -66,6 +75,23 @@ describe("relay lifecycle", () => {
 
     expect(result.started).toBe(true)
     expect(starts).toBe(1)
+  })
+
+  it("waits for a bound relay to finish restoring without starting another process", async () => {
+    let attempts = 0
+    let starts = 0
+    const result = await Effect.runPromise(ensureRelay({
+      relay: relay({
+        version: Effect.suspend(() => ++attempts >= 3 ? Effect.succeed(version) : Effect.fail(starting())),
+      }),
+      buildId: "build-current",
+      start: Effect.sync(() => { starts++ }),
+      retryTimes: 3,
+      retryDelayMs: 0,
+    }))
+
+    expect(result).toEqual({ version, started: false })
+    expect(starts).toBe(0)
   })
 
   it("reports a stale relay instead of silently using it", async () => {

--- a/test/relay-session-persistence.test.ts
+++ b/test/relay-session-persistence.test.ts
@@ -1,0 +1,204 @@
+import fs from "node:fs"
+import net from "node:net"
+import os from "node:os"
+import path from "node:path"
+import { Effect } from "effect"
+import { WebSocket } from "ws"
+import { afterEach, describe, expect, it } from "vitest"
+import { startRelay } from "../src/relay.ts"
+import { SessionCatalog } from "../src/session-catalog.ts"
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true })
+})
+
+describe("relay session persistence", () => {
+  it("restores a named session after a clean relay restart", async () => {
+    const port = await freePort()
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-relay-sessions-"))
+    temporaryDirectories.push(directory)
+    const sessionCatalogPath = path.join(directory, "sessions.json")
+
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port, sessionCatalogPath })
+      yield* Effect.tryPromise(async () => {
+        const response = await fetch(new URL("/cli/session/new", relay.url), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "restart-proof", readOnly: true }),
+        })
+        expect(response.status).toBe(200)
+      })
+    })))
+
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port, sessionCatalogPath })
+      yield* Effect.tryPromise(async () => {
+        const response = await fetch(new URL("/cli/sessions", relay.url))
+        expect(response.status).toBe(200)
+        await expect(response.json()).resolves.toMatchObject({
+          sessions: [{ id: "restart-proof", readOnly: true, connected: false, pageUrl: null, stateKeys: [] }],
+        })
+      })
+    })))
+  })
+
+  it("reclaims persisted target ownership when the extension re-announces the tab", async () => {
+    const port = await freePort()
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-relay-sessions-"))
+    temporaryDirectories.push(directory)
+    const sessionCatalogPath = path.join(directory, "sessions.json")
+    await new SessionCatalog(sessionCatalogPath).save([{
+      id: "restored",
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:01:00.000Z",
+      readOnly: false,
+      target: { id: "restored-target", owner: "user" },
+    }])
+
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port, sessionCatalogPath })
+      yield* Effect.tryPromise(async () => {
+        const extension = await openFakeExtension(relay.url, "restored-target")
+
+        let targets: unknown
+        await waitFor(async () => {
+          targets = await fetch(new URL("/json/list", relay.url)).then((response) => response.json())
+          return Array.isArray(targets) && targets.some((target) => {
+            return typeof target === "object" && target !== null &&
+              "browserControlSessionId" in target && target.browserControlSessionId === "restored"
+          })
+        })
+        expect(targets).toMatchObject([{
+          id: "restored-target",
+          owner: "user",
+          browserControlSessionId: "restored",
+        }])
+        extension.close()
+        await waitFor(async () => {
+          const current = await fetch(new URL("/json/list", relay.url)).then((response) => response.json())
+          return Array.isArray(current) && current.length === 0
+        })
+
+        const reconnected = await openFakeExtension(relay.url, "restored-target")
+        await waitFor(async () => {
+          const current = await fetch(new URL("/json/list", relay.url)).then((response) => response.json())
+          return Array.isArray(current) && current.some((target) => {
+            return typeof target === "object" && target !== null &&
+              "browserControlSessionId" in target && target.browserControlSessionId === "restored"
+          })
+        })
+        const reset = await fetch(new URL("/cli/session/reset", relay.url), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "restored" }),
+        })
+        expect(reset.status).toBe(200)
+        await waitFor(async () => {
+          const current = await fetch(new URL("/json/list", relay.url)).then((response) => response.json())
+          return Array.isArray(current) && current.some((target) => {
+            return typeof target === "object" && target !== null &&
+              "id" in target && target.id === "restored-target" &&
+              !("browserControlSessionId" in target)
+          })
+        })
+        reconnected.close()
+      })
+    })))
+  })
+
+  it("does not let a process that loses the port race rewrite the catalog", async () => {
+    const port = await freePort()
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-relay-sessions-"))
+    temporaryDirectories.push(directory)
+    const sessionCatalogPath = path.join(directory, "sessions.json")
+    const catalog = new SessionCatalog(sessionCatalogPath)
+    await catalog.save([{
+      id: "port-owner",
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:01:00.000Z",
+      readOnly: false,
+    }])
+
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      yield* startRelay({ port, sessionCatalogPath })
+      const before = fs.readFileSync(sessionCatalogPath, "utf8")
+      const failure = yield* Effect.result(Effect.scoped(startRelay({ port, sessionCatalogPath })))
+      expect(failure._tag).toBe("Failure")
+      expect(fs.readFileSync(sessionCatalogPath, "utf8")).toBe(before)
+    })))
+  })
+
+  it("retains a restored relay target when reset runs before extension re-announcement", async () => {
+    const port = await freePort()
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-relay-sessions-"))
+    temporaryDirectories.push(directory)
+    const sessionCatalogPath = path.join(directory, "sessions.json")
+    const catalog = new SessionCatalog(sessionCatalogPath)
+    await catalog.save([{
+      id: "restored",
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:01:00.000Z",
+      readOnly: false,
+      target: { id: "relay-target", owner: "relay" },
+    }])
+
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port, sessionCatalogPath })
+      yield* Effect.tryPromise(async () => {
+        const reset = await fetch(new URL("/cli/session/reset", relay.url), {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ id: "restored" }),
+        })
+        expect(reset.status).toBe(500)
+        await expect(catalog.load()).resolves.toMatchObject([{
+          id: "restored",
+          target: { id: "relay-target", owner: "relay" },
+        }])
+      })
+    })))
+  })
+})
+
+async function openFakeExtension(relayUrl: string, targetId: string): Promise<WebSocket> {
+  const extension = await openSocket(`${relayUrl.replace("http://", "ws://")}/extension`)
+  extension.on("message", (data) => {
+    const command = JSON.parse(data.toString()) as { readonly id: number; readonly method: string; readonly params?: { readonly method?: string } }
+    const result = command.method === "debugger.sendCommand" && command.params?.method === "Target.getTargetInfo"
+      ? { targetInfo: { targetId, type: "page", title: "Restored", url: "https://example.com/", attached: true, canAccessOpener: false } }
+      : {}
+    extension.send(JSON.stringify({ id: command.id, result }))
+  })
+  extension.send(JSON.stringify({ method: "hello", params: { version: "0.0.17" } }))
+  extension.send(JSON.stringify({ method: "debugger.attached", params: { tabId: 7 } }))
+  return extension
+}
+
+async function openSocket(url: string): Promise<WebSocket> {
+  const socket = new WebSocket(url)
+  await new Promise<void>((resolve, reject) => {
+    socket.once("open", resolve)
+    socket.once("error", reject)
+  })
+  return socket
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + 2_000
+  while (!(await predicate())) {
+    if (Date.now() > deadline) throw new Error("Timed out waiting for relay test condition")
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+async function freePort(): Promise<number> {
+  const server = net.createServer()
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("Expected TCP address")
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  return address.port
+}

--- a/test/relay-visibility-prune.test.ts
+++ b/test/relay-visibility-prune.test.ts
@@ -10,7 +10,7 @@ describe("relay target visibility pruning", () => {
   it("detaches raw relay targets from a session client once that session gains an owned target", async () => {
     const port = 24_000 + Math.floor(Math.random() * 10_000)
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
-      const relay = yield* startRelay({ port })
+      const relay = yield* startRelay({ port, sessionCatalogPath: null })
       const extension = yield* Effect.promise(() => connectFakeExtension(relay.url))
       const rawClient = yield* Effect.promise(() => connectCdpClient(relay.url))
       const sessionClient = yield* Effect.promise(() => connectCdpClient(relay.url, "session-a"))

--- a/test/session-catalog.test.ts
+++ b/test/session-catalog.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { defaultSessionCatalogPath, SessionCatalog, type PersistedSession } from "../src/session-catalog.ts"
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true })
+})
+
+describe("SessionCatalog", () => {
+  it("round-trips endpoint-scoped session descriptors with private permissions", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-session-catalog-"))
+    temporaryDirectories.push(home)
+    const filePath = defaultSessionCatalogPath(20001, home)
+    const catalog = new SessionCatalog(filePath)
+    const sessions: PersistedSession[] = [{
+      id: "alpha",
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:01:00.000Z",
+      readOnly: true,
+      target: { id: "target-1", owner: "relay" },
+    }]
+
+    await catalog.save(sessions)
+
+    await expect(catalog.load()).resolves.toEqual(sessions)
+    expect(fs.statSync(path.dirname(filePath)).mode & 0o777).toBe(0o700)
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600)
+  })
+
+  it("reports invalid data without overwriting it", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-session-catalog-"))
+    temporaryDirectories.push(home)
+    const filePath = defaultSessionCatalogPath(20002, home)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, "not json")
+    const catalog = new SessionCatalog(filePath)
+
+    await expect(catalog.load()).rejects.toThrow("Could not decode Browser Control session catalog")
+    expect(fs.readFileSync(filePath, "utf8")).toBe("not json")
+  })
+
+  it("rejects session ids that the HTTP API cannot address", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-session-catalog-"))
+    temporaryDirectories.push(home)
+    const filePath = defaultSessionCatalogPath(20003, home)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, JSON.stringify({
+      version: 1,
+      sessions: [{ id: "../escape", createdAt: "now", updatedAt: "now", readOnly: false }],
+    }))
+
+    await expect(new SessionCatalog(filePath).load()).rejects.toThrow("Invalid persisted session id")
+  })
+})

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 import { Deferred, Effect, Fiber } from "effect"
 import { adoptionTipForUrl, BrowserControlSessions, shouldAppendAdoptionTip } from "../src/session-manager.ts"
 import type { ExecuteSandboxLike } from "../src/relay-types.ts"
+import type { PersistedSession } from "../src/session-catalog.ts"
 import { TargetRegistry } from "../src/target-registry.ts"
 
 type FakeSandbox = ExecuteSandboxLike & {
@@ -10,6 +11,7 @@ type FakeSandbox = ExecuteSandboxLike & {
   readonly crashedTargets: () => string[]
   readonly detachedTargets: () => string[]
   readonly replacedTargets: () => Array<readonly [string, string]>
+  readonly restoredTarget: () => PersistedSession["target"]
 }
 
 const makeFakeSandbox = (options?: {
@@ -26,7 +28,14 @@ const makeFakeSandbox = (options?: {
   const crashedTargets: string[] = []
   const detachedTargets: string[] = []
   const replacedTargets: Array<readonly [string, string]> = []
+  let persistenceTarget: PersistedSession["target"] = options?.defaultTargetId
+    ? { id: options.defaultTargetId, owner: "relay" }
+    : undefined
   const close = () => Effect.sync(() => {
+    closes += 1
+    persistenceTarget = undefined
+  }).pipe(Effect.andThen(options?.onClose ?? Effect.void))
+  const disconnect = () => Effect.sync(() => {
     closes += 1
   }).pipe(Effect.andThen(options?.onClose ?? Effect.void))
   return {
@@ -50,6 +59,8 @@ const makeFakeSandbox = (options?: {
             }),
       ),
     close,
+    disconnect,
+    disconnectSettled: disconnect,
     closeSettled: close,
     networkStart: () => Effect.succeed({ active: true, entryCount: 0, responseCount: 0, failureCount: 0, capturedBodyBytes: 0, truncatedBodyCount: 0, droppedEntryCount: 0 }),
     networkStatus: () => ({ active: false, entryCount: 0, responseCount: 0, failureCount: 0, capturedBodyBytes: 0, truncatedBodyCount: 0, droppedEntryCount: 0 }),
@@ -57,25 +68,34 @@ const makeFakeSandbox = (options?: {
     networkCancel: () => Effect.succeed({ cancelled: false }),
     authRefresh: () => Effect.fail(new Error("auth refresh is not configured")),
     redactNetworkCaptureText: (text) => options?.redactText?.(text) ?? text,
-    adoptPage: (selection) => options?.onAdopt
+    adoptPage: (selection) => (options?.onAdopt
       ? options.onAdopt(selection)
       : options?.adoptFailure
       ? Effect.fail(options.adoptFailure)
       : Effect.sync(() => {
           adoptedSelections.push(selection)
           return "https://example.com/adopted"
-        }),
+        })).pipe(Effect.tap(() => Effect.sync(() => {
+          persistenceTarget = { id: selection.targetId, owner: "user" }
+        }))),
     markTargetCrashed: (targetId) => {
       crashedTargets.push(targetId)
-      return options?.defaultTargetId === undefined || options.defaultTargetId === targetId
+      return persistenceTarget?.id === targetId
     },
     markTargetDetached: (targetId) => {
       detachedTargets.push(targetId)
-      return options?.defaultTargetId === undefined || options.defaultTargetId === targetId
+      const affected = persistenceTarget?.id === targetId
+      if (affected) persistenceTarget = undefined
+      return affected
     },
     markTargetReplaced: (previousTargetId, targetId) => {
       replacedTargets.push([previousTargetId, targetId])
-      return options?.defaultTargetId === undefined || options.defaultTargetId === previousTargetId
+      const affected = persistenceTarget?.id === previousTargetId
+      if (affected && persistenceTarget) persistenceTarget = { ...persistenceTarget, id: targetId }
+      return affected
+    },
+    restore: (target) => {
+      persistenceTarget = target
     },
     getStatus: () => ({ connected: false, pageUrl: null, stateKeys: [] }),
     closes: () => closes,
@@ -83,10 +103,178 @@ const makeFakeSandbox = (options?: {
     crashedTargets: () => crashedTargets,
     detachedTargets: () => detachedTargets,
     replacedTargets: () => replacedTargets,
+    restoredTarget: () => persistenceTarget,
   }
 }
 
 describe("BrowserControlSessions", () => {
+  it("restores persisted identity and target ownership with reset JavaScript state", async () => {
+    const persisted: PersistedSession[][] = []
+    const sessions = new BrowserControlSessions(
+      "http://127.0.0.1:0",
+      () => makeFakeSandbox({ defaultTargetId: "target-1" }),
+      { onSessionsChanged: (entries) => persisted.push([...entries]) },
+    )
+    sessions.createNew("alpha", { readOnly: true })
+    sessions.updateTarget("alpha", { id: "target-1", owner: "relay" })
+    await Effect.runPromise(sessions.persist())
+    const descriptor = persisted.at(-1)?.[0]
+    expect(descriptor).toMatchObject({ id: "alpha", readOnly: true, target: { id: "target-1", owner: "relay" } })
+
+    const restoredSandboxes: FakeSandbox[] = []
+    const restored = new BrowserControlSessions("http://127.0.0.1:0", () => {
+      const sandbox = makeFakeSandbox()
+      restoredSandboxes.push(sandbox)
+      return sandbox
+    })
+    restored.restore(descriptor ? [descriptor] : [])
+
+    expect(restored.listSummaries()).toMatchObject([{ id: "alpha", readOnly: true, stateKeys: [] }])
+    expect(restored.persistedTargetOwner("target-1")).toEqual({ sessionId: "alpha", owner: "relay" })
+    expect(restoredSandboxes[0]?.restoredTarget()).toEqual({ id: "target-1", owner: "relay" })
+  })
+
+  it("rejects duplicate target ownership in a persisted catalog", () => {
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox())
+    const entry = {
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:01:00.000Z",
+      readOnly: false,
+      target: { id: "target-1", owner: "relay" as const },
+    }
+
+    expect(() => sessions.restore([{ ...entry, id: "alpha" }, { ...entry, id: "beta" }]))
+      .toThrow("Duplicate persisted target owner: target-1")
+  })
+
+  it("persists target identity while disconnecting sessions for relay shutdown", async () => {
+    const persisted: PersistedSession[][] = []
+    const sessions = new BrowserControlSessions(
+      "http://127.0.0.1:0",
+      () => makeFakeSandbox({ defaultTargetId: "target-1" }),
+      { onSessionsChanged: (entries) => persisted.push([...entries]) },
+    )
+    sessions.createNew("alpha")
+    sessions.updateTarget("alpha", { id: "target-1", owner: "relay" })
+
+    await Effect.runPromise(sessions.closeAll())
+
+    expect(persisted.at(-1)).toMatchObject([{
+      id: "alpha",
+      target: { id: "target-1", owner: "relay" },
+    }])
+    expect(sessions.listSummaries()).toEqual([])
+  })
+
+  it("does not acknowledge reset until the targetless catalog state is committed", async () => {
+    await Effect.runPromise(Effect.gen(function* () {
+      let markCommitStarted: (() => void) | undefined
+      let releaseCommit: (() => void) | undefined
+      const commitStarted = new Promise<void>((resolve) => {
+        markCommitStarted = resolve
+      })
+      const commitGate = new Promise<void>((resolve) => {
+        releaseCommit = resolve
+      })
+      let blockWrites = false
+      const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox(), {
+        onSessionsChanged: () => {
+          if (!blockWrites) return
+          markCommitStarted?.()
+          return commitGate
+        },
+      })
+      sessions.createNew("alpha")
+      yield* sessions.persist()
+      blockWrites = true
+
+      const reset = yield* Effect.forkChild(sessions.reset("alpha"))
+      yield* Effect.promise(() => commitStarted)
+      expect(reset.pollUnsafe()).toBeUndefined()
+
+      releaseCommit?.()
+      expect((yield* Fiber.join(reset))?.id).toBe("alpha")
+    }))
+  })
+
+  it("does not let a target callback resurrect a session during a blocked delete commit", async () => {
+    let markCommitStarted: (() => void) | undefined
+    let releaseCommit: (() => void) | undefined
+    const commitStarted = new Promise<void>((resolve) => {
+      markCommitStarted = resolve
+    })
+    const commitGate = new Promise<void>((resolve) => {
+      releaseCommit = resolve
+    })
+    let blockWrites = false
+    const committed: PersistedSession[][] = []
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox(), {
+      onSessionsChanged: async (entries) => {
+        if (blockWrites) {
+          markCommitStarted?.()
+          await commitGate
+        }
+        committed.push([...entries])
+      },
+    })
+    sessions.createNew("alpha")
+    sessions.createNew("beta")
+    await Effect.runPromise(sessions.persist())
+    blockWrites = true
+
+    const deletion = Effect.runPromise(sessions.delete("alpha"))
+    await commitStarted
+    sessions.updateTarget("beta", { id: "target-beta", owner: "relay" })
+    releaseCommit?.()
+    await expect(deletion).resolves.toBe(true)
+    await Effect.runPromise(sessions.persist())
+
+    expect(committed.slice(-2).every((entries) => entries.every((entry) => entry.id !== "alpha"))).toBe(true)
+  })
+
+  it("fails durable lifecycle operations when the catalog cannot commit", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    let failWrites = false
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox(), {
+      onSessionsChanged: () => failWrites ? Promise.reject(new Error("catalog unavailable")) : undefined,
+    })
+    sessions.createNew("alpha")
+    await Effect.runPromise(sessions.persist())
+    failWrites = true
+
+    try {
+      await expect(Effect.runPromise(sessions.reset("alpha"))).rejects.toThrow("catalog unavailable")
+      expect(sessions.summary("alpha")).toBeDefined()
+      await expect(Effect.runPromise(sessions.delete("alpha"))).rejects.toThrow("catalog unavailable")
+      expect(sessions.summary("alpha")).toBeDefined()
+      await expect(Effect.runPromise(sessions.create("beta"))).rejects.toThrow("catalog unavailable")
+      expect(sessions.summary("beta")).toBeUndefined()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("releases a restored relay-owned target during reset", async () => {
+    const released: string[] = []
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox(), {
+      onReleaseRelayTarget: (targetId) => Effect.sync(() => {
+        released.push(targetId)
+      }),
+    })
+    sessions.restore([{
+      id: "alpha",
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:01:00.000Z",
+      readOnly: false,
+      target: { id: "target-1", owner: "relay" },
+    }])
+
+    await Effect.runPromise(sessions.reset("alpha"))
+
+    expect(released).toEqual(["target-1"])
+    expect(sessions.persistedTargetOwner("target-1")).toBeUndefined()
+  })
+
   it("creates a readable session id inside the first execute request", async () => {
     const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox())
 
@@ -656,6 +844,83 @@ describe("BrowserControlSessions", () => {
     )
   })
 
+  it("finishes execute journaling after an interrupted request once browser work settles", async () => {
+    await Effect.runPromise(Effect.gen(function* () {
+      const executeStarted = yield* Deferred.make<void>()
+      const releaseExecute = yield* Deferred.make<void>()
+      let markJournalStarted: (() => void) | undefined
+      let releaseJournal: (() => void) | undefined
+      let markJournalCompleted: (() => void) | undefined
+      const journalStarted = new Promise<void>((resolve) => {
+        markJournalStarted = resolve
+      })
+      const journalGate = new Promise<void>((resolve) => {
+        releaseJournal = resolve
+      })
+      const journalCompleted = new Promise<void>((resolve) => {
+        markJournalCompleted = resolve
+      })
+      const sessions = new BrowserControlSessions(
+        "http://127.0.0.1:0",
+        () => makeFakeSandbox({
+          onExecute: Deferred.succeed(executeStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseExecute)),
+            Effect.uninterruptible,
+          ),
+        }),
+        {
+          onExecuteRecord: () => {
+            markJournalStarted?.()
+            return journalGate.then(() => {
+              markJournalCompleted?.()
+            })
+          },
+        },
+      )
+      sessions.createNew("alpha")
+      const execute = yield* Effect.forkChild(sessions.execute({ sessionId: "alpha", code: "wait", createIfMissing: false }))
+      yield* Deferred.await(executeStarted)
+      yield* Fiber.interrupt(execute)
+
+      yield* Deferred.succeed(releaseExecute, undefined)
+      yield* Effect.promise(() => journalStarted)
+
+      releaseJournal?.()
+      yield* Effect.promise(() => journalCompleted)
+      expect(sessions.isExecuting("alpha")).toBe(false)
+    }))
+  })
+
+  it("bounds best-effort journal I/O without retaining the execute permit", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox(), {
+      journalTimeoutMs: 20,
+      onExecuteRecord: () => new Promise(() => {}),
+    })
+    sessions.createNew("alpha")
+    try {
+      await expect(Effect.runPromise(sessions.execute({ sessionId: "alpha", code: "noop", createIfMissing: false })))
+        .resolves.toMatchObject({ result: { text: "ok" } })
+      await expect(Effect.runPromise(sessions.delete("alpha"))).resolves.toBe(true)
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("removes an implicitly created session when its durable execute commit fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox(), {
+      onSessionsChanged: () => Promise.reject(new Error("catalog unavailable")),
+    })
+    try {
+      await expect(Effect.runPromise(sessions.execute({ sessionId: "ghost", code: "noop", createIfMissing: true })))
+        .rejects.toThrow("catalog unavailable")
+      expect(sessions.summary("ghost")).toBeUndefined()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("hook failures do not fail execute", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
     const sessions = new BrowserControlSessions(
@@ -813,7 +1078,7 @@ describe("BrowserControlSessions", () => {
       expect(implicitResult._tag).toBe("Failure")
       expect(sessions.listSummaries().map((session) => session.id).sort()).toEqual(["alpha", "beta"])
 
-      expect(sessions.releaseAdoptedTarget("target-1")).toBe("alpha")
+      expect(sessions.markTargetDetached("target-1")).toEqual(["alpha"])
       expect((yield* sessions.adopt({ sessionId: "beta", createIfMissing: false, targetId: "target-1", targetUrl: "https://example.com/adopted" })).session.id).toBe("beta")
     }))
   })
@@ -910,6 +1175,76 @@ describe("BrowserControlSessions", () => {
     expect(sessions.adoptedTargetId("alpha")).toBe("target-b")
     expect(registry.targetsByTargetId.get("target-a2")?.browserControlSessionId).toBeUndefined()
     expect(registry.targetsByTargetId.get("target-b")?.browserControlSessionId).toBe("alpha")
+  })
+
+  it("explicitly releases the previous target when a later adoption fails", async () => {
+    const registry = new TargetRegistry()
+    const addTarget = (tabId: number, targetId: string) => registry.addRootTarget({
+      tabId,
+      sessionId: `bc-tab-${tabId}`,
+      owner: "user" as const,
+      targetInfo: {
+        targetId,
+        type: "page" as const,
+        title: targetId,
+        url: `https://example.com/${targetId}`,
+        attached: true,
+        canAccessOpener: false,
+      },
+    })
+    addTarget(1, "target-a")
+    addTarget(2, "target-b")
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox({
+      onAdopt: (target) => target.targetId === "target-b"
+        ? Effect.fail(new Error("prompt target vanished"))
+        : Effect.succeed(target.url),
+    }), undefined, registry)
+    sessions.createNew("alpha")
+    await Effect.runPromise(sessions.adopt({
+      sessionId: "alpha",
+      createIfMissing: false,
+      targetId: "target-a",
+      targetUrl: "https://example.com/target-a",
+    }))
+
+    await expect(Effect.runPromise(sessions.adopt({
+      sessionId: "alpha",
+      createIfMissing: false,
+      targetId: "target-b",
+      targetUrl: "https://example.com/target-b",
+    }))).rejects.toThrow("prompt target vanished")
+
+    expect(sessions.adoptedTargetId("alpha")).toBeUndefined()
+    expect(registry.targetsByTargetId.get("target-a")?.browserControlSessionId).toBeUndefined()
+    expect(registry.targetsByTargetId.get("target-b")?.browserControlSessionId).toBeUndefined()
+  })
+
+  it("surfaces a durable adoption rollback failure", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    let failRollback = false
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox({
+      adoptFailure: new Error("target vanished"),
+    }), {
+      onSessionsChanged: (entries) => failRollback && entries.some((entry) => entry.id === "alpha" && !entry.target)
+        ? Promise.reject(new Error("rollback catalog unavailable"))
+        : undefined,
+    })
+    sessions.createNew("alpha")
+    await Effect.runPromise(sessions.persist())
+    sessions.updateTarget("alpha", { id: "target-a", owner: "user" })
+    await Effect.runPromise(sessions.persist())
+    failRollback = true
+
+    try {
+      await expect(Effect.runPromise(sessions.adopt({
+        sessionId: "alpha",
+        createIfMissing: false,
+        targetId: "target-b",
+        targetUrl: "https://example.com/target-b",
+      }))).rejects.toThrow("rollback catalog unavailable")
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
   it("preserves an existing sandbox when adoption times out before starting", async () => {


### PR DESCRIPTION
## What

Persist named Browser Control session identity, read-only mode, and exact default-target ownership across relay process restarts. Add prompt-first handoffs for native WebAuthn/payment UI, where WAIT is visible before the blocking action starts.

The extension shim advances to `0.0.18` so `pageStatus.set` acknowledges actual content-script delivery rather than silently accepting a missing WAIT UI.

## Before / After

**Before:** relay shutdown disconnected Playwright and discarded the in-memory session map. A later relay recreated no named sessions, so explicit `--session` calls failed or silently lost their default tab. Reset/delete could race catalog writes, and a process losing the port race could rewrite stale state.

**After:** the relay binds its endpoint before loading the private per-port catalog, restores exact session/target identity, and durably commits lifecycle state through atomic replacement plus file/directory sync. Corrupt catalogs fail closed. Relay-owned targets must re-announce before reset/delete can discard their identity.

**Before:** a native prompt could block the click before `handoff()` registered WAIT, while `Promise.all` could retain the execute permit forever after handoff timeout.

**After:** `handoff(message, { start })` registers the exact target waiter, waits for extension acknowledgement of WAIT, then invokes `start`. Human completion waits for the action; timeout/detach settles the Playwright disconnect before releasing the permit. Interrupted HTTP requests leave a bounded worker to finish aftermath, journaling, and catalog bookkeeping.

## How

- `src/session-catalog.ts` adds versioned endpoint-scoped persistence with schema decoding, private permissions, atomic replacement, and fsync durability.
- `src/session-manager.ts` restores sessions, serializes catalog snapshots, rolls back failed durable lifecycle changes, keeps execute/adopt permits through cleanup, and releases exact target ownership.
- `src/execute.ts` tracks one durable default target, removes stale page listeners, separates destructive close from relay disconnect, and exposes prompt-first handoff startup.
- `src/handoff.ts` coordinates WAIT presentation, action settlement, target cancellation, and timeout-safe action disconnection.
- `src/relay.ts` gates startup readiness until catalog restore, reclaims re-announced targets, and requires extension acknowledgement before prompt startup.
- `extension/src/background.ts` reports WAIT delivery failure and bumps the shim to `0.0.18`.
- Agent/user guidance documents restart state reset and native-prompt handoff behavior.

## Scope

- JavaScript `state` and snapshot refs remain process-local and reset with an explicit warning after relay restart.
- This does not claim a separate App Store Connect locator defect; compact snapshot and Playwright accessibility/role views can differ by frame and rerender timing.
- A disconnected extension still cannot create or attach browser targets; logical session identity now survives transport reconnect.
- Live browser smoke was not run because reloading shim `0.0.18` would disrupt unrelated sessions on the shared stale relay.

## Testing

- `pnpm run ci` (`350` tests, typecheck, CLI build, extension build)
- `pnpm pack --dry-run`
- `pnpm build:cli`
- `pnpm build:extension`
- `git diff --check`
- Isolated relay restart, target reclaim, extension reconnect, corrupt catalog, losing-port-race, pre-reannounce reset, lifecycle rollback, and handoff-ordering regressions
- Installed OpenCode Browser Control skill synced byte-for-byte

## Flow

```mermaid
sequenceDiagram
  participant Agent
  participant Relay
  participant Catalog
  participant Extension
  participant Page

  Relay->>Relay: bind endpoint
  Relay->>Catalog: load and validate
  Relay->>Relay: restore named sessions
  Extension->>Relay: re-announce attached target
  Relay->>Relay: reclaim exact owner

  Agent->>Relay: handoff(message, start)
  Relay->>Extension: pageStatus.set(WAIT)
  Extension->>Page: install completion control
  Extension-->>Relay: WAIT acknowledged
  Relay->>Page: invoke prompt action
  Page-->>Relay: matching completion or timeout
  Relay->>Catalog: durably commit final session state
  Relay-->>Agent: result and aftermath
```
