### PR TITLE
fix(relay): allow slower managed startup

### DIFF
--- a/.changeset/warm-relay-startup.md
+++ b/.changeset/warm-relay-startup.md
@@ -1,0 +1,6 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Allow cold managed relays up to ten seconds to restore persisted sessions and
+become ready before reporting startup failure.

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -60,7 +60,7 @@ export const ensureRelay = Effect.fn("RelayLifecycle.ensureRelay")(function* (op
   if (relayWasAbsent) yield* options.start ?? spawnManagedRelay()
   const version = yield* probe.pipe(
     Effect.retry({
-      times: options.retryTimes ?? 40,
+      times: options.retryTimes ?? 200,
       schedule: Schedule.spaced(options.retryDelayMs ?? 50),
       while: isRelayStartingOrUnreachable,
     }),

--- a/test/relay-lifecycle.test.ts
+++ b/test/relay-lifecycle.test.ts
@@ -77,6 +77,21 @@ describe("relay lifecycle", () => {
     expect(starts).toBe(1)
   })
 
+  it("allows a cold managed relay more than two seconds of readiness probes", async () => {
+    let attempts = 0
+    const result = await Effect.runPromise(ensureRelay({
+      relay: relay({
+        version: Effect.suspend(() => ++attempts >= 42 ? Effect.succeed(version) : Effect.fail(unreachable())),
+      }),
+      buildId: "build-current",
+      start: Effect.void,
+      retryDelayMs: 0,
+    }))
+
+    expect(result.started).toBe(true)
+    expect(attempts).toBe(42)
+  })
+
   it("waits for a bound relay to finish restoring without starting another process", async () => {
     let attempts = 0
     let starts = 0


### PR DESCRIPTION
## What

Allow a cold managed Browser Control relay up to ten seconds to become ready instead of failing after two seconds.

## Before / After

**Before:** a clean relay restart with two persisted sessions spawned the new relay successfully, but session restoration and extension target re-announcement took longer than the CLI's 40 x 50ms probe budget. The first execute returned `Browser Control relay did not start`; retrying moments later succeeded against the already-running relay.

**After:** managed startup gets 200 x 50ms readiness probes. The command continues waiting through the observed cold-start window while retaining the same retryable unreachable/starting error boundary.

## How

- Increase only `ensureRelay`'s default managed-start budget from 2s to 10s.
- Keep extension reconnect timing unchanged.
- Add a deterministic regression that becomes ready on probe 42, one probe beyond the previous default.

## Testing

- `pnpm run ci` (351 tests, typecheck, CLI and extension builds)
- `pnpm pack --dry-run`
- Live reproduction on CLI/relay 0.1.3 with extension 0.0.18: first command timed out at 2s, relay subsequently became healthy, and identical retry restored the persisted DOM and exact target.
