### PR TITLE
feat(client): add authenticated origin requests

### DIFF
--- a/.changeset/bright-taxis-reveal.md
+++ b/.changeset/bright-taxis-reveal.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Add `BrowserControlClient.reveal` for consuming sensitive authenticated responses across package-manager layouts with separate Effect runtime instances, plus `resetSession` for recovering disconnected named sessions without invoking the CLI.

--- a/.changeset/clear-browser-control-skill.md
+++ b/.changeset/clear-browser-control-skill.md
@@ -1,0 +1,6 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Reorganize the Browser Control agent skill around an inspect-act-verify golden
+path, explicit completion criteria, and concise optional workflows.

--- a/.changeset/typed-authenticated-origin.md
+++ b/.changeset/typed-authenticated-origin.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": minor
+---
+
+Add a public Effect client with atomic named sessions and schema-decoded, same-origin JSON requests authenticated by the live browser page. Sensitive responses are returned as `Redacted` values and bypass execute journals and active network captures.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,6 +116,21 @@ An environment-variable name such as `BC_SECRET_1` that retains its identity
 when a Secret Profile is refreshed from the same request source.
 _Avoid_: Token value, hardcoded credential
 
+**Authenticated Origin**:
+A session capability pinned to one HTTP origin. It performs bounded,
+schema-decoded `window.fetch` requests in the session's live default page so
+ambient browser authentication stays inside the User Browser. An explicit
+start URL may establish the page; request paths and redirects cannot escape the
+pinned origin.
+_Avoid_: Cookie export, Secret Profile request, arbitrary execute callback
+
+**Sensitive Response**:
+An Authenticated Origin result that bypasses execute journals and active Network
+Capture, crosses the local relay with `no-store`, and is returned to the caller
+as an Effect `Redacted` value. This prevents accidental disclosure; it is not
+cryptographic isolation from the trusted caller.
+_Avoid_: Secret Profile, encrypted response
+
 ## Relationships
 
 - A **Driver** serves one or more external **Agents**.
@@ -136,6 +151,10 @@ _Avoid_: Token value, hardcoded credential
 - An **Execute Sandbox** owns at most one active **Network Capture**.
 - A **Capture Artifact** refers to values in a **Secret Profile** through
   **Stable Secret References**.
+- An **Authenticated Origin** uses the current page's browser context without
+  reading a **Secret Profile** or exporting cookies.
+- A **Sensitive Response** is never appended to the execute journal or admitted
+  while **Network Capture** is active.
 - **Detach** removes an **Attached Tab** from the **Attached-Tab Pool**.
 
 ## Example Dialogue

--- a/PLAN.md
+++ b/PLAN.md
@@ -344,6 +344,18 @@ reconciles existing client announcements, browser grouping, and page status.
   JSON checks.
 - CLI and MCP relay access goes through `src/relay-client.ts`; neither maintains
   an ad hoc HTTP client.
+- The public Effect client uses the same typed relay client. It atomically
+  ensures named sessions and exposes an origin-bound capability for structured
+  JSON requests in the live default page.
+- Authenticated-origin requests use page-context `window.fetch`, never exported
+  cookies or Secret Profiles. They pin an exact origin, accept relative paths,
+  block redirects, bound response bytes, and never retry mutations.
+- Sensitive authenticated responses bypass execute journals, return as Effect
+  `Redacted` values, set `Cache-Control: no-store`, and fail closed while a
+  session Network Capture is active.
+- The public client reveals sensitive responses through its own `reveal`
+  operation so package-manager layouts with multiple Effect instances do not
+  cross incompatible module-local Redacted registries.
 - Boundary failures use tagged schema errors and a shared coded error envelope.
   The relay retains its message as the top-level human-readable message while
   clients can branch on stable codes for invalid requests, missing resources,

--- a/README.md
+++ b/README.md
@@ -128,6 +128,51 @@ browser-control status
 `doctor` and `status` are read-only. They report a stopped relay but never start
 one. Use `browser-control serve` only for foreground debugging.
 
+## TypeScript Client
+
+The package also exports an Effect client for applications that need structured
+browser-authenticated requests without executing generated JavaScript:
+
+```ts
+import { BrowserControlClient } from "@opencode-ai/browser-control"
+import { Effect, Schema } from "effect"
+
+const program = Effect.gen(function* () {
+  const client = yield* BrowserControlClient.make()
+  const browserSession = yield* client.ensureSession({ id: "my-app" })
+  const account = yield* browserSession.authenticatedOrigin({
+    origin: "https://app.example.com",
+    startUrl: "/account",
+  })
+
+  const sensitive = yield* account.json({
+    path: "/api/session",
+    method: "POST",
+    body: {},
+    response: Schema.Struct({ accessToken: Schema.String }),
+    sensitive: true,
+  })
+  const credentials = BrowserControlClient.reveal(sensitive)
+
+  const profile = yield* account.json({
+    path: "/api/profile",
+    response: Schema.Struct({ name: Schema.String }),
+  })
+  return { credentials, profile }
+})
+```
+
+Requests use `window.fetch` in the session's current page, so ambient browser
+cookies stay in the browser. Paths must be same-origin, redirects are blocked,
+responses are bounded, and mutations are never retried automatically. Set
+`sensitive: true` to receive `Redacted<A>`; sensitive requests bypass execute
+journals and are rejected while session network capture is active. Reveal a
+sensitive result with `BrowserControlClient.reveal`; this keeps unwrapping in
+the same Effect runtime that created the redacted value, including when an
+application and Browser Control resolve separate Effect package instances.
+Use `resetSession(id)` to replace a persisted session generation that is no
+longer connected before creating a new authenticated-origin capability.
+
 ## Work in Sessions
 
 A bare `execute` creates a fresh session. Pass its ID to continue with the same
@@ -203,7 +248,8 @@ Other inspection helpers include:
 - `fillInput()` and `fillInputs()` when browser extensions interfere with
   Playwright's normal `locator.fill()`
 
-The agent skill documents these helpers and their options in detail.
+The agent skill gives the operating workflow and canonical examples; command
+`--help` output remains the source of truth for detailed options.
 
 ## Pause for Human-Only Steps
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
     "url": "git+https://github.com/anomalyco/browser-control.git"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "files": [
     "dist",
     "extension/dist",
@@ -27,6 +33,7 @@
     "browser-control": "./dist/cli.js",
     "browser-control-mcp": "./dist/mcp.js"
   },
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "bench:recording": "tsx scripts/bench-recording.ts",
     "build:cli": "tsx scripts/build-cli.ts",

--- a/scripts/build-cli.ts
+++ b/scripts/build-cli.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises"
+import { execFile } from "node:child_process"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
 import { build } from "esbuild"
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
@@ -8,12 +10,14 @@ const dist = path.join(root, "dist")
 
 const packageJson = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as { readonly version: string }
 const buildId = new Date().toISOString()
+const execFileAsync = promisify(execFile)
 
 await fs.rm(dist, { recursive: true, force: true })
 await fs.mkdir(dist, { recursive: true })
 await build({
   entryPoints: {
     cli: path.join(root, "src", "cli.ts"),
+    index: path.join(root, "src", "index.ts"),
     mcp: path.join(root, "src", "mcp-main.ts"),
   },
   bundle: true,
@@ -27,5 +31,6 @@ await build({
   },
   outdir: dist,
 })
+await execFileAsync(path.join(root, "node_modules", ".bin", "tsc"), ["-p", path.join(root, "tsconfig.build.json")])
 await fs.chmod(path.join(dist, "cli.js"), 0o755)
 await fs.chmod(path.join(dist, "mcp.js"), 0o755)

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -1,386 +1,278 @@
 ---
 name: browser-control
-description: Control the user's existing Chromium-family browser through the Browser Control extension and local relay. Use when asked to automate, test, inspect, or drive the visible browser with Browser Control, especially in this repo or once the extension is installed.
+description: Drive the user's existing Chromium-family browser with deterministic Playwright. Use when asked to inspect, automate, test, or interact with a visible browser tab; continue an authenticated browser workflow; handle 2FA, passkeys, CAPTCHAs, or payment confirmation; record browser behavior; or capture an authenticated network flow.
 ---
 
 # Browser Control
 
-Use Browser Control as a **driver**: run deterministic Playwright code against
-the user's visible Chromium-family browser. Do not treat it as an autonomous
-agent.
+Browser Control is a **driver**, not an agent. The calling agent decides what to
+do; Browser Control runs deterministic Playwright code in the user's visible
+browser.
 
-## Workflow
+Use one loop throughout: **inspect, act, verify**. Inspect the real page before
+choosing locators, act through the narrowest stable control, then verify the
+result through a URL or fresh page read. Never treat a successful click or human
+acknowledgment as proof that the task succeeded.
 
-1. Run the first task directly.
+## Core Workflow
+
+### 1. Run The Task Directly
+
+Start with the requested browser work. Relay-backed commands start the detached
+relay and wait for the extension; do not start `browser-control serve` first.
 
 ```bash
-browser-control --help
 browser-control execute 'return { url: page.url(), title: await page.title() }'
 ```
 
-Relay-backed commands start a detached relay when needed and wait briefly for
-the extension to reconnect. Do not start `browser-control serve` first; it is
-the foreground debugging path and intentionally does not return.
-CLI and MCP share this detached relay; restarting the MCP process does not stop
-the relay or interrupt a CLI execute or pending handoff.
-
-If `browser-control` is not on PATH, install it with `npm install --global
-@opencode-ai/browser-control`. Use the source setup in the repository README only
-when developing Browser Control itself.
-
-`browser-control skill` prints this skill text from the installed package/repo.
-Use it to verify another agent has the current Browser Control instructions.
-
-Completion criterion: execute returns a page result and a readable session id
-with the exact `--session` continuation command.
-
-2. Inspect health only when setup or runtime behavior is unclear.
+Use `browser-control doctor` only when setup or runtime behavior is unclear.
+`status` and `doctor` are observational and never start the relay.
 
 ```bash
 browser-control doctor
-browser-control doctor --json
-browser-control status
 browser-control status --json
-browser-control session list
 ```
 
-`status` and `doctor` are read-only and never start the relay. A stopped `status`
-prints one concise next step instead of a stack trace. When running, `status`
-reports relay build compatibility, extension connectivity, sessions, targets,
-child target counts, and `crashed=true` for known crashed targets.
+Completion: one execute returns a page result and a readable session id, or
+`doctor` identifies the concrete setup failure.
 
-Use `browser-control doctor` before deeper debugging. It is read-only and checks
-the package/bin metadata, relay HTTP endpoint, extension connection/version,
-current and stale sessions, active, relay-owned, crashed, and browser-error
-targets, whether the running relay matches the current CLI build, and built
-artifacts such as `dist/cli.js`,
-`dist/mcp.js`, and `extension/dist/manifest.json`. Relay-backed commands reject
-a stale relay build with a concise restart message.
+### 2. Choose The Page Deliberately
 
-After extension shim changes, also confirm `version` matches
-`extension/manifest.json`.
+A bare CLI execute creates a fresh session-owned page and prints the exact
+`--session <id>` continuation command. Every later CLI call must pass that id or
+set `BROWSER_CONTROL_SESSION`; bare execute never guesses from human-shell
+current state.
 
-3. Create once, then continue the named session.
+```bash
+browser-control execute 'return page.url()'
+browser-control execute --session cosmic-otter-866 'return page.url()'
+```
 
-Bare execute always creates a fresh isolated session and prints `Continue with
---session <id>`. Every later shell call must pass that id (or set
-`BROWSER_CONTROL_SESSION`). No toolbar attachment is required.
+MCP keeps one implicit process session. Omit `session` for that normal path, or
+call `session_new` and pass an explicit id when one MCP process needs multiple
+sessions.
 
 To control a tab already open in the user's browser, ask the user to click the
-Browser Control toolbar button on that tab, then select it while creating a new
-session or adopt it for sticky reuse:
+Browser Control toolbar button on that tab. Select it for one execute or adopt
+it for sticky reuse:
 
 ```bash
-browser-control execute --target-url example.com 'return page.url()'
-browser-control session adopt --target-url example.com
+browser-control execute --target-url github.com 'return page.url()'
+browser-control session adopt --target-url github.com --session github
 ```
 
-4. Execute Playwright code.
+`targetUrl` and `targetIndex` select existing attached pages; they never
+navigate. A URL selector must match exactly one page, and URL and index selectors
+cannot be combined. Adoption makes that tab the session default, closes the
+session's previous relay-created page, and is exclusive to one Browser Control
+session. Reset or delete releases an adopted user tab without closing it.
 
-```bash
-# Creates a fresh session and prints its id.
-browser-control execute 'return { url: page.url(), title: await page.title() }'
-# Continue only with that returned id.
-browser-control execute --session cosmic-otter-866 'page.url()'
-browser-control execute --session cosmic-otter-866 --file ./script.js
-browser-control session new amazon
-browser-control execute --session amazon 'await page.goto("https://www.amazon.com")'
-browser-control execute --target-url example.com 'return page.url()'
-browser-control execute --target-index 0 'return page.url()'
-```
+Prefer adoption for authenticated browser state rather than reproducing login
+in a fresh page.
 
-Use `page`, `context`, `browser`, relay-backed persistent `state`, and `fillInput`
-inside execute code. Without a session, CLI execute atomically creates a fresh
-one and returns its id without reading or writing shared current-session state.
-Explicit ids from `--session`, `BROWSER_CONTROL_SESSION`, or MCP `execute({
-session: "id" })` must already exist. Each session gets one owned default page
-that persists across named execute calls. MCP keeps its own process-local current
-session because the MCP process itself is the agent boundary.
+Completion: the selected page URL is the intended page, and later work either
+retains the returned session id or intentionally uses the MCP process session.
 
-Create an explicit id with `session_new` first. With MCP, omit the id to let the
-server establish its process-local current session. `targetUrl` and
-`targetIndex` only select pages that already exist in
-the attached page pool; they never navigate or create a page. Use `page.goto()`
-to open a URL in a session-owned page, or attach an existing user tab with the
-toolbar before selecting or adopting it.
+### 3. Inspect, Act, Verify
 
-The sandbox also exposes Node modules both through `modules` and convenient
-aliases such as `fs` and `path`. Execute code runs in its own lexical scope, so
-scripts may safely declare local names such as `const path = ...` without
-colliding with those aliases.
-
-MCP `execute` extracts returned screenshot buffers, including buffers nested in
-objects and arrays, into ordered native image attachments without temporary
-files. This lets one call return images plus metadata. A screenshot saved to a
-path but not returned remains file-only. `snapshot()` remains the preferred
-compact textual read; request images only when visual layout matters.
-
-Bare execute drives its new session-owned page, never the user's attached tabs. To
-drive a tab the user attached with the toolbar, adopt it as the session's
-default page:
-
-```bash
-browser-control session adopt --target-url opencode-agent
-browser-control session adopt --target-index 0 -s my-session
-```
-
-Adoption is sticky: later executes reuse the adopted tab. Adopting closes the
-session's previous relay-created page; session reset/delete releases an adopted
-tab but never closes it. MCP exposes the same operation as `session_adopt`.
-When a bare execute has to create a fresh page while a user-attached tab is
-open, the result includes a warning tip suggesting the adopt command —
-that is the "why did a new tab appear?" moment. `--target-url`/`--target-index`
-on execute itself remain one-command selections, not sticky adoption. For multi-field forms that wedge on repeated
-locator-level DOM evaluation, use `fillInputs(page, fields)` to fill several
-selectors in one page execution.
-
-For authentication already established in a user-attached tab, prefer
-`execute --target-url <unique-url-part>` for one command or `session adopt
---target-url <unique-url-part>` for sticky reuse rather than reproducing login in
-a fresh relay-owned tab. After navigation or `handoff`, verify the expected URL
-or a stable element before entering data or continuing.
-
-Single-expression snippets such as `page.url()` and `await page.title()` return
-their value automatically; multi-statement scripts still require `return` for a
-value. Use `browser-control execute --file <path>` for longer scripts instead of
-embedding code in the shell. Prefer single-quoted shell arguments with
-double-quoted JavaScript strings so `$`, backticks, and `!` are not expanded by
-the shell. If the script itself needs shell single quotes, use `--file`. Do not
-pass both positional code and `--file`.
-Execute responses include structured per-call script/page console logs and page
-errors; human CLI output prints the returned value first, then logs, then any
-warnings and a one-line aftermath summary when the page URL changed or the call
-navigated, hit page errors, or paused for handoffs.
-
-Use `browser-control execute --json` when you want to branch on the result: it
-prints `{ ok, isError, text, value, valueUnavailable, error?: { _tag, message },
-logs, warnings, diagnostic?, aftermath, session }`. `value` is the structured JSON result of
-the script (jq-able: `execute --json '({a: 1})' | jq .value.a` prints `1`);
-`text` is the human-formatted rendering. `value` carries plain data only: objects,
-arrays, and primitives round-trip; `Map` becomes a plain object, `Set` an
-array, bigints strings. Class instances (Playwright `Page`, `Locator`, ...)
-and results whose JSON exceeds 32KB are withheld: `value` is `null` and
-`valueUnavailable` is `true` — fall back to `text`.
-`aftermath` reports `startUrl`, `endUrl`, main-frame `navigations`,
-`consoleErrorCount`, `pageErrorCount`, and `handoffs` for that one call.
-Recurring permissions-policy warnings and blocked analytics resources are folded
-into representative log entries, while application errors stay distinct and
-aftermath error counts continue to include every event. Warnings are delivered
-with the call that caused them, for example when the session default page was
-closed, crashed, or recreated. After an execution-context failure or crash,
-the next normal execute gives the default page a one-second health check. An
-unhealthy relay-owned page is recreated after it closes; a close failure gives
-reset guidance instead of leaking the old tab. An unhealthy adopted tab is
-preserved and the call fails quickly with reset/adopt guidance. Failed
-execution-context calls also carry a short fixed diagnostic classification with page/navigation
-counts; cross-extension navigation failures use
-`target/cross-extension-page`. Diagnostics never include evaluation arguments
-or results.
-
-Playwright downloads are not available through extension-backed tabs. Chromium
-blocks both `Browser.setDownloadBehavior` and the legacy
-`Page.setDownloadBehavior` through `chrome.debugger`, so
-`page.waitForEvent("download")` rejects immediately with a capability error
-instead of timing out and `download.saveAs()` cannot receive an artifact. When
-the page exposes the payload through fetch or an API response, read those bytes
-in the page and write them with the sandbox's `fs` module instead.
-
-## Guardrails And Read-Only Sessions
-
-The relay always blocks CDP commands that would destroy the user's real browser
-state: `Network.clearBrowserCookies`, `Network.clearBrowserCache`,
-`Storage.clearCookies` (which backs `context.clearCookies()`), and
-`Browser.close`. Scripts that call them fail with a clear error; never try to
-work around this.
-
-For inspect-only tasks, create a read-only session. The relay rejects
-input-dispatching CDP (`Input.*`) for it, so scripts can navigate, read, and
-screenshot but not click or type:
-
-```bash
-browser-control session new inspect-prod --read-only
-browser-control execute -s inspect-prod 'await page.goto("https://example.com"); return await page.title()'
-```
-
-In a read-only session, Playwright actions like `locator.click()` keep retrying
-the rejected input dispatch until their own timeout; pass a short `{ timeout }`
-if you expect a click to be blocked. Note that `page.evaluate` can still mutate
-the page via JavaScript; read-only guards trusted mistakes, not malicious code.
-
-## Human Handoff
-
-When a flow hits 2FA, CAPTCHAs, payment confirmation, or anything the user must
-do personally, call `handoff(message, { timeoutMs, start? })` inside execute code. It
-shows the message and an accessible **I'm done, continue** control in the page,
-blocks the script, and resumes only when the user activates that control. The
-WAIT UI survives top-level navigation and ambiguous extension child-target
-closures. Actual tab removal cancels the handoff explicitly. Default timeout is
-10 minutes; a timeout throws so the failure is explicit.
+Inspect before guessing roles or selectors:
 
 ```js
-await page.goto("https://accounts.example.com/login")
-await fillInput("#email", "me@example.com")
-await page.getByRole("button", { name: "Continue" }).click()
-await handoff("Complete the 2FA prompt, then use the in-page continue control")
-if (!page.url().startsWith("https://app.example.com/")) {
-  throw new Error(`2FA did not reach the app: ${page.url()}`)
-}
-await page.getByRole("heading", { name: "Dashboard" }).waitFor()
-return await page.title()
+return await snapshot()
 ```
 
-When the action itself may block on native WebAuthn, pass it as `start` so WAIT
-state is registered and acknowledged by the extension before the click. Keep
-the action timeout aligned with the handoff timeout and keep `start` limited to
-the browser action that opens the prompt:
+Then act from the returned structure and verify the destination:
+
+```js
+await ref("e12").click()
+await page.getByRole("heading", { name: "Settings" }).waitFor()
+if (!page.url().includes("/settings")) {
+  throw new Error(`Unexpected destination: ${page.url()}`)
+}
+return { url: page.url(), heading: await page.getByRole("heading").first().innerText() }
+```
+
+Use normal Playwright first. Keep dependent interactions in one execute when
+they rely on transient UI such as an open menu, selected rows, hover state, or
+an in-progress form.
+
+If native `locator.fill()` hangs because a browser extension interferes with
+focus, use the explicit `input`/`textarea` fallback:
+
+```js
+await fillInput(page.getByPlaceholder("Username"), "standard_user")
+```
+
+Completion: the final return value contains evidence of the requested outcome,
+not merely evidence that an action was attempted.
+
+### 4. Continue Or Finish Cleanly
+
+Named sessions preserve their default page across short-lived CLI and MCP
+processes. They also survive relay restarts: Browser Control restores the id,
+read-only mode, and exact default target. JavaScript `state` and snapshot refs
+are process-local and reset after a relay restart with an explicit warning.
+
+```bash
+browser-control session list
+browser-control session reset github
+browser-control session delete github
+```
+
+Every execute is journaled under
+`~/.browser-control/sessions/<id>/journal.jsonl`. The journal records code,
+status, duration, URL movement, warnings, handoffs, and bounded diagnostics.
+Never place credentials directly in execute source.
+
+```bash
+browser-control journal --session github --limit 50
+```
+
+Completion: retain the session only when follow-up work is expected; otherwise
+reset or delete session-owned pages and report any warnings that affect later
+work.
+
+## Canonical Authenticated Flow
+
+The distinguishing Browser Control workflow is an authenticated tab plus a
+human-only prompt:
+
+Attach and adopt the existing tab, inspect its real UI, fill ordinary fields,
+then register `handoff` before triggering WebAuthn, 2FA, CAPTCHA, or payment UI.
+After the user completes it, verify the authenticated destination. The same
+session can continue after an MCP process or relay restart.
+
+When the prompt-triggering action may itself block, put only that action in
+`start`. Browser Control presents and acknowledges WAIT before invoking it:
 
 ```js
 await handoff("Complete the security-key prompt, then continue", {
   timeoutMs: 600_000,
-  start: () => page.getByRole("button", { name: "Use security key" }).click({ timeout: 600_000 }),
+  start: () => page
+    .getByRole("button", { name: /passkey|security key|sign in/i })
+    .click({ timeout: 600_000 }),
 })
+
+await page.waitForURL((url) => !url.pathname.startsWith("/login"))
+await page.getByRole("heading", { name: /account|dashboard/i }).waitFor()
+return { authenticatedUrl: page.url(), title: await page.title() }
 ```
 
-After human completion, Browser Control waits for the action to settle before
-resuming. If the handoff times out or its target disappears while the action is
-still pending, Browser Control disconnects that session's Playwright connection
-before releasing the execute permit; the exact target remains the session
-default and is reacquired on the next execute.
+Tell the user what action is waiting. Human acknowledgment is not verification:
+always assert the expected URL or stable element after `handoff`. If the action
+was already completed and only the human step remains, call `handoff(message)`
+without `start`. The default timeout is ten minutes.
 
-Tell the user what you need before or while the handoff is pending. Handoffs are
-counted in the result aftermath and recorded in the session journal. Human
-acknowledgment is not proof that the task succeeded: always assert the expected
-URL or element after `handoff` before continuing. A toolbar click never resumes
-a handoff and does not detach its tab while the execute call is active.
+Completion: the prompt was presented only after WAIT was registered, the action
+settled, and the authenticated result was independently verified.
 
-## Session Journal
+## Inspection Tools
 
-Every execute call is journaled to
-`~/.browser-control/sessions/<id>/journal.jsonl` with a timestamp, the code, the
-result status, duration, URL movement, warnings, handoffs, and any bounded
-execution-context failure diagnostic. Use it to audit
-what an agent did to the browser or to debug a session after the fact:
+Use the least expensive view that answers the question:
+
+- `snapshot()` is the compact read-before-act default. It prioritizes semantic
+  groups, alerts, lists, tables, headings, links, and controls. Text input and
+  textarea values are omitted.
+- `ref("e12")` resolves a control from the latest snapshot. Refs fail closed
+  after navigation or incompatible DOM drift.
+- `snapshot({ diff: true })` reports semantic changes from the compatible prior
+  baseline. A diff invalidates earlier refs and exposes refs only for added or
+  changed current lines.
+- `ariaSnapshot(target?, { timeout })` returns Playwright's detailed YAML aria
+  tree when the compact snapshot omits needed structure.
+- `screenshotWithLabels({ page, path? })` adds visual labels and metadata when
+  layout matters.
+
+```js
+return await snapshot({ within: "main", maxItems: 200 })
+// When layout matters, return the image through MCP so it can be inspected.
+return await screenshotWithLabels({ page })
+```
+
+Saving an image and returning only `"ok"` proves file creation, not visual
+correctness. Return screenshot buffers through MCP when visual evidence matters.
+
+## Execute Interface
+
+Execute code can use `page`, `context`, `browser`, persistent `state`, selected
+Node modules through `modules` and aliases such as `fs` and `path`, plus the
+Browser Control helpers documented here. Single expressions auto-return;
+multi-statement scripts need `return`. Use `--file` for longer scripts:
 
 ```bash
-browser-control journal -s amazon --limit 50
-browser-control journal -s amazon --json
+browser-control execute --session github --file ./perform-flow.js
 ```
 
-For concurrent agents, let each agent's first bare execute create a fresh session,
-then require that agent to retain and pass its returned id. Use `browser-control
-session list` to see session-owned pages. `--target-url` and `--target-index` are manual
-recovery selectors for adopting a specific attached page for one command. The same
-selection can be supplied to scripts with `BROWSER_CONTROL_TARGET_URL` or
-`BROWSER_CONTROL_TARGET_INDEX`. `--target-url` must match exactly one attached
-page; use a more specific URL substring or `--target-index` if it matches multiple
-pages. Do not set URL and index selectors together.
-
-Prefer normal Playwright actions first:
-
-```js
-await page.getByRole("textbox", { name: "Email" }).fill("me@example.com")
-```
-
-Inspect before acting. Start with `snapshot()` and use `ariaSnapshot()` when the
-compact view omits the structure you need; do not spend a default 30-second
-locator timeout testing a guessed role or selector. Use a short exploratory
-timeout, inspect the current page after a miss, and only then choose the stable
-locator. After a click that navigates, verify the destination URL or a stable
-element before filling the next document. If execution-context diagnostics
-repeat, stop changing selectors and investigate page/session health instead.
-
-For visual verification, return screenshot buffers through MCP so the image is
-actually attached and inspectable. Saving a screenshot to a path and returning
-only `"ok"` proves that capture completed, not that the layout looks correct.
-Report exactly the viewport, state, and interaction path tested; do not describe
-a synthetic browser fixture as broad end-to-end or physical-device coverage.
-
-If normal `locator.fill()` hangs on login/password-style fields in the user's
-existing browser, use the explicit DOM-input fallback:
-
-```js
-await fillInput("#user-name", "standard_user")
-await fillInput(page.getByPlaceholder("Username"), "standard_user")
-await fillInputs(page, [
-  { selector: "#first-name", value: "Kit" },
-  { selector: "#last-name", value: "BrowserControl" },
-])
-```
-
-This is useful when installed browser extensions, such as password managers,
-interfere with Playwright's focus/fill machinery. It sets the value and dispatches
-`input` and `change` events; it is only for `input` and `textarea` locators.
-
-Allowed Playwright mouse actions automatically show a spring-animated arrow cursor that
-fades after idle time. The relay mirrors successful `Input.dispatchMouseEvent`
-move/press/release commands; blocked read-only input never renders the cursor.
-Use the helpers to keep it visible, customize it, or disable it for the current
-document:
-
-```js
-await page.goto("https://example.com")
-await page.mouse.move(100, 120)
-await page.getByRole("button", { name: "Submit" }).click()
-await showGhostCursor({ size: 20 })
-await ghostCursor.hide()
-```
-
-`showGhostCursor()` / `ghostCursor.show()` enters persistent mode.
-`hideGhostCursor()` / `ghostCursor.hide()` disables the cursor until the page's
-next document. Recording does not change cursor mode, and the cursor does not
-start or edit recordings.
-
-## Recording
-
-Use `browser-control recording start <output-path>` to record an attached tab.
-The default `--mode auto` keeps `chrome.tabCapture` for user-owned tabs and uses
-timestamped CDP screencasting for relay-owned tabs, so session-created `bc-tab-*`
-pages can be recorded without clicking the extension icon. CDP mode requires
-`ffmpeg` on `PATH`, accepts `.webm` or `.mp4`, defaults to 25 fps, and bounds
-the active viewport within 1280×720. It activates the recorded tab because
-Chromium throttles compositor frames in background tabs. `tab-capture` output
-must end in `.webm`; pass `--mode cdp` for `.mp4` or to force CDP on a
-user-owned tab.
-The `--session` flag accepts either the Browser Control session id you use with
-`execute` or the lower-level CDP `bc-tab-*` session id from `status --json`.
+Human CLI output includes logs, warnings, and a concise aftermath. Use `--json`
+when another command needs to branch on `ok`, `value`, `error`, `warnings`, or
+`aftermath`:
 
 ```bash
-browser-control recording start ./tmp/demo.mp4 --session my-session --mode cdp
-browser-control recording status --session my-session
-browser-control recording stop --session my-session
+browser-control execute --json --session github '({ url: page.url() })' | jq .value.url
 ```
 
-`tab-capture` writes a WebM file and can include audio. `cdp` writes WebM or MP4
-plus a `.json` metadata sidecar with source, encoded, coalesced, and dropped
-frame counts; it does not capture audio.
+Playwright downloads are unavailable through extension-backed tabs because
+Chromium blocks download artifact control through `chrome.debugger`. If the
+page exposes the payload through fetch or an API response, read the bytes in the
+page and write them with `fs`. Do not retry `page.waitForEvent("download")`.
 
-Session-owned pages stay attached and visible so repeated shell commands reuse the
-same browser state. Use `browser-control session reset` or
-`browser-control session delete` to close a session-owned page and clear its
-state. Close manually attached tabs normally, call `await page.close()`, or detach
-with the toolbar when you want to release them.
+## Safety
 
-Named sessions survive relay process restarts. Browser Control restores the
-session id, read-only mode, and exact default tab when it reappears, but
-JavaScript `state` and snapshot refs are process-local and reset with a warning.
-Successful create, reset, delete, adopt, and execute responses wait for their
-session catalog update to commit.
+Browser Control blocks CDP commands that would destroy shared browser state,
+including browser close and cookie/cache clearing. Never work around those
+guardrails.
 
-For multi-step UI tasks, prefer one `execute` block when the steps depend on
-transient page state such as selected rows, open menus, dialogs, hover state, or
-in-progress form edits. Persistent tabs preserve navigation and DOM state between
-commands, but a single script is safer when one action creates the exact UI state
-that the next action must consume.
+For inspect-only work, use a read-only session:
+
+```bash
+browser-control session new inspect-prod --read-only
+browser-control execute --session inspect-prod 'await page.goto("https://example.com"); return page.title()'
+```
+
+Read-only sessions reject `Input.*`, so they cannot click or type through
+Playwright. `page.evaluate` can still mutate the DOM; read-only prevents trusted
+mistakes, not malicious code.
+
+For destructive UI work, use a two-phase **read, confirm, verify** flow:
+
+1. Read candidates and return exact stable identifiers or row text.
+2. Obtain user approval for those exact items.
+3. Re-select only approved items and assert the selected count.
+4. Read the confirmation dialog and throw unless it matches the approved action.
+5. Confirm, then verify through a fresh page read or independent CLI/API path.
+
+Do not discover and confirm destructive candidates in one script unless the
+user already approved exact stable identifiers. Never globally auto-accept
+native dialogs; wait for the expected dialog and assert its type and message
+before accepting it.
+
+## TypeScript Client
+
+Applications can import `BrowserControlClient` for schema-decoded,
+same-origin requests authenticated by a session page. Use `sensitive: true`
+for token-bearing responses and reveal them through Browser Control's API, not
+the application's own Effect `Redacted` import; package-manager layouts may
+resolve separate Effect runtimes.
+
+```ts
+import { BrowserControlClient } from "@opencode-ai/browser-control"
+
+const sensitive = yield* origin.json({
+  path: "/api/session",
+  method: "POST",
+  body: {},
+  response: SessionResponse,
+  sensitive: true,
+})
+const session = BrowserControlClient.reveal(sensitive)
+```
 
 ## Authenticated Network Capture
 
-Use network capture when repeated direct HTTP calls would be faster and more
-reliable than driving the browser every time. Browser Control records normalized
-Playwright request/response exchanges itself; HAR is only the interoperable
-export format.
-
-Start from a logged-in session, then exercise each client flow at least twice
-with different inputs so constants and parameters can be distinguished:
+Use network capture when the browser is needed to authenticate or discover a
+workflow, but repeated direct HTTP calls would be faster and more reliable.
+Capture each flow at least twice with different inputs so constants and
+parameters can be distinguished.
 
 ```bash
 browser-control network start --session github --url /api/ \
@@ -391,314 +283,85 @@ browser-control network stop --session github \
   --output ./github.har --secrets github
 ```
 
-Captures span execute calls and handoffs and follow the session's default page
-when it is adopted or recovered. Bodies default to `embed`; use `--content omit`
-when shapes are unnecessary. The defaults cap each body at 1 MB, total retained
-body data at 25 MB, and entries at 1000. Status and stop results report body
-bytes, truncations, failures, and dropped entries without captured values.
-JSON, URL-encoded forms, and text-only multipart forms are exported with
-credential substitution. Opaque, malformed, file-bearing multipart, binary, and
-truncated bodies are omitted and counted as truncated rather than written
-without reliable redaction.
-Response bodies also require an uncompressed declared `Content-Length` within
-the remaining budgets; unknown-length or compressed bodies are omitted rather
-than materialized without a memory bound.
+Written artifacts replace credential-bearing headers, cookies, query fields,
+and structured body fields with stable references such as `${BC_SECRET_1}`.
+`--secrets github` stores lossless values separately in a mode-`0600` Secret
+Profile. Never copy profile values into source, output, diagnostics, or journals,
+and never deliberately return or log credentials.
 
-Written artifacts are safe by default: credential-bearing headers, cookies,
-token-like query parameters, and structured body fields become literal stable
-references such as `${BC_SECRET_1}`. `--secrets github` stores the original
-values separately in `~/.browser-control/secrets/github.json` with mode `0600`.
-Never copy profile values into generated source, output, diagnostics, or a
-session journal.
-While capture is active, Browser Control also substitutes values observed in
-completed exchanges and removes secret-shaped returned fields from execute
-results, logs, URLs, and journal records. Do not deliberately return or log
-credentials; this redaction is a final safety boundary, not a secret-inspection
-interface.
-
-Inspect the HAR offline to identify first-party JSON endpoints, request
-dependencies, response shapes, pagination, and required headers. Generate one
-typed function per observed flow. Generated code reads the exact `BC_SECRET_N`
-environment variables referenced by the artifact and gives a concise refresh
-instruction on 401/403. Verify every generated function with a harmless live
-request before declaring the client complete.
-
-Run a generated client without exposing credential values:
+Inspect the redacted artifact offline, generate one typed function per observed
+flow, then verify each function with a harmless live request. Run generated
+clients without exposing values:
 
 ```bash
 browser-control secrets status github
 browser-control secrets run github -- ./github-cli repositories
 ```
 
-Browser Control injects the profile as environment variables and replaces known
-values in bounded child stdout/stderr with their references. Do not print the
-environment variables in generated code; redaction is defense in depth, not an
-invitation to log credentials.
-
-For credentials normally renewed by a page reload:
+Refresh credentials normally renewed by a page reload with:
 
 ```bash
 browser-control secrets refresh github --session github --url /api/
 ```
 
-Refresh preserves a reference when the credential observed at that source
-changes, and succeeds when a still-valid value is observed unchanged. If the
-site requires login, 2FA, or another human action instead, reauthenticate in the
-adopted tab and repeat `network start`/`network stop --secrets github`; the same
-source-based refresh behavior applies.
+If refresh requires login or a human prompt, reauthenticate in the adopted tab
+and repeat capture with the same profile. MCP exposes equivalent `network_*`
+and `secrets_*` tools.
 
-Execute code has equivalent `network.start(options)`, `network.status()`,
-`network.stop({ outputPath, secrets })`, and `network.cancel()` helpers. MCP
-provides `network_start`, `network_status`, `network_stop`, `network_cancel`,
-`secrets_status`, `secrets_refresh`, and `secrets_run` over the same recorder and
-profile store.
-Pass an absolute `outputPath` from execute code (use the provided `path.resolve`)
-so artifact location does not depend on the detached relay's original working
-directory. CLI and MCP resolve relative output and child-command paths against
-their caller process working directory before contacting the relay.
+Completion: the artifact contains references rather than credential values, the
+generated operation passes a harmless live check, and no secret value appears
+in source or output.
 
-## Labeled Screenshots
+## Recording
 
-Use `screenshotWithLabels({ page, path? })` when a visual page read would help.
-The helper overlays simple `e1`, `e2`, ... labels on visible likely-interactive
-elements, captures a Playwright screenshot, removes the overlay, and returns
-image plus label metadata. Omit `path` and return the result through MCP for an
-in-memory attachment; when supplied, `path` must be absolute and the image is
-saved instead.
-
-```js
-const screenshotPath = path.resolve("tmp/home-labels.png")
-return await screenshotWithLabels({ page, path: screenshotPath })
-```
-
-Labels cover a small DOM-only set: buttons, links, inputs, textareas, selects,
-`role=button/link/tab/menuitem`, `[onclick]`, and `[contenteditable]`. Each
-label entry carries its `ref` (`e1`, `e2`, ...), a `selector` for the next
-Playwright locator, and, when ambiguous, a short `context` string from the
-nearest row/section/heading so identical buttons (five "Connect" buttons in
-five integration rows) are distinguishable without another round-trip.
-
-## Accessibility Snapshot
-
-Prefer `snapshot()` for the compact read-before-act happy path. It uses the
-page's single `main` region when available, collapses navigation, and spends its
-bounded item budget on alerts, semantic groups, lists, tables, block code,
-headings, primary links, and controls before repeated metadata. It summarizes
-select option counts, pairs table headers with row cell values, and assigns refs
-to controls. Its timeout defaults to 10 seconds to accommodate a cold first
-browser evaluation. Text input and textarea values are omitted:
-
-```js
-return await snapshot()
-```
-
-Use a returned ref on the next execute call as a Playwright locator:
-
-```js
-await ref("e12").click()
-```
-
-Refs belong to the latest snapshot and are rejected after main-frame navigation.
-They combine structural position with captured accessible identity, so sibling
-DOM drift fails closed instead of silently retargeting a different named control.
-Drill into omitted context with `snapshot({ within, interactive, compact, depth,
-maxItems, timeout })`.
-
-After a full snapshot establishes a baseline, use `snapshot({ diff: true })`
-with the same page and shape options to return only semantic additions and
-removals plus an unchanged count:
-
-```js
-await ref("e12").click()
-return await snapshot({ diff: true })
-```
-
-Each successful diff becomes the next baseline. A diff invalidates earlier refs
-and assigns current refs only to added or changed lines. Take another full
-snapshot before acting on an unchanged element.
-
-Use `ariaSnapshot(target?, { timeout })` when the compact view omitted needed
-structure. It defaults to a 5-second timeout and
-returns Playwright's YAML aria snapshot for a selector, locator, or the whole
-page (default `body`), so one call shows you whether a "tab bar" is really a
-`<select>`, what a control's accessible name is, and which roles exist —
-without burning a 30s locator timeout on a wrong `getByRole` guess:
-
-```js
-return await ariaSnapshot("main", { timeout: 10_000 })
-```
-
-Omit the options for the 5-second default, or override `timeout` in milliseconds
-for a deliberately slow region. Use `screenshotWithLabels` when you need visual
-layout rather than structure, and raw Playwright when neither snapshot shape is
-specific enough.
-
-## Destructive UI Recipe
-
-For destructive UI work, such as deleting drafts when no CLI/API command exists,
-use a two-phase read-confirm-verify flow. Do not confirm destructive actions in
-the same script that first discovers candidates unless the user already approved
-the exact stable identifiers/text.
-
-Phase 1 inspects candidates and returns exact row text/IDs for user approval:
-
-```js
-await page.goto("https://example.com/items", { waitUntil: "domcontentloaded" })
-await page.waitForTimeout(3000)
-
-const rows = await page.locator("[role=row], tr").evaluateAll((nodes) => {
-  return nodes.map((node, index) => ({
-    index,
-    text: (node.textContent || "").replace(/\s+/g, " ").trim(),
-  })).filter((row) => row.text.includes("Draft"))
-})
-
-return { url: page.url(), title: await page.title(), rows }
-```
-
-Phase 2 acts only on approved rows. Scope clicks from stable row text or IDs, read
-the confirmation dialog, and throw unless the dialog matches the approved action:
-
-```js
-const approvedTexts = ["Draft invoice A $10.00", "Draft invoice B $20.00"]
-
-for (const approvedText of approvedTexts) {
-  const row = page.locator("[role=row], tr").filter({ hasText: approvedText })
-  if (await row.count() !== 1) {
-    throw new Error(`Expected exactly one row for ${approvedText}`)
-  }
-  await row.locator("input[type=checkbox], [role=checkbox]").first().click()
-}
-
-const selected = await page.locator("input[type=checkbox]").evaluateAll((nodes) => {
-  return nodes.map((node, index) => ({ index, checked: node instanceof HTMLInputElement && node.checked }))
-    .filter((item) => item.checked)
-})
-if (selected.length !== approvedTexts.length) {
-  throw new Error(`Expected ${approvedTexts.length} selected rows, got ${selected.length}`)
-}
-
-await page.getByRole("button", { name: /delete/i }).click()
-
-const dialogText = await page.locator("[role=dialog], [aria-modal=true]").innerText()
-if (!dialogText.includes(String(approvedTexts.length)) || !dialogText.match(/delete/i)) {
-  throw new Error(`Unexpected confirmation dialog: ${dialogText}`)
-}
-
-await page.getByRole("button", { name: /delete|confirm/i }).last().click()
-await page.waitForTimeout(1000)
-
-return { approvedTexts, selected, dialogText, url: page.url() }
-```
-
-After confirming in the UI, verify independently with a fresh read path, such as
-the app's list page, a CLI/API command, or a second `browser-control execute` that
-reloads the page and checks the target rows are gone.
-
-Never globally auto-accept native browser dialogs. If a native alert/confirm/prompt
-is expected, use `page.waitForEvent("dialog")`, assert `dialog.type()` and exact
-`dialog.message()`, then accept only that dialog.
-
-## Iteration Rule
-
-The extension is a stable Chrome API shim. Prefer changing relay code over
-extension code. Relay-only changes should require restarting `serve`, not
-reloading the browser extension.
-
-If `extension/src/background.ts`, `src/protocol.ts`, or extension build config
-changes, run:
+Record an attached or session-owned tab with:
 
 ```bash
-pnpm build:extension
+browser-control recording start ./tmp/demo.mp4 --session github --mode cdp
+browser-control recording status --session github
+browser-control recording stop --session github
 ```
 
-Then reload the unpacked extension once in Brave.
+`--mode auto` uses tab capture for user-owned tabs and CDP for relay-owned tabs.
+Tab capture can include audio; CDP requires `ffmpeg` and has no audio. Use the
+command's `--help` for format and cursor options.
 
-The relay/extension protocol is a small custom JSON-over-websocket protocol. The
-Node relay uses Effect for orchestration, but the MV3 shim does not use Effect RPC
-unless a future protocol-versioning need justifies it.
-
-## Keep Docs Synced
-
-When architecture, commands, install flow, troubleshooting, or agent-facing
-behavior changes, update this file and `PLAN.md` in the same change. When domain
-language changes, update `CONTEXT.md` too.
+Completion: stop the recorder, inspect the resulting media rather than only its
+existence, and report the viewport, state, and interaction path actually tested.
 
 ## Troubleshooting
 
-- `connected:false`: run a relay-backed command to auto-start the relay, then
-  reload the unpacked extension if its reconnect loop does not recover.
-- `Target not found`: check `/extension/status`, then attach a tab or inspect
-  relay logs.
-- Extension changes not taking effect: rebuild `extension/dist` and reload the
-  unpacked extension once.
-- Repeated `hello` messages or in-flight RPC timeouts: check for duplicate shim
-  websocket reconnects. The current shim version is `0.0.18`.
-- Relay restarted while tabs were attached: shim `0.0.7`+ re-announces attached
-  tabs after reconnecting, so the relay rebuilds its target registry without
-  re-clicking the toolbar. Named sessions reclaim the exact persisted target;
-  JavaScript state and snapshot refs reset. If `activeTargets` stays 0 with an
-  older shim, reload the unpacked extension and re-attach.
-- Stale relay build: operational CLI and MCP calls reject the relay before
-  invoking a route. `status` and `doctor` remain observational. Source runs use
-  a content fingerprint, so rebuilds and worktrees cannot silently share
-  incompatible relay code. Bounded process-fault diagnostics for managed relays
-  are retained in `~/.browser-control/relay.log`; `/version` reports the relay
-  instance id, start time, and PID.
-- All tabs suddenly detached (`activeTargets: 0`) while the browser looks fine:
-  the user probably dismissed the "is being debugged" banner, which detaches
-  chrome.debugger from every tab at once. Re-attach via the toolbar (or
-  `session adopt` after re-attaching).
-- Control group: shim `0.0.16`+ puts session-owned tabs, including adopted user
-  tabs, in a purple `control` group within each browser window. Merely attached
-  tabs remain where the user put them. Reset, delete, or re-adoption releases an
-  adopted tab from the group without closing it. Legacy `browser-control`,
-  `bc:*`, and `bc · *` groups remain recognized for cleanup.
-- Full session ids remain in CLI status, journals, and in-page accessibility
-  text. The toolbar badge shows `ON` when attached, `RUN` while a mutable session executes,
-  and `WAIT` while a handoff is pending. Read-only execution stays quietly `ON`.
-  Badges beyond `ON` require shim `0.0.6`
-  or newer. The explicit in-page handoff completion control and navigation
-  reinjection require shim `0.0.10`; cursor-anchored handoff prompts require
-  `0.0.15`.
-- Active targets after an execute run are expected: relay-created tabs persist
-  across short-lived CLI calls. Close the visible tab, call `await page.close()`,
-  or detach it with the toolbar if you want `/extension/status` to return to zero.
-- Clipboard failures on HTTP pages: prefer a secure origin and explicit browser
-  permissions. DOM clicking alone may not update or expose clipboard contents.
-- Download waits fail with a direct capability error: Chromium does not expose
-  download artifact control through an extension's `chrome.debugger` tab
-  attachment. Prefer fetching the payload and writing it with `fs`; do not wait
-  for a Playwright download event or retry the click.
-- Login or password field fill timeouts: suspect installed browser extensions
-  interfering with Playwright's native fill path. Try selector-based
-  `fillInput(selector, value)` first, or `fillInput(locator, value)` after
-  confirming the locator resolves.
-- Ghost cursor overlay: allowed Playwright mouse actions show it automatically,
-  and it fades when idle. Use `showGhostCursor()`, `hideGhostCursor()`, or
-  `ghostCursor.show/hide` for persistent/customized or disabled behavior.
-  Read-only input is rejected before rendering; recording does not change mode.
-- Closed page during input on real-world React apps: suspect CDP session detach
-  handling around `Target.detachFromTarget` / `Input.dispatchKeyEvent`. Reproduce
-  with local smoke fixtures before changing unrelated locator code, then compare
-  against the real-world page after accounting for browser extension interference.
-- Missing iframe after reconnect: run `SMOKE_CASE=oopif-reconnect pnpm smoke`.
-  Browser Control should replay stored child target attaches and current child
-  frame navigation for the current OOPIF canary.
-- Repeated `Execution context was destroyed` failures: run one short follow-up
-  execute so Browser Control can wait through transient context replacement and
-  health-check the default page. Same-tab root replacements preserve ownership,
-  handoffs, and the exact target id. A genuinely unhealthy relay-owned page is
-  recreated automatically; reset or re-adopt an unhealthy user-owned tab
-  because Browser Control will not replace it. If failures continue,
-  restart the relay with `BROWSER_CONTROL_DEBUG=1` before reproducing. `[bc:ctx]`
-  lines contain bounded metadata only: target/context IDs, ownership, loader changes, URL origin/shape
-  plus fingerprint, reset outcomes, and evaluate shape/failure class. They never
-  include expressions, arguments, results, headers, cookies, or form values.
-- Long-running relay testing: from the repository root, use `termctrl start
-  browser-control-relay --cwd "$PWD" --cols 120 --rows 24 --
-  browser-control serve`.
-- Bursty navigation to the same heavyweight origin: if several fresh sessions
-  all stall before commit while other origins work, serialize those navigations
-  or give `page.goto` a deliberate longer timeout. Browser Control preserves raw
-  Playwright navigation semantics rather than adding hidden retries.
+1. Run `browser-control doctor`; it checks package metadata, CLI/relay build
+   identity, extension connection/version, sessions, targets, and artifacts.
+2. Use `status --json` to inspect exact sessions and target ownership.
+3. Reproduce once with the smallest execute before changing code.
+
+Common diagnoses:
+
+- `connected:false`: run a relay-backed command, then reload the unpacked
+  extension only if its reconnect loop does not recover.
+- Stale relay build: operational commands reject it with restart guidance;
+  rebuild the CLI and restart the relay.
+- `Target not found`: attach the intended tab, then select or adopt it using a
+  unique URL substring or explicit index.
+- All targets disappeared: dismissing Chromium's debugging banner detaches every
+  tab. Reattach through the toolbar.
+- Relay restarted: named sessions reclaim exact targets, but JavaScript `state`
+  and snapshot refs reset. Continue after the warning.
+- Repeated execution-context errors: run one short follow-up so Browser Control
+  can health-check the page. It may recreate a relay-owned page, but it never
+  replaces an unhealthy adopted user tab; reset or re-adopt that tab.
+- Fill timeout on login fields: inspect first, then try `fillInput` after
+  confirming the selector or locator resolves.
+- Download wait fails: use fetch plus `fs`; extension-backed Playwright cannot
+  retain a native download artifact.
+
+For deeper relay diagnosis, restart with `BROWSER_CONTROL_DEBUG=1`. Debug traces
+must never include expressions, arguments, results, headers, cookies, or form
+values.
+
+Whenever Browser Control fails, wedges, replaces a page/session, or behaves
+unexpectedly, create or update a `browser-control` project todo with the Browser
+Control version, safe session/page context, exact error, deterministic
+reproduction, expected versus actual behavior, and recovery attempted. Never
+include credentials, form values, or private account data.

--- a/src/authenticated-origin.ts
+++ b/src/authenticated-origin.ts
@@ -1,0 +1,229 @@
+import { Effect, Schema } from "effect"
+import type { Page } from "playwright-core"
+import type {
+  AuthenticatedJsonMethod,
+  AuthenticatedJsonOutcome,
+  AuthenticatedJsonRequest,
+} from "./relay-schema.ts"
+
+const defaultTimeoutMs = 30_000
+const defaultMaxResponseBytes = 2_000_000
+
+export class AuthenticatedOriginError extends Schema.TaggedErrorClass<AuthenticatedOriginError>()(
+  "AuthenticatedOrigin.Error",
+  {
+    message: Schema.String,
+    reason: Schema.Literals(["invalid-request", "page-failed"]),
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {}
+
+type RequestOptions = Omit<AuthenticatedJsonRequest, "sessionId">
+
+type PageRequestInput = {
+  readonly origin: string
+  readonly method: AuthenticatedJsonMethod
+  readonly url: string
+  readonly body?: unknown
+  readonly timeoutMs: number
+  readonly maxResponseBytes: number
+}
+
+export const requestJson = Effect.fn("AuthenticatedOrigin.requestJson")(function* (
+  page: Page,
+  request: RequestOptions,
+) {
+  const target = yield* Effect.try({
+    try: () => {
+      const origin = normalizeOrigin(request.origin)
+      return {
+        origin,
+        requestUrl: resolveRequestUrl(origin, request.path),
+        startUrl: request.startUrl === undefined ? undefined : resolveStartUrl(origin, request.startUrl),
+      }
+    },
+    catch: (cause) => cause instanceof AuthenticatedOriginError
+      ? cause
+      : new AuthenticatedOriginError({
+          message: "Invalid authenticated origin request",
+          reason: "invalid-request",
+          cause,
+        }),
+  })
+  const { origin, requestUrl, startUrl } = target
+
+  if (pageOrigin(page.url()) !== origin && startUrl !== undefined) {
+    yield* Effect.tryPromise({
+      try: () => page.goto(startUrl, { waitUntil: "domcontentloaded", timeout: request.timeoutMs ?? defaultTimeoutMs }),
+      catch: (cause) => new AuthenticatedOriginError({
+        message: cause instanceof Error ? cause.message : "Navigate to authenticated origin",
+        reason: "page-failed",
+        cause,
+      }),
+    })
+  }
+
+  const actualOrigin = pageOrigin(page.url())
+  if (actualOrigin !== origin) {
+    return {
+      _tag: "OriginMismatch",
+      expectedOrigin: origin,
+      actualOrigin,
+    } satisfies AuthenticatedJsonOutcome
+  }
+
+  const input: PageRequestInput = {
+    origin,
+    method: request.method,
+    url: requestUrl,
+    ...(request.body === undefined ? {} : { body: request.body }),
+    timeoutMs: request.timeoutMs ?? defaultTimeoutMs,
+    maxResponseBytes: request.maxResponseBytes ?? defaultMaxResponseBytes,
+  }
+
+  return yield* Effect.tryPromise({
+    try: () => page.evaluate(runPageRequest, input),
+    catch: (cause) => new AuthenticatedOriginError({
+      message: cause instanceof Error ? cause.message : "Run authenticated page request",
+      reason: "page-failed",
+      cause,
+    }),
+  }).pipe(Effect.uninterruptible)
+})
+
+export function normalizeOrigin(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch (cause) {
+    throw new AuthenticatedOriginError({
+      message: `Invalid authenticated origin: ${value}`,
+      reason: "invalid-request",
+      cause,
+    })
+  }
+  if ((url.protocol !== "https:" && url.protocol !== "http:") || url.username || url.password) {
+    throw new AuthenticatedOriginError({
+      message: `Authenticated origin must be an HTTP(S) origin without credentials: ${value}`,
+      reason: "invalid-request",
+    })
+  }
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw new AuthenticatedOriginError({
+      message: `Authenticated origin must not include a path, query, or fragment: ${value}`,
+      reason: "invalid-request",
+    })
+  }
+  return url.origin
+}
+
+function resolveRequestUrl(origin: string, path: string): string {
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    throw new AuthenticatedOriginError({
+      message: "Authenticated request path must start with one slash",
+      reason: "invalid-request",
+    })
+  }
+  const url = new URL(path, origin)
+  if (url.origin !== origin) {
+    throw new AuthenticatedOriginError({
+      message: `Authenticated request escaped its declared origin: ${path}`,
+      reason: "invalid-request",
+    })
+  }
+  return url.toString()
+}
+
+function resolveStartUrl(origin: string, value: string): string {
+  const url = new URL(value, origin)
+  if (url.origin !== origin) {
+    throw new AuthenticatedOriginError({
+      message: `Authenticated origin startUrl must stay on ${origin}`,
+      reason: "invalid-request",
+    })
+  }
+  return url.toString()
+}
+
+function pageOrigin(value: string): string {
+  try {
+    return new URL(value).origin
+  } catch {
+    return "null"
+  }
+}
+
+async function runPageRequest(input: PageRequestInput): Promise<AuthenticatedJsonOutcome> {
+  if (window.location.origin !== input.origin) {
+    return {
+      _tag: "OriginMismatch",
+      expectedOrigin: input.origin,
+      actualOrigin: window.location.origin,
+    }
+  }
+
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), input.timeoutMs)
+  let requestStarted = false
+  try {
+    const body = input.body === undefined ? undefined : JSON.stringify(input.body)
+    requestStarted = true
+    const response = await window.fetch(input.url, {
+      method: input.method,
+      credentials: "same-origin",
+      mode: "same-origin",
+      redirect: "error",
+      signal: controller.signal,
+      ...(body === undefined
+        ? {}
+        : {
+            headers: { "content-type": "application/json" },
+            body,
+          }),
+    })
+
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined)
+      return { _tag: "HttpError", status: response.status }
+    }
+
+    const reader = response.body?.getReader()
+    const decoder = new TextDecoder()
+    let byteCount = 0
+    let text = ""
+    if (reader) {
+      while (true) {
+        const chunk = await reader.read()
+        if (chunk.done) break
+        byteCount += chunk.value.byteLength
+        if (byteCount > input.maxResponseBytes) {
+          await reader.cancel().catch(() => undefined)
+          return {
+            _tag: "ResponseTooLarge",
+            status: response.status,
+            maxResponseBytes: input.maxResponseBytes,
+          }
+        }
+        text += decoder.decode(chunk.value, { stream: true })
+      }
+      text += decoder.decode()
+    }
+
+    try {
+      return {
+        _tag: "Success",
+        status: response.status,
+        value: text ? JSON.parse(text) : null,
+      }
+    } catch {
+      return { _tag: "InvalidJson", status: response.status }
+    }
+  } catch (cause) {
+    return {
+      _tag: "RequestFailed",
+      outcome: requestStarted ? "unknown" : "not-sent",
+    }
+  } finally {
+    window.clearTimeout(timeout)
+  }
+}

--- a/src/browser-control-client.ts
+++ b/src/browser-control-client.ts
@@ -1,0 +1,353 @@
+import { fileURLToPath } from "node:url"
+import { Context, Effect, Layer, Redacted, Schema } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import * as AuthenticatedOriginInternal from "./authenticated-origin.ts"
+import * as RelayClient from "./relay-client.ts"
+import * as RelayLifecycle from "./relay-lifecycle.ts"
+import type {
+  AuthenticatedJsonMethod,
+  AuthenticatedJsonOutcome,
+  SessionSummary,
+} from "./relay-schema.ts"
+
+export type Json = Schema.Schema.Type<typeof Schema.Json>
+
+export class ClientError extends Schema.TaggedErrorClass<ClientError>()(
+  "BrowserControlClient.Error",
+  {
+    message: Schema.String,
+    reason: Schema.Literals(["connect", "session", "invalid-request"]),
+    code: Schema.optionalKey(Schema.String),
+    status: Schema.optionalKey(Schema.Number),
+  },
+) {}
+
+export class OriginMismatch extends Schema.TaggedErrorClass<OriginMismatch>()(
+  "AuthenticatedOrigin.OriginMismatch",
+  {
+    expectedOrigin: Schema.String,
+    actualOrigin: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class HttpError extends Schema.TaggedErrorClass<HttpError>()(
+  "AuthenticatedOrigin.HttpError",
+  {
+    status: Schema.Number,
+    method: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class RequestFailed extends Schema.TaggedErrorClass<RequestFailed>()(
+  "AuthenticatedOrigin.RequestFailed",
+  {
+    method: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class RequestOutcomeUnknown extends Schema.TaggedErrorClass<RequestOutcomeUnknown>()(
+  "AuthenticatedOrigin.RequestOutcomeUnknown",
+  {
+    method: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+export class InvalidResponse extends Schema.TaggedErrorClass<InvalidResponse>()(
+  "AuthenticatedOrigin.InvalidResponse",
+  {
+    reason: Schema.Literals(["invalid-json", "too-large"]),
+    status: Schema.Number,
+    maxResponseBytes: Schema.optionalKey(Schema.Number),
+    message: Schema.String,
+  },
+) {}
+
+export class ResponseDecodeFailed extends Schema.TaggedErrorClass<ResponseDecodeFailed>()(
+  "AuthenticatedOrigin.ResponseDecodeFailed",
+  {
+    message: Schema.String,
+  },
+) {}
+
+export class SensitiveCaptureActive extends Schema.TaggedErrorClass<SensitiveCaptureActive>()(
+  "AuthenticatedOrigin.SensitiveCaptureActive",
+  {
+    message: Schema.String,
+  },
+) {}
+
+export type Error =
+  | ClientError
+  | OriginMismatch
+  | HttpError
+  | RequestFailed
+  | RequestOutcomeUnknown
+  | InvalidResponse
+  | ResponseDecodeFailed
+  | SensitiveCaptureActive
+
+export interface JsonOptions<S extends Schema.Top> {
+  readonly path: `/${string}`
+  readonly method?: AuthenticatedJsonMethod
+  readonly body?: Json
+  readonly response: S
+  readonly sensitive?: boolean
+  readonly timeoutMs?: number
+  readonly maxResponseBytes?: number
+}
+
+export interface AuthenticatedOrigin {
+  readonly origin: string
+  readonly json: {
+    <S extends Schema.Top>(
+      options: JsonOptions<S> & { readonly sensitive: true },
+    ): Effect.Effect<Redacted.Redacted<S["Type"]>, Error, S["DecodingServices"]>
+    <S extends Schema.Top>(
+      options: JsonOptions<S> & { readonly sensitive?: false },
+    ): Effect.Effect<S["Type"], Error, S["DecodingServices"]>
+  }
+}
+
+/** Reveal a sensitive response using Browser Control's Effect runtime. */
+export const reveal = <A>(value: Redacted.Redacted<A>): A => Redacted.value(value)
+
+export interface AuthenticatedOriginOptions {
+  readonly origin: string
+  /** Explicitly navigate here when the session page is not already on `origin`. */
+  readonly startUrl?: string
+}
+
+export interface Session {
+  readonly id: string
+  readonly summary: SessionSummary
+  readonly authenticatedOrigin: (
+    options: AuthenticatedOriginOptions,
+  ) => Effect.Effect<AuthenticatedOrigin, ClientError>
+}
+
+export interface EnsureSessionOptions {
+  readonly id: string
+  readonly readOnly?: boolean
+}
+
+export interface Interface {
+  readonly ensureSession: (
+    options: EnsureSessionOptions,
+  ) => Effect.Effect<Session, ClientError>
+  readonly resetSession: (id: string) => Effect.Effect<Session, ClientError>
+}
+
+export interface MakeOptions {
+  readonly endpoint?: string
+}
+
+export class Service extends Context.Service<Service, Interface>()(
+  "@opencode-ai/browser-control/BrowserControlClient",
+) {}
+
+export const make = Effect.fn("BrowserControlClient.make")(function* (options: MakeOptions = {}) {
+  const relay = yield* RelayClient.make(options).pipe(
+    Effect.provide(FetchHttpClient.layer),
+    Effect.mapError((error) => clientError("connect", error)),
+  )
+  const readiness = yield* RelayLifecycle.ensureRelay({
+    relay,
+    // The consumer may run under Bun; the relay is a Node application.
+    start: RelayLifecycle.startManagedRelay(fileURLToPath(import.meta.url), "node", []),
+  }).pipe(Effect.mapError((error) => clientError("connect", error)))
+  if (readiness.buildProblem) {
+    return yield* Effect.fail(new ClientError({
+      message: readiness.buildProblem,
+      reason: "connect",
+    }))
+  }
+  yield* RelayLifecycle.ensureExtensionConnected({
+    relay,
+    waitForReconnect: readiness.started,
+  }).pipe(Effect.mapError((error) => clientError("connect", error)))
+
+  const ensureSession = Effect.fn("BrowserControlClient.ensureSession")(function* (
+    sessionOptions: EnsureSessionOptions,
+  ) {
+    const summary = yield* relay.sessionEnsure(sessionOptions.id, {
+      ...(sessionOptions.readOnly === undefined ? {} : { readOnly: sessionOptions.readOnly }),
+    }).pipe(Effect.mapError((error) => clientError("session", error)))
+    return makeSession(relay, summary)
+  })
+
+  const resetSession = Effect.fn("BrowserControlClient.resetSession")(function* (id: string) {
+    const summary = yield* relay.sessionReset(id).pipe(
+      Effect.mapError((error) => clientError("session", error)),
+    )
+    return makeSession(relay, summary)
+  })
+
+  return Service.of({ ensureSession, resetSession })
+})
+
+export const layer = (options: MakeOptions = {}): Layer.Layer<Service, ClientError> =>
+  Layer.effect(Service, make(options))
+
+function makeSession(relay: RelayClient.Interface, summary: SessionSummary): Session {
+  return {
+    id: summary.id,
+    summary,
+    authenticatedOrigin: (options) => Effect.try({
+      try: () => makeAuthenticatedOrigin(relay, summary.id, options),
+      catch: (cause) => cause instanceof ClientError
+        ? cause
+        : new ClientError({
+            message: cause instanceof globalThis.Error ? cause.message : "Invalid authenticated origin",
+            reason: "invalid-request",
+          }),
+    }),
+  }
+}
+
+function makeAuthenticatedOrigin(
+  relay: RelayClient.Interface,
+  sessionId: string,
+  options: AuthenticatedOriginOptions,
+): AuthenticatedOrigin {
+  const origin = AuthenticatedOriginInternal.normalizeOrigin(options.origin)
+  const startUrl = options.startUrl === undefined ? undefined : new URL(options.startUrl, origin)
+  if (startUrl && startUrl.origin !== origin) {
+    throw new ClientError({
+      message: `Authenticated origin startUrl must stay on ${origin}`,
+      reason: "invalid-request",
+    })
+  }
+
+  function json<S extends Schema.Top>(
+    request: JsonOptions<S> & { readonly sensitive: true },
+  ): Effect.Effect<Redacted.Redacted<S["Type"]>, Error, S["DecodingServices"]>
+  function json<S extends Schema.Top>(
+    request: JsonOptions<S> & { readonly sensitive?: false },
+  ): Effect.Effect<S["Type"], Error, S["DecodingServices"]>
+  function json<S extends Schema.Top>(
+    request: JsonOptions<S>,
+  ): Effect.Effect<S["Type"] | Redacted.Redacted<S["Type"]>, Error, S["DecodingServices"]> {
+    const method = request.method ?? "GET"
+    if (method === "GET" && request.body !== undefined) {
+      return Effect.fail(new ClientError({
+        message: "GET authenticated origin requests cannot include a body",
+        reason: "invalid-request",
+      }))
+    }
+    const mutation = method !== "GET"
+    return relay.authenticatedJson({
+      sessionId,
+      origin,
+      ...(startUrl ? { startUrl: startUrl.toString() } : {}),
+      method,
+      path: request.path,
+      ...(request.body === undefined ? {} : { body: request.body }),
+      ...(request.sensitive === true ? { sensitive: true } : {}),
+      ...(request.timeoutMs === undefined ? {} : { timeoutMs: request.timeoutMs }),
+      ...(request.maxResponseBytes === undefined ? {} : { maxResponseBytes: request.maxResponseBytes }),
+    }).pipe(
+      Effect.mapError((error): Error => mutation && (
+          error instanceof RelayClient.RelayUnreachable || error instanceof RelayClient.RelayDecodeFailed
+        )
+        ? unknownOutcome(method)
+        : clientError("session", error)),
+      Effect.flatMap((outcome) => decodeOutcome(outcome, method, mutation, request)),
+    )
+  }
+
+  return { origin, json }
+}
+
+function decodeOutcome<S extends Schema.Top>(
+  outcome: AuthenticatedJsonOutcome,
+  method: AuthenticatedJsonMethod,
+  mutation: boolean,
+  request: JsonOptions<S>,
+): Effect.Effect<S["Type"] | Redacted.Redacted<S["Type"]>, Error, S["DecodingServices"]> {
+  switch (outcome._tag) {
+    case "Success": {
+      if (request.sensitive === true) {
+        return Schema.decodeUnknownEffect(Schema.RedactedFromValue(request.response, {
+          label: "Browser Control authenticated response",
+          disallowEncode: true,
+        }))(outcome.value).pipe(
+          Effect.mapError(() => mutation
+            ? unknownOutcome(method)
+            : new ResponseDecodeFailed({ message: "Sensitive authenticated response did not match the expected schema" })),
+        )
+      }
+      return Schema.decodeUnknownEffect(request.response)(outcome.value).pipe(
+        Effect.mapError((cause) => mutation
+          ? unknownOutcome(method)
+          : new ResponseDecodeFailed({ message: `Authenticated response did not match the expected schema: ${cause.message}` })),
+      )
+    }
+    case "OriginMismatch":
+      return Effect.fail(new OriginMismatch({
+        expectedOrigin: outcome.expectedOrigin,
+        actualOrigin: outcome.actualOrigin,
+        message: `Session page origin ${outcome.actualOrigin} does not match ${outcome.expectedOrigin}`,
+      }))
+    case "HttpError":
+      return Effect.fail(new HttpError({
+        status: outcome.status,
+        method,
+        message: `Authenticated ${method} request was rejected with HTTP ${outcome.status}`,
+      }))
+    case "RequestFailed":
+      return Effect.fail(mutation || outcome.outcome === "unknown"
+        ? unknownOutcome(method)
+        : new RequestFailed({ method, message: `Authenticated ${method} request failed before it was sent` }))
+    case "InvalidJson":
+      return Effect.fail(mutation
+        ? unknownOutcome(method)
+        : new InvalidResponse({
+            reason: "invalid-json",
+            status: outcome.status,
+            message: "Authenticated response was not valid JSON",
+          }))
+    case "ResponseTooLarge":
+      return Effect.fail(mutation
+        ? unknownOutcome(method)
+        : new InvalidResponse({
+            reason: "too-large",
+            status: outcome.status,
+            maxResponseBytes: outcome.maxResponseBytes,
+            message: `Authenticated response exceeded ${outcome.maxResponseBytes} bytes`,
+          }))
+    case "SensitiveCaptureActive":
+      return Effect.fail(new SensitiveCaptureActive({
+        message: "Sensitive authenticated requests are blocked while session network capture is active",
+      }))
+  }
+}
+
+function unknownOutcome(method: AuthenticatedJsonMethod): RequestOutcomeUnknown {
+  return new RequestOutcomeUnknown({
+    method,
+    message: `Authenticated ${method} request outcome is unknown; reconcile state before retrying`,
+  })
+}
+
+function clientError(reason: ClientError["reason"], error: unknown): ClientError {
+  if (error instanceof ClientError) return error
+  if (error instanceof RelayClient.RelayRejected) {
+    return new ClientError({
+      message: error.message,
+      reason,
+      status: error.status,
+      ...(error.code ? { code: error.code } : {}),
+    })
+  }
+  return new ClientError({
+    message: error instanceof globalThis.Error ? error.message : "Browser Control request failed",
+    reason,
+  })
+}
+
+export * as BrowserControlClient from "./browser-control-client.ts"
+export * as AuthenticatedOrigin from "./browser-control-client.ts"

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -16,8 +16,9 @@ import zlib from "node:zlib"
 import { hideGhostCursor as hideGhostCursorOnPage, showGhostCursor as showGhostCursorOnPage, type GhostCursorClientOptions } from "./ghost-cursor.ts"
 import type { HandoffOutcome } from "./handoff.ts"
 import * as AuthProfile from "./auth-profile.ts"
+import * as AuthenticatedOrigin from "./authenticated-origin.ts"
 import * as NetworkCapture from "./network-capture.ts"
-import type { ExecuteAftermath, ExecuteLogEntry, ExecuteLogSummary, ExecuteMedia } from "./relay-schema.ts"
+import type { AuthenticatedJsonOutcome, AuthenticatedJsonRequest, ExecuteAftermath, ExecuteLogEntry, ExecuteLogSummary, ExecuteMedia } from "./relay-schema.ts"
 import type { SessionTarget } from "./relay-types.ts"
 import { executionContextFailureDiagnostic, runtimeFailureKind } from "./runtime-diagnostics.ts"
 
@@ -499,6 +500,22 @@ export class ExecuteSandbox {
         },
       }),
     )
+  }
+
+  authenticatedJson(
+    request: Omit<AuthenticatedJsonRequest, "sessionId">,
+  ): Effect.Effect<AuthenticatedJsonOutcome, Error> {
+    const sandbox = this
+    return Effect.gen(function* () {
+      if (request.sensitive === true && sandbox.networkCapture.status().active) {
+        return { _tag: "SensitiveCaptureActive" } as const
+      }
+      const globals = yield* Effect.tryPromise({
+        try: () => sandbox.getGlobals({}),
+        catch: (cause) => cause instanceof Error ? cause : new Error("Set up authenticated origin page", { cause }),
+      })
+      return yield* AuthenticatedOrigin.requestJson(globals.page, request)
+    }).pipe(Effect.uninterruptible)
   }
 
   private drainWarnings(): string[] {

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -1,6 +1,7 @@
 import http from "node:http"
 import { Effect, Schema } from "effect"
 import * as AuthProfile from "./auth-profile.ts"
+import { AuthenticatedOriginError } from "./authenticated-origin.ts"
 import { NetworkCaptureError } from "./network-capture.ts"
 import {
   HttpRouteError,
@@ -17,6 +18,7 @@ import {
 import { selectTarget, TargetSelectionError } from "./execute.ts"
 import {
   AuthProfileRequest,
+  AuthenticatedJsonRequest,
   AuthRefreshRequest,
   AuthRunRequest,
   ExecuteRequest,
@@ -27,6 +29,7 @@ import {
   RecordingTargetRequest,
   SessionAdoptRequest,
   SessionIdRequest,
+  SessionEnsureRequest,
   SessionNewRequest,
   type TargetSummary,
 } from "./relay-schema.ts"
@@ -115,6 +118,15 @@ export function createHttpRequestHandler(options: {
       runRequestEffect(response, handleAuthRequest({ request, response, pathname, sessions: options.sessions }))
       return
     }
+    if (pathname.startsWith("/v1/")) {
+      runRequestEffect(response, handleClientRequest({
+        request,
+        response,
+        pathname,
+        sessions: options.sessions,
+      }))
+      return
+    }
     if (pathname.startsWith("/cli/")) {
       runRequestEffect(response, handleCliRequest({
         request,
@@ -128,6 +140,33 @@ export function createHttpRequestHandler(options: {
     response.writeHead(404)
     response.end("Not found")
   }
+}
+
+function handleClientRequest(options: {
+  readonly request: http.IncomingMessage
+  readonly response: http.ServerResponse
+  readonly pathname: string
+  readonly sessions: BrowserControlSessions
+}): Effect.Effect<void, Error> {
+  return Effect.gen(function* () {
+    if (options.pathname === "/v1/sessions/ensure" && options.request.method === "POST") {
+      const request = yield* decodeRequest(SessionEnsureRequest, yield* readJsonBody(options.request), "session ensure")
+      sendJson(options.response, {
+        session: yield* options.sessions.ensure(request.id, {
+          ...(request.readOnly === undefined ? {} : { readOnly: request.readOnly }),
+        }),
+      })
+      return
+    }
+    if (options.pathname === "/v1/authenticated-origin/json" && options.request.method === "POST") {
+      const request = yield* decodeRequest(AuthenticatedJsonRequest, yield* readJsonBody(options.request), "authenticated origin")
+      options.response.setHeader("cache-control", "no-store")
+      sendJson(options.response, yield* options.sessions.authenticatedJson(request))
+      return
+    }
+    options.response.writeHead(404)
+    options.response.end("Not found")
+  })
 }
 
 function handleNetworkRequest(options: {
@@ -502,6 +541,13 @@ export function relayHttpError(error: unknown): HttpRouteError {
       message: error.message,
       status: error.reason === "invalid-name" ? 400 : error.reason === "not-found" ? 404 : 500,
       code: error.reason === "invalid-name" ? "invalid-request" : error.reason === "not-found" ? "auth-profile-not-found" : "internal",
+    })
+  }
+  if (error instanceof AuthenticatedOriginError) {
+    return new HttpRouteError({
+      message: error.message,
+      status: error.reason === "invalid-request" ? 400 : 500,
+      code: error.reason === "invalid-request" ? "invalid-request" : "setup-failed",
     })
   }
   if (error instanceof TargetSelectionError) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { AuthenticatedOrigin, BrowserControlClient } from "./browser-control-client.ts"

--- a/src/relay-client.ts
+++ b/src/relay-client.ts
@@ -2,6 +2,8 @@ import { Config, Context, Effect, Layer, Option, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest, type HttpClientResponse } from "effect/unstable/http"
 import {
   type AuthProfileRequest,
+  type AuthenticatedJsonRequest,
+  AuthenticatedJsonOutcome,
   AuthProfileSummary,
   type AuthRefreshRequest,
   type AuthRunRequest,
@@ -27,6 +29,7 @@ import {
   SessionAdoptResponse,
   SessionContainer,
   SessionDeleted,
+  SessionEnsureResponse,
   SessionsContainer,
   TargetSummaries,
   type SessionAdoptRequest,
@@ -100,10 +103,12 @@ export interface Interface {
   readonly targets: Effect.Effect<readonly TargetSummary[], RelayClientError>
   readonly sessions: Effect.Effect<readonly SessionSummary[], RelayClientError>
   readonly sessionNew: (id?: string | undefined, options?: { readonly readOnly?: boolean }) => Effect.Effect<SessionSummary, RelayClientError>
+  readonly sessionEnsure: (id: string, options?: { readonly readOnly?: boolean }) => Effect.Effect<SessionSummary, RelayClientError>
   readonly sessionReset: (id: string) => Effect.Effect<SessionSummary, RelayClientError>
   readonly sessionAdopt: (request: SessionAdoptRequest) => Effect.Effect<SessionAdoptResponse, RelayClientError>
   readonly sessionDelete: (id: string) => Effect.Effect<SessionDeleted, RelayClientError>
   readonly execute: (request: ExecuteRequest) => Effect.Effect<ExecuteResponse, RelayClientError>
+  readonly authenticatedJson: (request: AuthenticatedJsonRequest) => Effect.Effect<AuthenticatedJsonOutcome, RelayClientError>
   readonly networkStart: (request: NetworkStartRequest) => Effect.Effect<NetworkStatusResponse, RelayClientError>
   readonly networkStatus: (request: NetworkSessionRequest) => Effect.Effect<NetworkStatusResponse, RelayClientError>
   readonly networkStop: (request: NetworkStopRequest) => Effect.Effect<NetworkStopResponse, RelayClientError>
@@ -236,6 +241,11 @@ export const make = Effect.fn("RelayClient.make")(function* (options?: { readonl
         ...(id ? { id } : {}),
         ...(options?.readOnly ? { readOnly: true } : {}),
       }, SessionContainer).pipe(Effect.map((container) => container.session)),
+    sessionEnsure: (id, options) =>
+      postJson("/v1/sessions/ensure", {
+        id,
+        ...(options?.readOnly === undefined ? {} : { readOnly: options.readOnly }),
+      }, SessionEnsureResponse).pipe(Effect.map((container) => container.session)),
     sessionReset: (id) =>
       postJson("/cli/session/reset", { id }, SessionContainer).pipe(Effect.map((container) => container.session)),
     sessionAdopt: (request) =>
@@ -252,6 +262,7 @@ export const make = Effect.fn("RelayClient.make")(function* (options?: { readonl
         createIfMissing: request.createIfMissing,
         ...(request.targetSelection === undefined ? {} : { targetSelection: request.targetSelection }),
       }, ExecuteResponse),
+    authenticatedJson: (request) => postJson("/v1/authenticated-origin/json", { ...request }, AuthenticatedJsonOutcome),
     networkStart: (request) => postJson("/network/start", { ...request }, NetworkStatusResponse),
     networkStatus: (request) => postJson("/network/status", { ...request }, NetworkStatusResponse),
     networkStop: (request) => postJson("/network/stop", { ...request }, NetworkStopResponse),

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -57,7 +57,7 @@ export const ensureRelay = Effect.fn("RelayLifecycle.ensureRelay")(function* (op
     return yield* Effect.fail(initial.failure)
   }
 
-  if (relayWasAbsent) yield* options.start ?? spawnManagedRelay()
+  if (relayWasAbsent) yield* options.start ?? startManagedRelay()
   const version = yield* probe.pipe(
     Effect.retry({
       times: options.retryTimes ?? 200,
@@ -118,14 +118,18 @@ export function statusCollections(status: ExtensionStatus): {
   return status.sessions && status.targets ? { sessions: status.sessions, targets: status.targets } : undefined
 }
 
-function spawnManagedRelay(): Effect.Effect<void, Error> {
+export function startManagedRelay(
+  entrypoint = process.argv[1],
+  executable = process.execPath,
+  execArgv: readonly string[] = process.execArgv,
+): Effect.Effect<void, Error> {
   return Effect.try({
     try: () => {
-      const entrypoint = process.argv[1]
       if (!entrypoint) {
         throw new Error("Cannot locate the browser-control CLI entrypoint")
       }
-      const child = spawn(process.execPath, [...process.execArgv, managedRelayEntrypoint(entrypoint), "serve"], {
+      const launch = managedRelayLaunch(entrypoint, executable, execArgv)
+      const child = spawn(launch.executable, launch.args, {
         detached: true,
         stdio: "ignore",
         env: { ...process.env, BROWSER_CONTROL_MANAGED_RELAY: "1" },
@@ -136,12 +140,23 @@ function spawnManagedRelay(): Effect.Effect<void, Error> {
   })
 }
 
+export function managedRelayLaunch(
+  entrypoint: string,
+  executable = process.execPath,
+  execArgv: readonly string[] = process.execArgv,
+): { readonly executable: string; readonly args: string[] } {
+  return {
+    executable,
+    args: [...execArgv, managedRelayEntrypoint(entrypoint), "serve"],
+  }
+}
+
 export function managedRelayEntrypoint(entrypoint: string): string {
   const name = path.basename(entrypoint)
-  if (name === "mcp.js") {
+  if (name === "mcp.js" || name === "index.js" || name === "browser-control-client.js") {
     return path.join(path.dirname(entrypoint), "cli.js")
   }
-  if (name === "mcp-main.ts") {
+  if (name === "mcp-main.ts" || name === "index.ts" || name === "browser-control-client.ts") {
     return path.join(path.dirname(entrypoint), "cli.ts")
   }
   return entrypoint

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -81,6 +81,19 @@ export const SessionNewRequest = Schema.Struct({
 
 export interface SessionNewRequest extends Schema.Schema.Type<typeof SessionNewRequest> {}
 
+export const SessionEnsureRequest = Schema.Struct({
+  id: Schema.NonEmptyString,
+  readOnly: Schema.optionalKey(Schema.Boolean),
+})
+
+export interface SessionEnsureRequest extends Schema.Schema.Type<typeof SessionEnsureRequest> {}
+
+export const SessionEnsureResponse = Schema.Struct({
+  session: SessionSummary,
+})
+
+export interface SessionEnsureResponse extends Schema.Schema.Type<typeof SessionEnsureResponse> {}
+
 export const SessionIdRequest = Schema.Struct({
   id: Schema.String,
 })
@@ -161,6 +174,51 @@ export const ExecuteResponse = Schema.Struct({
 })
 
 export interface ExecuteResponse extends Schema.Schema.Type<typeof ExecuteResponse> {}
+
+export const AuthenticatedJsonMethod = Schema.Literals(["GET", "POST", "PUT", "PATCH", "DELETE"])
+
+export type AuthenticatedJsonMethod = Schema.Schema.Type<typeof AuthenticatedJsonMethod>
+
+export const AuthenticatedJsonRequest = Schema.Struct({
+  sessionId: Schema.NonEmptyString,
+  origin: Schema.NonEmptyString,
+  startUrl: Schema.optionalKey(Schema.NonEmptyString),
+  method: AuthenticatedJsonMethod,
+  path: Schema.NonEmptyString,
+  body: Schema.optionalKey(Schema.Json),
+  sensitive: Schema.optionalKey(Schema.Boolean),
+  timeoutMs: Schema.optionalKey(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 120_000 }))),
+  maxResponseBytes: Schema.optionalKey(Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 10_000_000 }))),
+})
+
+export interface AuthenticatedJsonRequest extends Schema.Schema.Type<typeof AuthenticatedJsonRequest> {}
+
+export const AuthenticatedJsonOutcome = Schema.TaggedUnion({
+  Success: {
+    status: Schema.Int,
+    value: Schema.Json,
+  },
+  OriginMismatch: {
+    expectedOrigin: Schema.String,
+    actualOrigin: Schema.String,
+  },
+  RequestFailed: {
+    outcome: Schema.Literals(["not-sent", "unknown"]),
+  },
+  HttpError: {
+    status: Schema.Int,
+  },
+  ResponseTooLarge: {
+    status: Schema.Int,
+    maxResponseBytes: Schema.Int,
+  },
+  InvalidJson: {
+    status: Schema.Int,
+  },
+  SensitiveCaptureActive: {},
+})
+
+export type AuthenticatedJsonOutcome = typeof AuthenticatedJsonOutcome.Type
 
 export const TargetSummary = Schema.Struct({
   id: Schema.String,

--- a/src/relay-types.ts
+++ b/src/relay-types.ts
@@ -2,7 +2,7 @@ import type { Effect, Semaphore } from "effect"
 import type { AdoptTarget, ExecuteOptions, ExecuteResult } from "./execute.ts"
 import type { NetworkCaptureOptions, NetworkCaptureResult, NetworkCaptureStatus, NetworkCaptureStopOptions } from "./network-capture.ts"
 import type { JsonObject, TargetInfo } from "./protocol.ts"
-import type { SessionSummary } from "./relay-schema.ts"
+import type { AuthenticatedJsonOutcome, AuthenticatedJsonRequest, SessionSummary } from "./relay-schema.ts"
 export type SessionTarget = {
   readonly id: string
   readonly owner: "relay" | "user"
@@ -49,6 +49,7 @@ export type PendingExtensionRequest = {
  */
 export interface ExecuteSandboxLike {
   execute(code: string, options?: ExecuteOptions): Effect.Effect<ExecuteResult>
+  authenticatedJson(request: Omit<AuthenticatedJsonRequest, "sessionId">): Effect.Effect<AuthenticatedJsonOutcome, Error>
   adoptPage(target: AdoptTarget): Effect.Effect<string, Error>
   close(): Effect.Effect<void, Error>
   /** Relay shutdown disconnects Playwright without closing or forgetting the default tab. */

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -3,6 +3,7 @@ import { defaultPageClosedWarning, ExecuteSandbox, hasExplicitTargetSelection, t
 import type { NetworkCaptureOptions, NetworkCaptureResult, NetworkCaptureStatus, NetworkCaptureStopOptions } from "./network-capture.ts"
 import { generateSessionId } from "./relay-helpers.ts"
 import type { BrowserControlSession, ExecuteSandboxLike, SessionSummary, SessionTarget } from "./relay-types.ts"
+import type { AuthenticatedJsonOutcome, AuthenticatedJsonRequest } from "./relay-schema.ts"
 import type { PersistedSession } from "./session-catalog.ts"
 import {
   MemoryTargetOwnership,
@@ -177,6 +178,35 @@ export class BrowserControlSessions {
         return yield* Effect.fail(error)
       })))
       return session
+    })
+  }
+
+  ensure(id: string, options?: { readonly readOnly?: boolean }): Effect.Effect<SessionSummary, Error> {
+    const manager = this
+    return Effect.gen(function* () {
+      if (manager.closing) {
+        return yield* Effect.fail(sessionError("inactive", "Browser Control sessions are closing", id))
+      }
+      const existing = manager.sessions.get(id)
+      if (existing) {
+        if (options?.readOnly === true && !existing.readOnly) {
+          return yield* Effect.fail(sessionError(
+            "invalid-request",
+            `Session ${id} already exists with write access and cannot be ensured as read-only`,
+            id,
+          ))
+        }
+        return manager.sessionSummary(existing)
+      }
+      const session = manager.createNew(id, options)
+      yield* manager.flushPersistence().pipe(Effect.catch((error) => Effect.gen(function* () {
+        if (manager.sessions.get(session.id) === session) manager.sessions.delete(session.id)
+        yield* manager.closeBrowserControlSession(session)
+        manager.schedulePersistence()
+        yield* manager.flushPersistence().pipe(Effect.ignore)
+        return yield* Effect.fail(error)
+      })))
+      return manager.sessionSummary(session)
     })
   }
 
@@ -358,6 +388,37 @@ export class BrowserControlSessions {
       }
       return yield* session.sandbox.authRefresh(options)
     }))
+  }
+
+  authenticatedJson(
+    request: AuthenticatedJsonRequest,
+  ): Effect.Effect<AuthenticatedJsonOutcome, Error> {
+    const manager = this
+    const session = this.sessions.get(request.sessionId)
+    if (!session) {
+      return Effect.fail(sessionError("not-found", `Session not found: ${request.sessionId}`, request.sessionId))
+    }
+    if (session.readOnly && request.method !== "GET") {
+      return Effect.fail(sessionError(
+        "invalid-request",
+        `Read-only session ${request.sessionId} cannot make ${request.method} authenticated requests`,
+        request.sessionId,
+      ))
+    }
+    const { sessionId: _sessionId, ...pageRequest } = request
+    return this.withLifecyclePermit(session, "authenticated request", Effect.gen(function* () {
+      if (manager.sessions.get(session.id) !== session) {
+        return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${session.id}`, session.id))
+      }
+      manager.setExecuting(session.id, true)
+      const result = yield* session.sandbox.authenticatedJson(pageRequest).pipe(
+        Effect.ensuring(Effect.sync(() => manager.setExecuting(session.id, false))),
+      )
+      session.updatedAt = new Date().toISOString()
+      manager.schedulePersistence()
+      yield* manager.flushPersistence()
+      return result
+    }).pipe(Effect.uninterruptible))
   }
 
   execute(options: {

--- a/test/browser-control-client.test.ts
+++ b/test/browser-control-client.test.ts
@@ -1,0 +1,134 @@
+import http from "node:http"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { Effect, Schema } from "effect"
+import * as BrowserControlClient from "../src/browser-control-client.ts"
+import { browserControlBuildId, browserControlVersion } from "../src/version.ts"
+
+let server: http.Server
+let endpoint: string
+let authenticatedOutcome: unknown
+
+const session = {
+  id: "x-live-chat-auth",
+  createdAt: "2026-07-19T00:00:00.000Z",
+  updatedAt: "2026-07-19T00:00:00.000Z",
+  connected: true,
+  pageUrl: "https://studio.x.com/live",
+  stateKeys: [],
+}
+
+beforeAll(async () => {
+  server = http.createServer((request, response) => {
+    const path = new URL(request.url ?? "/", "http://localhost").pathname
+    response.setHeader("content-type", "application/json")
+    if (path === "/version") {
+      response.end(JSON.stringify({ version: browserControlVersion, buildId: browserControlBuildId }))
+      return
+    }
+    if (path === "/extension/status") {
+      response.end(JSON.stringify({ connected: true, version: "test", activeTargets: 1 }))
+      return
+    }
+    const chunks: Buffer[] = []
+    request.on("data", (chunk: Buffer) => chunks.push(chunk))
+    request.on("end", () => {
+      if (path === "/v1/sessions/ensure") {
+        response.end(JSON.stringify({ session }))
+        return
+      }
+      if (path === "/cli/session/reset") {
+        response.end(JSON.stringify({ session }))
+        return
+      }
+      if (path === "/v1/authenticated-origin/json") {
+        response.end(JSON.stringify(authenticatedOutcome))
+        return
+      }
+      response.writeHead(404)
+      response.end(JSON.stringify({ error: "not found" }))
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("Expected test server address")
+  endpoint = `http://127.0.0.1:${address.port}`
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+})
+
+const makeOrigin = Effect.gen(function* () {
+  const client = yield* BrowserControlClient.make({ endpoint })
+  const liveSession = yield* client.ensureSession({ id: session.id })
+  return yield* liveSession.authenticatedOrigin({
+    origin: "https://studio.x.com",
+    startUrl: "/live",
+  })
+})
+
+describe("BrowserControlClient", () => {
+  it("resets a named session", async () => {
+    const result = await Effect.runPromise(Effect.gen(function* () {
+      const client = yield* BrowserControlClient.make({ endpoint })
+      return yield* client.resetSession(session.id)
+    }))
+    expect(result.id).toBe(session.id)
+    expect(result.summary).toEqual(session)
+  })
+
+  it("schema-decodes authenticated JSON responses", async () => {
+    authenticatedOutcome = { _tag: "Success", status: 200, value: { rows: [{ id: "1" }] } }
+    const result = await Effect.runPromise(Effect.gen(function* () {
+      const origin = yield* makeOrigin
+      return yield* origin.json({
+        path: "/api/live/get-broadcasts?limit=1000",
+        response: Schema.Struct({ rows: Schema.Array(Schema.Struct({ id: Schema.String })) }),
+      })
+    }))
+    expect(result).toEqual({ rows: [{ id: "1" }] })
+  })
+
+  it("returns sensitive values as Redacted and redacts schema failures", async () => {
+    const token = "distinctive-secret-chat-token"
+    authenticatedOutcome = { _tag: "Success", status: 200, value: { accessToken: token } }
+    const redacted = await Effect.runPromise(Effect.gen(function* () {
+      const origin = yield* makeOrigin
+      return yield* origin.json({
+        path: "/api/live/get-chat-session",
+        method: "POST",
+        body: { broadcastId: "1" },
+        response: Schema.Struct({ accessToken: Schema.String }),
+        sensitive: true,
+      })
+    }))
+    expect(String(redacted)).not.toContain(token)
+    expect(BrowserControlClient.reveal(redacted)).toEqual({ accessToken: token })
+
+    authenticatedOutcome = { _tag: "Success", status: 200, value: { accessToken: token } }
+    const error = await Effect.runPromise(Effect.gen(function* () {
+      const origin = yield* makeOrigin
+      return yield* origin.json({
+        path: "/api/live/get-chat-session",
+        response: Schema.Struct({ accessToken: Schema.Number }),
+        sensitive: true,
+      })
+    }).pipe(Effect.flip))
+    expect(error.message).not.toContain(token)
+    expect(String(error)).not.toContain(token)
+  })
+
+  it("reports mutating transport ambiguity as an unknown outcome", async () => {
+    authenticatedOutcome = { _tag: "RequestFailed", outcome: "unknown" }
+    const error = await Effect.runPromise(Effect.gen(function* () {
+      const origin = yield* makeOrigin
+      return yield* origin.json({
+        path: "/api/live/go-live",
+        method: "POST",
+        body: { title: "Private stream" },
+        response: Schema.Unknown,
+      })
+    }).pipe(Effect.flip))
+    expect(error).toBeInstanceOf(BrowserControlClient.RequestOutcomeUnknown)
+  })
+})

--- a/test/relay-client.test.ts
+++ b/test/relay-client.test.ts
@@ -126,6 +126,35 @@ describe("RelayClient", () => {
     expect(lastRequestBody).toEqual({ sessionId: session.id, code: "6 * 7", createIfMissing: false })
   })
 
+  it("ensures sessions and performs structured authenticated origin requests", async () => {
+    routes.set("POST /v1/sessions/ensure", { status: 200, body: { session } })
+    const ensured = await withClient((client) => client.sessionEnsure(session.id))
+    expect(ensured.id).toBe(session.id)
+    expect(lastRequestBody).toEqual({ id: session.id })
+
+    routes.set("POST /v1/authenticated-origin/json", {
+      status: 200,
+      body: { _tag: "Success", status: 200, value: { ok: true } },
+    })
+    const result = await withClient((client) => client.authenticatedJson({
+      sessionId: session.id,
+      origin: "https://example.com",
+      method: "POST",
+      path: "/api/private",
+      body: { value: 1 },
+      sensitive: true,
+    }))
+    expect(result).toEqual({ _tag: "Success", status: 200, value: { ok: true } })
+    expect(lastRequestBody).toEqual({
+      sessionId: session.id,
+      origin: "https://example.com",
+      method: "POST",
+      path: "/api/private",
+      body: { value: 1 },
+      sensitive: true,
+    })
+  })
+
   it("decodes execute image media", async () => {
     routes.set("POST /cli/execute", {
       status: 200,

--- a/test/relay-lifecycle.test.ts
+++ b/test/relay-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   ensureExtensionConnected,
   ensureRelay,
   managedRelayEntrypoint,
+  managedRelayLaunch,
   relayBuildProblem,
   statusCollections,
   stoppedRelayStatus,
@@ -158,7 +159,16 @@ describe("relay lifecycle", () => {
   it("starts a managed relay through the CLI entrypoint from MCP builds and source", () => {
     expect(managedRelayEntrypoint("/package/dist/mcp.js")).toBe("/package/dist/cli.js")
     expect(managedRelayEntrypoint("/package/src/mcp-main.ts")).toBe("/package/src/cli.ts")
+    expect(managedRelayEntrypoint("/package/dist/index.js")).toBe("/package/dist/cli.js")
+    expect(managedRelayEntrypoint("/package/src/browser-control-client.ts")).toBe("/package/src/cli.ts")
     expect(managedRelayEntrypoint("/package/dist/cli.js")).toBe("/package/dist/cli.js")
+  })
+
+  it("can launch the Node relay independently of a Bun consumer runtime", () => {
+    expect(managedRelayLaunch("/package/dist/index.js", "node", [])).toEqual({
+      executable: "node",
+      args: ["/package/dist/cli.js", "serve"],
+    })
   })
 
   it("gives source processes a deterministic content-sensitive build id", () => {

--- a/test/relay-schema.test.ts
+++ b/test/relay-schema.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 import { Schema } from "effect"
 import {
+  AuthenticatedJsonOutcome,
+  AuthenticatedJsonRequest,
   ExecuteRequest,
   ExecuteResponse,
   ExecuteSessionSummary,
@@ -15,6 +17,8 @@ import {
   SessionAdoptRequest,
   SessionAdoptResponse,
   SessionContainer,
+  SessionEnsureRequest,
+  SessionEnsureResponse,
   SessionNewRequest,
   SessionsContainer,
   SessionSummary,
@@ -41,6 +45,10 @@ const decodeRelayVersion = Schema.decodeUnknownSync(RelayVersion)
 const decodeErrorEnvelope = Schema.decodeUnknownSync(ErrorEnvelope)
 const decodeNetworkStartRequest = Schema.decodeUnknownSync(NetworkStartRequest)
 const decodeNetworkStopResponse = Schema.decodeUnknownSync(NetworkStopResponse)
+const decodeAuthenticatedJsonRequest = Schema.decodeUnknownSync(AuthenticatedJsonRequest)
+const decodeAuthenticatedJsonOutcome = Schema.decodeUnknownSync(AuthenticatedJsonOutcome)
+const decodeSessionEnsureRequest = Schema.decodeUnknownSync(SessionEnsureRequest)
+const decodeSessionEnsureResponse = Schema.decodeUnknownSync(SessionEnsureResponse)
 
 const session = {
   id: "rapid-otter-633",
@@ -113,6 +121,42 @@ describe("relay-schema", () => {
   it("decodes the optional readOnly flag on sessions", () => {
     expect(decodeSession(session).readOnly).toBeUndefined()
     expect(decodeSession({ ...session, readOnly: true }).readOnly).toBe(true)
+  })
+
+  it("decodes session ensure and authenticated origin contracts", () => {
+    expect(decodeSessionEnsureRequest({ id: "x-live-chat-auth" })).toEqual({ id: "x-live-chat-auth" })
+    expect(decodeSessionEnsureResponse({ session }).session.id).toBe(session.id)
+    expect(decodeAuthenticatedJsonRequest({
+      sessionId: "x-live-chat-auth",
+      origin: "https://studio.x.com",
+      startUrl: "https://studio.x.com/live",
+      method: "POST",
+      path: "/api/live/get-chat-session",
+      body: { broadcastId: "1" },
+      sensitive: true,
+    }).sensitive).toBe(true)
+    expect(decodeAuthenticatedJsonOutcome({
+      _tag: "Success",
+      status: 200,
+      value: { ok: true },
+    })._tag).toBe("Success")
+  })
+
+  it("rejects non-JSON bodies and invalid authenticated request limits", () => {
+    expect(() => decodeAuthenticatedJsonRequest({
+      sessionId: "x-live-chat-auth",
+      origin: "https://studio.x.com",
+      method: "POST",
+      path: "/api",
+      body: { invalid: undefined },
+    })).toThrow()
+    expect(() => decodeAuthenticatedJsonRequest({
+      sessionId: "x-live-chat-auth",
+      origin: "https://studio.x.com",
+      method: "GET",
+      path: "/api",
+      maxResponseBytes: 0,
+    })).toThrow()
   })
 
   it("decodes an execute response with warnings and aftermath", () => {

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -16,6 +16,7 @@ type FakeSandbox = ExecuteSandboxLike & {
 
 const makeFakeSandbox = (options?: {
   readonly onExecute?: Effect.Effect<void>
+  readonly onAuthenticatedJson?: ExecuteSandboxLike["authenticatedJson"]
   readonly setupFailure?: Error
   readonly adoptFailure?: Error
   readonly onAdopt?: ExecuteSandboxLike["adoptPage"]
@@ -58,6 +59,13 @@ const makeFakeSandbox = (options?: {
               warnings: [],
             }),
       ),
+    authenticatedJson: (request) => options?.onAuthenticatedJson
+      ? options.onAuthenticatedJson(request)
+      : Effect.succeed({
+          _tag: "Success",
+          status: 200,
+          value: { ok: true },
+        }),
     close,
     disconnect,
     disconnectSettled: disconnect,
@@ -108,6 +116,53 @@ const makeFakeSandbox = (options?: {
 }
 
 describe("BrowserControlSessions", () => {
+  it("atomically ensures one named session", async () => {
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox())
+    const summaries = await Effect.runPromise(Effect.all([
+      sessions.ensure("x-live-chat-auth"),
+      sessions.ensure("x-live-chat-auth"),
+    ], { concurrency: "unbounded" }))
+    expect(summaries.map((summary) => summary.id)).toEqual(["x-live-chat-auth", "x-live-chat-auth"])
+    expect(sessions.listSummaries()).toHaveLength(1)
+  })
+
+  it("runs authenticated requests under the session permit without journaling", async () => {
+    const records: string[] = []
+    const sessions = new BrowserControlSessions(
+      "http://127.0.0.1:0",
+      () => makeFakeSandbox(),
+      { onExecuteRecord: (record) => records.push(record.code) },
+    )
+    await Effect.runPromise(sessions.ensure("x-live-chat-auth"))
+    const result = await Effect.runPromise(sessions.authenticatedJson({
+      sessionId: "x-live-chat-auth",
+      origin: "https://studio.x.com",
+      method: "GET",
+      path: "/api/live/get-broadcasts",
+    }))
+    expect(result).toEqual({ _tag: "Success", status: 200, value: { ok: true } })
+    expect(records).toEqual([])
+  })
+
+  it("blocks mutations in read-only sessions before reaching the sandbox", async () => {
+    let requests = 0
+    const sessions = new BrowserControlSessions("http://127.0.0.1:0", () => makeFakeSandbox({
+      onAuthenticatedJson: () => Effect.sync(() => {
+        requests += 1
+        return { _tag: "Success", status: 200, value: null } as const
+      }),
+    }))
+    await Effect.runPromise(sessions.ensure("inspect", { readOnly: true }))
+    const error = await Effect.runPromise(sessions.authenticatedJson({
+      sessionId: "inspect",
+      origin: "https://example.com",
+      method: "POST",
+      path: "/api",
+    }).pipe(Effect.flip))
+    expect(error).toMatchObject({ reason: "invalid-request" })
+    expect(requests).toBe(0)
+  })
+
   it("restores persisted identity and target ownership with reset JavaScript state", async () => {
     const persisted: PersistedSession[][] = []
     const sessions = new BrowserControlSessions(

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "dist/types",
+    "rootDir": "src",
+    "rewriteRelativeImportExtensions": true
+  },
+  "include": ["src/index.ts"]
+}


### PR DESCRIPTION
## What

Add a public Effect client for structured, schema-decoded JSON requests authenticated by the live browser page. Applications can atomically ensure a named Browser Control session, bind it to an exact origin, and issue same-origin requests without exporting cookies or generating execute scripts.

Sensitive responses use Effect `Redacted`, bypass execute journals, set `Cache-Control: no-store`, and fail closed while session network capture is active.

The packaged agent skill is also reorganized around an inspect-act-verify golden path with explicit completion criteria.

## Before / After

**Before:** Application integrations had to invoke the CLI, embed JavaScript strings, parse execute envelopes, and use out-of-band private files to keep short-lived credentials out of journals. When imported from Bun, managed relay startup also reused Bun as the relay runtime, causing Playwright CDP checkout to time out.

**After:** Applications call the typed `BrowserControlClient` and `AuthenticatedOrigin.json` interface. Browser authentication stays in `window.fetch`, responses are schema-decoded, mutation ambiguity is explicit, and imported clients always launch the relay with Node even when the consumer runs under Bun.

## How

- `src/browser-control-client.ts` exposes the Effect service, session capability, typed errors, sensitive decoding, `reveal`, and session reset.
- `src/authenticated-origin.ts` validates origins and paths, performs bounded page-context fetches, blocks redirects, and classifies request outcomes.
- `src/session-manager.ts` atomically ensures sessions and serializes authenticated requests with existing lifecycle permits.
- `src/http-api.ts`, `src/relay-client.ts`, and `src/relay-schema.ts` define the two typed relay routes and wire contracts.
- `scripts/build-cli.ts`, `src/index.ts`, and `tsconfig.build.json` build and publish the ESM library entrypoint with declarations.
- `src/relay-lifecycle.ts` maps the library entrypoint to the packaged CLI and allows Bun consumers to launch the relay explicitly with Node.

## Scope

This does not serialize multi-request application workflows under one relay-owned transaction. Destructive workflows that require cross-process exclusivity, verification, and rollback should remain a single execute until that capability exists.

Saved authentication profiles remain an explicit, separate adapter. Authenticated-origin requests never read captured credentials or Secret Profiles.

## Testing

- `pnpm typecheck`
- `pnpm test` (`361` tests passed)
- `pnpm build:cli`
- `pnpm pack --dry-run`
- `git diff --check`
- Real Bun consumer verification against a signed-in X Studio page
- Verified stopped-relay auto-start, first typed request success, and `node .../dist/cli.js serve` as the managed process

## Flow

```mermaid
sequenceDiagram
  participant App as Effect application
  participant Client as BrowserControlClient
  participant Relay as Node relay
  participant Page as Live browser page
  participant Origin as Same-origin server

  App->>Client: ensureSession(id)
  Client->>Relay: POST /v1/sessions/ensure
  App->>Client: origin.json(path, schema)
  Client->>Relay: POST /v1/authenticated-origin/json
  Relay->>Page: evaluate fixed fetch routine
  Page->>Origin: window.fetch with browser auth
  Origin-->>Page: bounded JSON response
  Page-->>Relay: structured outcome
  Relay-->>Client: no-store response
  Client-->>App: decoded value or Redacted value
```
