### PR TITLE
fix(extension): unblock Arc handshake

### DIFF
--- a/.changeset/arc-groups-reconcile.md
+++ b/.changeset/arc-groups-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Prevent tab-group reconciliation from blocking the extension handshake in Arc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,8 @@ browser-control skill
 - On socket open the shim sends `hello` and then re-announces every tab it still
   has `chrome.debugger` attached to (`debugger.attached` events), so a restarted
   relay rebuilds its target registry without the user re-clicking the toolbar.
+- Send `ready` after the attached-tab inventory; tab-group reconciliation is
+  best-effort and must not block the handshake on browsers such as Arc.
 - Repair the reconnect alarm whenever the MV3 worker starts and send heartbeat
   traffic every 20 seconds while its relay socket is open. Chrome may clear
   persisted alarms and retires idle extension workers even with an open socket.

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -7,10 +7,10 @@ import type {
   OffscreenStatusRecordingResult,
   OffscreenStopRecordingResult,
 } from "./recording-types.ts"
-import { isBrowserControlGroupTitle, isCurrentBrowserControlGroupTitle, isLegacyBrowserControlGroupTitle, shouldUngroupBrowserControlTab, tabGroupColor, tabGroupTitle } from "./tab-groups.ts"
+import { isCurrentBrowserControlGroupTitle, isLegacyBrowserControlGroupTitle, shouldUngroupBrowserControlTab, tabGroupColor, tabGroupTitle } from "./tab-groups.ts"
 import { pageStatusFromJson } from "./page-status.ts"
 import { debuggerDetachedEvent } from "./debugger-detach.ts"
-import { ensureReconnectAlarm, reconnectAlarmName, startSocketKeepAlive } from "./connection-lifecycle.ts"
+import { completeExtensionHandshake, ensureReconnectAlarm, reconnectAlarmName, startSocketKeepAlive } from "./connection-lifecycle.ts"
 
 const relayHost = "127.0.0.1"
 const relayPort = 19989
@@ -174,26 +174,37 @@ async function announceHelloAndAttachedTabs(currentSocket: WebSocket): Promise<v
       protocolVersion: extensionProtocolVersion,
     },
   })
-  await reannounceAttachedTabsAndReconcileGroups(currentSocket)
-  sendOnSocket(currentSocket, { method: "ready" })
+  await reannounceAttachedTabs(currentSocket)
+  completeExtensionHandshake({
+    sendReady: () => sendOnSocket(currentSocket, { method: "ready" }),
+    reconcileGroups: () => reconcileBrowserControlGroups(),
+    reportReconciliationFailure: (error) => reportGroupReconciliationFailure(currentSocket, error),
+  })
 }
 
 function reportAnnouncementFailure(currentSocket: WebSocket, error: unknown): void {
   if (socket !== currentSocket || currentSocket.readyState !== WebSocket.OPEN) return
-  currentSocket.send(JSON.stringify({ method: "log", params: { level: "error", message: `Failed to re-announce attached tabs and reconcile groups: ${error instanceof Error ? error.message : String(error)}` } }))
+  currentSocket.send(JSON.stringify({ method: "log", params: { level: "error", message: `Failed to re-announce attached tabs: ${error instanceof Error ? error.message : String(error)}` } }))
   currentSocket.close(1011, "Attached-tab inventory failed")
 }
 
-async function reannounceAttachedTabsAndReconcileGroups(currentSocket: WebSocket): Promise<void> {
-  const attachedTabIds = new Set<number>()
+function reportGroupReconciliationFailure(currentSocket: WebSocket, error: unknown): void {
+  sendOnCurrentSocket(currentSocket, {
+    method: "log",
+    params: {
+      level: "error",
+      message: `Failed to reconcile tab groups: ${error instanceof Error ? error.message : String(error)}`,
+    },
+  })
+}
+
+async function reannounceAttachedTabs(currentSocket: WebSocket): Promise<void> {
   const targets = await chrome.debugger.getTargets()
   for (const target of targets) {
     if (target.attached && typeof target.tabId === "number") {
-      attachedTabIds.add(target.tabId)
       sendOnSocket(currentSocket, { method: "debugger.attached", params: { tabId: target.tabId } })
     }
   }
-  await reconcileBrowserControlGroups(attachedTabIds)
 }
 
 function sendOnSocket(currentSocket: WebSocket, message: JsonObject): void {
@@ -451,12 +462,12 @@ async function getTabCaptureStreamId(tabId: number): Promise<string> {
   }
 }
 
-async function reconcileBrowserControlGroups(knownAttachedTabIds?: ReadonlySet<number>): Promise<void> {
+async function reconcileBrowserControlGroups(): Promise<void> {
   if (!chrome.tabGroups) {
     return
   }
-  const attachedTabIds = knownAttachedTabIds ?? await getAttachedTabIds()
   const groups = await chrome.tabGroups.query({})
+  const attachedTabIds = await getAttachedTabIds()
   for (const group of groups) {
     if (!isCurrentBrowserControlGroupTitle(group.title) && !isLegacyBrowserControlGroupTitle(group.title)) {
       continue
@@ -469,7 +480,7 @@ async function reconcileBrowserControlGroups(knownAttachedTabIds?: ReadonlySet<n
       if (attachedTabIds.has(tab.id)) {
         continue
       }
-      await guardedUngroupBrowserControlTab(tab.id)
+      await guardedUngroupBrowserControlTab(tab.id, true)
     }
   }
 }
@@ -485,7 +496,7 @@ async function getAttachedTabIds(): Promise<Set<number>> {
   return attachedTabIds
 }
 
-async function guardedUngroupBrowserControlTab(tabId: number): Promise<void> {
+async function guardedUngroupBrowserControlTab(tabId: number, preserveAttached = false): Promise<void> {
   try {
     const tab = await chrome.tabs.get(tabId)
     if (tab.groupId === undefined || tab.groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) {
@@ -497,6 +508,9 @@ async function guardedUngroupBrowserControlTab(tabId: number): Promise<void> {
       groupTitle = group.title
     }
     if (!shouldUngroupBrowserControlTab(groupTitle)) {
+      return
+    }
+    if (preserveAttached && (await getAttachedTabIds()).has(tabId)) {
       return
     }
     await chrome.tabs.ungroup(tabId)

--- a/extension/src/connection-lifecycle.ts
+++ b/extension/src/connection-lifecycle.ts
@@ -4,6 +4,12 @@ const socketKeepAliveIntervalMs = 20_000
 
 type AlarmApi = Pick<typeof chrome.alarms, "create" | "get">
 
+type HandshakeCompletion = {
+  readonly sendReady: () => void
+  readonly reconcileGroups: () => Promise<void>
+  readonly reportReconciliationFailure: (error: unknown) => void
+}
+
 export async function ensureReconnectAlarm(alarms: AlarmApi): Promise<void> {
   if (await alarms.get(reconnectAlarmName)) return
   await alarms.create(reconnectAlarmName, { periodInMinutes: reconnectAlarmPeriodMinutes })
@@ -12,4 +18,9 @@ export async function ensureReconnectAlarm(alarms: AlarmApi): Promise<void> {
 export function startSocketKeepAlive(heartbeat: () => void): () => void {
   const timer = setInterval(heartbeat, socketKeepAliveIntervalMs)
   return () => clearInterval(timer)
+}
+
+export function completeExtensionHandshake({ sendReady, reconcileGroups, reportReconciliationFailure }: HandshakeCompletion): void {
+  sendReady()
+  void reconcileGroups().catch(reportReconciliationFailure)
 }

--- a/test/extension-connection-lifecycle.test.ts
+++ b/test/extension-connection-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
+  completeExtensionHandshake,
   ensureReconnectAlarm,
   reconnectAlarmName,
   startSocketKeepAlive,
@@ -41,5 +42,32 @@ describe("extension connection lifecycle", () => {
     vi.advanceTimersByTime(20_000)
 
     expect(heartbeat).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not block readiness on tab-group reconciliation", () => {
+    const sendReady = vi.fn()
+    const reconcileGroups = vi.fn(() => new Promise<void>(() => {}))
+    const reportReconciliationFailure = vi.fn()
+
+    completeExtensionHandshake({ sendReady, reconcileGroups, reportReconciliationFailure })
+
+    expect(sendReady).toHaveBeenCalledOnce()
+    expect(reconcileGroups).toHaveBeenCalledOnce()
+    expect(reportReconciliationFailure).not.toHaveBeenCalled()
+  })
+
+  it("reports tab-group reconciliation failures after readiness", async () => {
+    const failure = new Error("tab groups unavailable")
+    const sendReady = vi.fn()
+    const reportReconciliationFailure = vi.fn()
+
+    completeExtensionHandshake({
+      sendReady,
+      reconcileGroups: () => Promise.reject(failure),
+      reportReconciliationFailure,
+    })
+    await vi.waitFor(() => expect(reportReconciliationFailure).toHaveBeenCalledWith(failure))
+
+    expect(sendReady).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
## Summary

- send `ready` after the critical attached-tab inventory instead of waiting for tab-group reconciliation
- keep group cleanup best-effort and report failures without closing the extension socket
- refresh debugger attachment state before cleanup mutations so delayed reconciliation does not ungroup newly attached tabs

## Reproduction

With the unpacked v0.0.23 extension in Arc, `chrome.tabGroups.query({})` can remain pending during startup. The relay receives `hello` and `debugger.attached`, but never receives `ready`, so `browser-control status` reports a compatible extension with `connected: false`. Making reconciliation non-blocking restored a successful execute against an attached `example.com` tab.

## Verification

- `corepack pnpm typecheck`
- `corepack pnpm test` (426 tests)
- `corepack pnpm build:cli`
- `corepack pnpm build:extension`
- `corepack pnpm exec tsx scripts/package-extension.ts`
- `oxlint` on changed TypeScript files
- live Arc verification against `https://example.com/`