### PR TITLE
feat(relay): cross-host/WSL support via BROWSER_CONTROL_HOST and BROWSER_CONTROL_EXTENSION_ORIGINS

### DIFF
--- a/.changeset/wsl-remote-host-support.md
+++ b/.changeset/wsl-remote-host-support.md
@@ -1,0 +1,16 @@
+---
+"@opencode-ai/browser-control": minor
+---
+
+Support driving a browser on another host (e.g. Chrome on Windows → relay in
+WSL). Two opt-in settings, both defaulting to today's behavior:
+
+- `BROWSER_CONTROL_HOST` sets the relay bind host (default `127.0.0.1`); set it
+  to `0.0.0.0` so a browser off-host can reach the relay.
+- `BROWSER_CONTROL_EXTENSION_ORIGINS` allowlists extra `chrome-extension://<id>`
+  origins for the extension WebSocket (comma- or whitespace-separated), so an
+  unpacked extension whose path-derived id cannot match the relay's own bundled
+  path can still connect without patching `node_modules`.
+
+Adds `docs/WSL.md`. Provides a supported workaround for the cross-host 403 in
+#40 / #41 / #43.

--- a/README.md
+++ b/README.md
@@ -383,6 +383,12 @@ Current limitations:
   versions may differ when they use the same reported protocol version.
 - **Stale relay warning**: run `browser-control doctor`, stop the old relay
   process it identifies, then rerun a relay-backed command.
+- **WSL (Windows Chrome → relay in WSL)**: the relay and browser are on
+  different hosts, which shows up as `ERR_CONNECTION_REFUSED` (relay unreachable)
+  then a `403` handshake (extension origin not trusted). Set
+  `BROWSER_CONTROL_HOST=0.0.0.0` and
+  `BROWSER_CONTROL_EXTENSION_ORIGINS=chrome-extension://<id>`; full steps in
+  [docs/WSL.md](docs/WSL.md).
 
 For PowerShell, print the unpacked extension path with:
 

--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -1,0 +1,77 @@
+# Running Browser Control in WSL (Windows Chrome → relay in WSL)
+
+Browser Control's relay and the browser normally share one host, so the relay
+binds loopback (`127.0.0.1`) and only trusts the extension it can identify by
+its own install path. In WSL that assumption breaks in two independent ways,
+because the **relay runs in Linux (WSL)** while **Chrome runs on Windows**:
+
+1. **Reachability** — WSL and Windows have separate loopback stacks, so Windows
+   Chrome cannot reach a relay bound to `127.0.0.1` inside WSL. Symptom in the
+   extension's service-worker log:
+   `WebSocket connection to 'ws://127.0.0.1:19989/extension' failed: … ERR_CONNECTION_REFUSED`.
+2. **Origin trust** — an unpacked extension's id is a hash of its *load path*.
+   Chrome (Windows) loads it from a Windows path; the relay (WSL) computes the
+   allowed id from its own Linux path. They can never match, so the handshake is
+   rejected: `… WebSocket handshake: Unexpected response code: 403`.
+
+Two opt-in settings fix each half. Both default off, so nothing changes for
+same-host users.
+
+## Option A — keep using Windows Chrome
+
+### 1. Make the relay reachable from Windows
+
+Enable WSL **mirrored networking** so Windows and WSL share a loopback. In
+`C:\Users\<you>\.wslconfig`:
+
+```ini
+[wsl2]
+networkingMode=mirrored
+```
+
+Then from a Windows terminal: `wsl --shutdown` and reopen WSL.
+
+Bind the relay to all interfaces so it is reachable through the shared loopback
+(mirrored mode alone does not expose a *loopback-only* WSL service):
+
+```bash
+export BROWSER_CONTROL_HOST=0.0.0.0
+```
+
+`ERR_CONNECTION_REFUSED` should now be gone (the 403 below remains until step 2).
+
+### 2. Allowlist the unpacked extension's origin
+
+Find the extension's id in Windows Chrome at `chrome://extensions` (the 32‑char
+string on the **Browser Control** card), then allowlist exactly that origin:
+
+```bash
+export BROWSER_CONTROL_EXTENSION_ORIGINS=chrome-extension://<your-extension-id>
+```
+
+Restart the relay (`pkill -f browser-control`, then rerun any relay-backed
+command) and reload the extension. `browser-control status` should report
+`extension: connected`.
+
+`BROWSER_CONTROL_EXTENSION_ORIGINS` accepts several origins separated by commas
+or whitespace; anything that is not a bare `chrome-extension://<id>` origin is
+ignored, so a malformed value can never widen the check to a web origin.
+
+Persist both in `~/.bashrc` (or your shell profile) so the auto-started relay
+inherits them.
+
+### Security note
+
+`BROWSER_CONTROL_HOST=0.0.0.0` makes the relay reachable from your LAN, not just
+Windows. It stays gated by the `Host`-header allowlist and the extension-origin
+allowlist (only the ids you list, plus the Web Store build, may connect), but
+prefer a specific interface address over `0.0.0.0` where you can, and only
+allowlist extension ids you trust.
+
+## Option B — run Chromium inside WSL (no configuration)
+
+Install a Linux Chromium/Chrome inside WSL and load the same
+`extension/dist` there. The browser and relay then share one host and one
+filesystem, so neither setting is needed — loopback works and the extension's
+path-derived id matches the relay's. The trade-off is a separate browser profile
+from your Windows Chrome.

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -340,6 +340,11 @@ Common diagnoses:
 
 - `connected:false`: run a relay-backed command, then reload the unpacked
   extension only if its reconnect loop does not recover.
+- WSL (Windows Chrome, relay in WSL): `ERR_CONNECTION_REFUSED` then a `403`
+  handshake because the relay and browser are on different hosts. Set
+  `BROWSER_CONTROL_HOST=0.0.0.0` so Windows can reach the relay and
+  `BROWSER_CONTROL_EXTENSION_ORIGINS=chrome-extension://<id>` to trust the
+  Windows-loaded extension. See docs/WSL.md.
 - Incompatible extension protocol: update either the extension or npm package;
   exact extension and relay release versions do not need to match.
 - Stale relay build: operational commands reject it with restart guidance;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url"
 import { createDoctorReport, formatDoctorReport } from "./doctor.ts"
 import { runMcpServer } from "./mcp.ts"
 import * as RelayClient from "./relay-client.ts"
+import { parseAdditionalExtensionOrigins } from "./relay-helpers.ts"
 import * as RelayLifecycle from "./relay-lifecycle.ts"
 import type { ExecuteAftermath, ExecuteLogEntry, ExecuteResponse, NetworkStatusResponse, NetworkStopResponse } from "./relay-schema.ts"
 import { startRelay } from "./relay.ts"
@@ -196,9 +197,11 @@ const serve = Command.make(
   {},
   Effect.fn("Cli.serve")(function* () {
     const port = yield* RelayClient.portConfig
+    const host = yield* RelayClient.hostConfig
+    const additionalExtensionOrigins = parseAdditionalExtensionOrigins(yield* RelayClient.extensionOriginsConfig)
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const relay = yield* startRelay({ port })
+        const relay = yield* startRelay({ host, port, additionalExtensionOrigins })
         yield* Console.log(`browser-control relay listening at ${relay.url}`)
         yield* Console.log("Load extension/dist as an unpacked extension and click the toolbar button to attach a tab.")
         yield* Effect.never

--- a/src/relay-client.ts
+++ b/src/relay-client.ts
@@ -46,6 +46,21 @@ import {
 
 export const portConfig = Config.int("BROWSER_CONTROL_PORT").pipe(Config.withDefault(19989))
 
+/**
+ * Host the relay binds to. Defaults to loopback. Set to `0.0.0.0` (or a specific
+ * interface) so a browser on another host can reach the relay — e.g. Chrome on
+ * Windows driving a relay running inside WSL. See docs/WSL.md.
+ */
+export const hostConfig = Config.string("BROWSER_CONTROL_HOST").pipe(Config.withDefault("127.0.0.1"))
+
+/**
+ * Extra `chrome-extension://<id>` origins to allowlist for the extension
+ * WebSocket, comma- or whitespace-separated. Needed when the unpacked
+ * extension's path-derived id cannot match the relay's own bundled path
+ * (cross-host / WSL setups). Parsed by `parseAdditionalExtensionOrigins`.
+ */
+export const extensionOriginsConfig = Config.string("BROWSER_CONTROL_EXTENSION_ORIGINS").pipe(Config.withDefault(""))
+
 export const endpointForPort = (port: number): string => `http://127.0.0.1:${port}`
 
 export class RelayUnreachable extends Schema.TaggedErrorClass<RelayUnreachable>()(

--- a/src/relay-helpers.ts
+++ b/src/relay-helpers.ts
@@ -21,6 +21,35 @@ export function chromeExtensionOriginForPath(extensionPath: string): string {
   return `chrome-extension://${extensionId}`
 }
 
+const chromeExtensionOriginPattern = /^chrome-extension:\/\/[a-p]+$/
+
+/**
+ * Parses the operator-supplied `BROWSER_CONTROL_EXTENSION_ORIGINS` value into a
+ * de-duplicated list of `chrome-extension://<id>` origins to allowlist in
+ * addition to the built-ins. Entries are separated by commas or whitespace;
+ * anything that is not a bare `chrome-extension://` origin (web origins, paths,
+ * scheme-less ids) is dropped so a malformed value can never widen the origin
+ * check to a non-extension origin. Used for cross-host setups (e.g. Chrome on
+ * Windows driving a relay in WSL) where the path-derived unpacked id cannot
+ * match the relay's own bundled path.
+ */
+export function parseAdditionalExtensionOrigins(raw: string | undefined): string[] {
+  if (!raw) {
+    return []
+  }
+  const seen = new Set<string>()
+  const origins: string[] = []
+  for (const token of raw.split(/[\s,]+/)) {
+    const value = token.trim()
+    if (!value || !chromeExtensionOriginPattern.test(value) || seen.has(value)) {
+      continue
+    }
+    seen.add(value)
+    origins.push(value)
+  }
+  return origins
+}
+
 const maxCliBodyBytes = 1_000_000
 
 export class HttpRouteError extends Schema.TaggedErrorClass<HttpRouteError>()(

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -67,6 +67,7 @@ export const startRelay = Effect.fn("Relay.start")(function* (options: {
   readonly port?: number
   readonly releaseTargetGraceMs?: number
   readonly sessionCatalogPath?: string | null
+  readonly additionalExtensionOrigins?: readonly string[]
 } = {}) {
   yield* installRelayProcessGuard
   return yield* Effect.acquireRelease(makeRelay(options), (server) => {
@@ -151,6 +152,7 @@ const makeRelay = Effect.fnUntraced(function* (options: {
   readonly port?: number
   readonly releaseTargetGraceMs?: number
   readonly sessionCatalogPath?: string | null
+  readonly additionalExtensionOrigins?: readonly string[]
 } = {}) {
   const host = options.host ?? defaultHost
   const port = options.port ?? defaultPort
@@ -159,9 +161,10 @@ const makeRelay = Effect.fnUntraced(function* (options: {
   const endpointUrl = `http://${formatHostForUrl(host)}:${port}`
   const allowAnyChromeExtension = browserControlVersion === "0.0.0-dev"
   const bundledUnpackedExtensionOrigin = getBundledUnpackedExtensionOrigin()
-  const additionalChromeExtensionOrigins = new Set(
-    bundledUnpackedExtensionOrigin ? [bundledUnpackedExtensionOrigin] : [],
-  )
+  const additionalChromeExtensionOrigins = new Set([
+    ...(bundledUnpackedExtensionOrigin ? [bundledUnpackedExtensionOrigin] : []),
+    ...(options.additionalExtensionOrigins ?? []),
+  ])
   const sessionCatalog = options.sessionCatalogPath === null
     ? undefined
     : new SessionCatalog(options.sessionCatalogPath ?? defaultSessionCatalogPath(port))

--- a/test/relay-helpers.test.ts
+++ b/test/relay-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   getTargetInfo,
   isRestrictedTarget,
   optionalSessionId,
+  parseAdditionalExtensionOrigins,
   parseTargetSelection,
   validateBrowserFetchSite,
   validateHostHeader,
@@ -80,6 +81,40 @@ describe("validateWebSocketOrigin", () => {
     expect(validateWebSocketOrigin({ origin: "https://example.com", requireChromeExtension: true })).toBeDefined()
     expect(validateWebSocketOrigin({ origin: "https://example.com" })).toBeDefined()
     expect(validateWebSocketOrigin({ origin: "chrome-extension://different-extension" })).toBeDefined()
+  })
+
+  it("accepts an operator-provided extension origin (BROWSER_CONTROL_EXTENSION_ORIGINS)", () => {
+    const extra = parseAdditionalExtensionOrigins("chrome-extension://hkjpchgckkjgpkcpiikmdeobkhmejhda")
+    expect(validateWebSocketOrigin({
+      origin: "chrome-extension://hkjpchgckkjgpkcpiikmdeobkhmejhda",
+      requireChromeExtension: true,
+      additionalChromeExtensionOrigins: new Set(extra),
+    })).toBeUndefined()
+  })
+})
+
+describe("parseAdditionalExtensionOrigins", () => {
+  it("splits comma- and whitespace-separated chrome-extension origins", () => {
+    expect(
+      parseAdditionalExtensionOrigins("chrome-extension://aaaa, chrome-extension://bbbb\nchrome-extension://cccc"),
+    ).toEqual(["chrome-extension://aaaa", "chrome-extension://bbbb", "chrome-extension://cccc"])
+  })
+
+  it("trims entries and drops empties and duplicates", () => {
+    expect(
+      parseAdditionalExtensionOrigins("  chrome-extension://aaaa , , chrome-extension://aaaa "),
+    ).toEqual(["chrome-extension://aaaa"])
+  })
+
+  it("keeps only chrome-extension:// origins, rejecting web origins, paths, and bare ids", () => {
+    expect(
+      parseAdditionalExtensionOrigins("https://evil.example, chrome-extension://aaaa/background.js, bbbb, chrome-extension://cccc"),
+    ).toEqual(["chrome-extension://cccc"])
+  })
+
+  it("returns an empty array for undefined or empty input", () => {
+    expect(parseAdditionalExtensionOrigins(undefined)).toEqual([])
+    expect(parseAdditionalExtensionOrigins("   ")).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

Makes it possible to drive a browser running on a **different host** than the
relay — the motivating case is Chrome on **Windows** driving a relay inside
**WSL**, but it applies to any remote/split setup.

Two things break in that topology, and this PR adds one opt-in setting for each.
Both default to today's behavior, so nothing changes for same-host users.

### 1. Reachability — `BROWSER_CONTROL_HOST`

The relay binds `127.0.0.1`, and WSL/Windows have separate loopback stacks, so
Windows Chrome can't reach it (`WebSocket … ERR_CONNECTION_REFUSED`). New
`BROWSER_CONTROL_HOST` (default `127.0.0.1`, mirrors the existing
`BROWSER_CONTROL_PORT`) lets an operator bind `0.0.0.0`/a specific interface.
Threaded `serve → startRelay → makeRelay`, so both the foreground and the
auto-started detached relay honor it (the detached spawn already inherits
`process.env`).

### 2. Origin trust — `BROWSER_CONTROL_EXTENSION_ORIGINS`

An unpacked extension's id is a hash of its **load path**. Chrome (Windows)
loads it from a Windows path; the relay (WSL) computes the allowed id from its
own Linux path, so they can never match and the handshake is `403`'d. This is
the same **path-derived id mismatch** behind #40 / #41 / #43 (Windows UTF-16
hashing, moved installs, Edge/Linux). New `BROWSER_CONTROL_EXTENSION_ORIGINS`
allowlists extra `chrome-extension://<id>` origins (comma/whitespace-separated),
so users no longer have to patch `node_modules`. Parsing (`parseAdditionalExtensionOrigins`)
drops anything that isn't a bare `chrome-extension://` origin, so a malformed
value can never widen the check to a web origin.

Adds `docs/WSL.md` and troubleshooting notes in the README and the skill.

## Why not pin the extension id with a manifest `key`?

Pinning the id (as #41's first suggestion proposes) is the cleaner root-cause
fix, but the manifest is shared with the Chrome Web Store package (#32/#34), and
the Web Store rejects uploads that contain a `key`. Doing that safely means a
store-strip in `package-extension.ts` plus a decision about which key is
canonical — worth a separate PR. This change is additive, security-preserving,
and unblocks the cross-host/WSL case today; it's a **supported workaround** for
#40 / #41 / #43 rather than a full close.

## Testing

- New unit tests for `parseAdditionalExtensionOrigins` (split/trim/dedupe;
  rejects web origins, paths, scheme-less ids) and for `validateWebSocketOrigin`
  accepting an operator-provided origin. TDD'd (red → green).
- `pnpm typecheck`, `pnpm build`, and the full `pnpm test` suite (**429 tests**) pass.
- End-to-end against a **built** relay (real version → strict origin check, so
  `allowAnyChromeExtension` is off), raw WebSocket handshake to `/extension`:

  | Origin | with `BROWSER_CONTROL_EXTENSION_ORIGINS` | without (default) |
  |---|---|---|
  | the allowlisted extension id | **101 accepted** | 403 rejected |
  | a bogus `chrome-extension://…` id | 403 rejected | 403 rejected |
  | no Origin | 403 rejected | 403 rejected |

- Live: with `BROWSER_CONTROL_HOST=0.0.0.0` + the origins var, a real Chrome
  (Windows) extension connected to the WSL relay (`extension: connected`,
  protocol 2) and `execute` drove it end-to-end (`https://example.com` →
  `Example Domain`).

## Compatibility

Both settings default to current behavior; unset, the relay binds `127.0.0.1`
and allowlists only the Web Store origin + its own bundled-path origin, exactly
as before.
