### PR TITLE
fix(extension): stabilize unpacked connectivity

### DIFF
--- a/.changeset/reliable-extension-connectivity.md
+++ b/.changeset/reliable-extension-connectivity.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Keep extension readiness independent from browser tab-group APIs that can remain pending indefinitely in Arc, and give unpacked builds a stable extension id with platform-correct migration support for existing Windows installs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,11 +242,18 @@ browser-control skill
 
 - Load `extension/dist` as the unpacked extension.
 - The relay listens on `127.0.0.1:19989` by default.
-- Current shim version is `0.0.23` and extension protocol version is `2`.
+- Current shim version is `0.0.24` and extension protocol version is `2`.
 - Store and npm versions may differ while their extension protocol versions remain compatible.
+- The source and unpacked-build manifest carries the public key for stable id
+  `eibhgjafffkigblngnhafgbcipofaeon`. Store packaging must strip that key so the
+  Chrome Web Store keeps its assigned extension id.
 - On socket open the shim sends `hello` and then re-announces every tab it still
   has `chrome.debugger` attached to (`debugger.attached` events), so a restarted
   relay rebuilds its target registry without the user re-clicking the toolbar.
+- Send `ready` after the attached-tab inventory; tab-group presentation and
+  stale-group cleanup are best-effort and must never block extension readiness.
+  Serialize group and ungroup presentation per tab so delayed browser APIs
+  cannot apply an older ownership state after a newer one.
 - Repair the reconnect alarm whenever the MV3 worker starts and send heartbeat
   traffic every 20 seconds while its relay socket is open. Chrome may clear
   persisted alarms and retires idle extension workers even with an open socket.

--- a/PLAN.md
+++ b/PLAN.md
@@ -71,6 +71,14 @@ Verification:
 
 ## Recently Shipped
 
+### Unpacked extension connectivity survives browser and path differences
+
+The unpacked manifest carries a stable public key, while Store packaging strips
+it before creating the review ZIP. Extension readiness waits only for debugger
+inventory: Arc tab-group queries and restored-tab presentation run afterward,
+cannot mutate from stale sockets, serialize ownership changes per tab, and
+report failures through relay diagnostics.
+
 ### Tab-capture recordings stream with intrinsic framing
 
 Extension protocol `2` sends each recording chunk as a sequenced `BCRD` binary
@@ -186,7 +194,9 @@ require a new extension capture protocol and permission model.
   link`.
 - Until the first Store review completes, the browser extension is loaded
   unpacked from the npm package's `extension/dist` directory or a source build.
-  Its current shim version is `0.0.23`.
+  Its current shim version is `0.0.24`. A manifest public key gives unpacked
+  builds one stable extension id across install paths and operating systems;
+  Store packaging strips that key so the Store keeps its assigned id.
 - Extension and npm releases are independently versioned. The extension hello
   reports an explicit protocol version, and compatibility rather than exact
   package-version equality determines whether the local driver may use it.

--- a/docs/CHROME_WEB_STORE.md
+++ b/docs/CHROME_WEB_STORE.md
@@ -110,5 +110,8 @@ Upload `artifacts/browser-control-extension-<version>.zip`. Record the printed
 SHA-256 digest with the release notes.
 
 The production relay accepts Store extension ID
-`gmjpoplfomnnjipeiojccjbpjlodkjhn`. Source-mode relays additionally accept
-unpacked development extension origins.
+`gmjpoplfomnnjipeiojccjbpjlodkjhn` and stable unpacked ID
+`eibhgjafffkigblngnhafgbcipofaeon`. The source manifest carries the unpacked
+public key; `package:extension` strips it from the Store ZIP so the Store keeps
+its assigned ID. Source-mode relays additionally accept development extension
+origins.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Browser Control",
-  "version": "0.0.23",
+  "version": "0.0.24",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzTg+VNnMmpavX6z5WKu4FYh9xa2J+jjxTS/EmxYdgbzh33amUxawAVWV3p5NF58Y9yZxBEv11M1BUPWVVdAYyTsHYj70+xpCXGCnljQF6igo8hKBPoNNvg/+/IyI+FPbj34Mv2P1u+ZUCR9cAhFcqmD5mSvMbB8zFVSa+Rgknwwz5Uegu1bKzpI5Z9nO2EI6KOgjeJV/YEjl6NecC743FlCVztFZ1NIiJKl7DFmTSUa1/Piu7WHucBNfNDnoc6A9tmLTTLYnOH+KinXV3MsakWGNhGQTPCBRGLlGQ3SAa6HN7SPzZIkqHABBdMbf/1nO9Vj7dWAKIhX3Zud3GHxObwIDAQAB",
   "description": "Connect browser tabs to the local Browser Control driver.",
   "minimum_chrome_version": "120",
   "permissions": ["activeTab", "alarms", "debugger", "offscreen", "tabCapture", "tabGroups"],

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -7,10 +7,10 @@ import type {
   OffscreenStatusRecordingResult,
   OffscreenStopRecordingResult,
 } from "./recording-types.ts"
-import { isBrowserControlGroupTitle, isCurrentBrowserControlGroupTitle, isLegacyBrowserControlGroupTitle, shouldUngroupBrowserControlTab, tabGroupColor, tabGroupTitle } from "./tab-groups.ts"
+import { finalizeBrowserControlGrouping, isBrowserControlGroupTitle, shouldUngroupBrowserControlTab, tabGroupColor, tabGroupTitle } from "./tab-groups.ts"
 import { pageStatusFromJson } from "./page-status.ts"
 import { debuggerDetachedEvent } from "./debugger-detach.ts"
-import { ensureReconnectAlarm, reconnectAlarmName, startSocketKeepAlive } from "./connection-lifecycle.ts"
+import { completeExtensionHandshake, ensureReconnectAlarm, reconnectAlarmName, startSocketKeepAlive } from "./connection-lifecycle.ts"
 
 const relayHost = "127.0.0.1"
 const relayPort = 19989
@@ -21,6 +21,11 @@ let socket: WebSocket | undefined
 let connectionPromise: Promise<void> | undefined
 let reconnectTimer: ReturnType<typeof setTimeout> | undefined
 let offscreenDocumentCreating: Promise<void> | undefined
+let groupReconciliation: Promise<void> | undefined
+let socketGeneration = 0
+const tabGroupingCommands = new Map<number, Promise<unknown>>()
+
+class ConnectionChangedError extends Error {}
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name !== reconnectAlarmName) {
@@ -90,10 +95,11 @@ function startConnection(): WebSocket {
     reconnectTimer = undefined
   }
   const currentSocket = new WebSocket(`ws://${relayHost}:${relayPort}/extension`)
+  const currentGeneration = ++socketGeneration
   let stopKeepAlive: (() => void) | undefined
   socket = currentSocket
   currentSocket.onopen = () => {
-    void announceHelloAndAttachedTabs(currentSocket).then(
+    void announceHelloAndAttachedTabs(currentSocket, currentGeneration).then(
       () => {
         if (socket === currentSocket && currentSocket.readyState === WebSocket.OPEN) {
           stopKeepAlive = startSocketKeepAlive(() => sendOnCurrentSocket(currentSocket, { method: "pong" }))
@@ -166,7 +172,7 @@ async function ensureConnection(): Promise<void> {
   }
 }
 
-async function announceHelloAndAttachedTabs(currentSocket: WebSocket): Promise<void> {
+async function announceHelloAndAttachedTabs(currentSocket: WebSocket, currentGeneration: number): Promise<void> {
   sendOnSocket(currentSocket, {
     method: "hello",
     params: {
@@ -174,32 +180,55 @@ async function announceHelloAndAttachedTabs(currentSocket: WebSocket): Promise<v
       protocolVersion: extensionProtocolVersion,
     },
   })
-  await reannounceAttachedTabsAndReconcileGroups(currentSocket)
-  sendOnSocket(currentSocket, { method: "ready" })
+  await completeExtensionHandshake({
+    announceAttachedTabs: () => reannounceAttachedTabs(currentSocket),
+    sendReady: () => sendOnSocket(currentSocket, { method: "ready" }),
+    startGroupReconciliation: () => startGroupReconciliation(currentGeneration),
+  })
 }
 
 function reportAnnouncementFailure(currentSocket: WebSocket, error: unknown): void {
   if (socket !== currentSocket || currentSocket.readyState !== WebSocket.OPEN) return
-  currentSocket.send(JSON.stringify({ method: "log", params: { level: "error", message: `Failed to re-announce attached tabs and reconcile groups: ${error instanceof Error ? error.message : String(error)}` } }))
+  currentSocket.send(JSON.stringify({ method: "log", params: { level: "error", message: `Failed to re-announce attached tabs: ${error instanceof Error ? error.message : String(error)}` } }))
   currentSocket.close(1011, "Attached-tab inventory failed")
 }
 
-async function reannounceAttachedTabsAndReconcileGroups(currentSocket: WebSocket): Promise<void> {
-  const attachedTabIds = new Set<number>()
+function startGroupReconciliation(currentGeneration: number): void {
+  if (groupReconciliation) return
+  const pending = reconcileBrowserControlGroups(currentGeneration)
+    .catch((error: unknown) => {
+      if (error instanceof ConnectionChangedError || currentGeneration !== socketGeneration) return
+      const currentSocket = socket
+      if (!currentSocket) return
+      sendOnCurrentSocket(currentSocket, {
+        method: "log",
+        params: {
+          level: "error",
+          message: `Failed to reconcile tab groups: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      })
+    })
+    .finally(() => {
+      if (groupReconciliation !== pending) return
+      groupReconciliation = undefined
+      if (currentGeneration !== socketGeneration && socket?.readyState === WebSocket.OPEN) {
+        startGroupReconciliation(socketGeneration)
+      }
+    })
+  groupReconciliation = pending
+}
+
+async function reannounceAttachedTabs(currentSocket: WebSocket): Promise<void> {
   const targets = await chrome.debugger.getTargets()
   for (const target of targets) {
     if (target.attached && typeof target.tabId === "number") {
-      attachedTabIds.add(target.tabId)
       sendOnSocket(currentSocket, { method: "debugger.attached", params: { tabId: target.tabId } })
     }
   }
-  await reconcileBrowserControlGroups(attachedTabIds)
 }
 
 function sendOnSocket(currentSocket: WebSocket, message: JsonObject): void {
-  if (socket !== currentSocket || currentSocket.readyState !== WebSocket.OPEN) {
-    throw new Error("Extension connection changed during attached-tab inventory")
-  }
+  assertCurrentSocket(currentSocket)
   currentSocket.send(JSON.stringify(message))
 }
 
@@ -212,7 +241,7 @@ async function handleSocketMessage(currentSocket: WebSocket, data: unknown): Pro
     return
   }
   try {
-    const result = await handleCommand(command)
+    const result = await handleCommand(command, currentSocket)
     sendOnCurrentSocket(currentSocket, { id: command.id, result })
   } catch (error) {
     sendOnCurrentSocket(currentSocket, { id: command.id, error: error instanceof Error ? error.message : String(error) })
@@ -220,12 +249,12 @@ async function handleSocketMessage(currentSocket: WebSocket, data: unknown): Pro
 }
 
 function sendOnCurrentSocket(currentSocket: WebSocket, message: JsonObject): void {
-  if (socket === currentSocket && currentSocket.readyState === WebSocket.OPEN) {
+  if (isCurrentSocket(currentSocket)) {
     currentSocket.send(JSON.stringify(message))
   }
 }
 
-async function handleCommand(command: ShimCommand): Promise<JsonObject> {
+async function handleCommand(command: ShimCommand, currentSocket: WebSocket): Promise<JsonObject> {
   if (command.method === "ping") {
     return {}
   }
@@ -243,7 +272,9 @@ async function handleCommand(command: ShimCommand): Promise<JsonObject> {
   if (command.method === "debugger.detach") {
     const tabId = numberParam(command.params, "tabId")
     await chrome.debugger.detach({ tabId })
-    await guardedUngroupBrowserControlTab(tabId)
+    await runTabGroupingCommand(tabId, () => guardedUngroupBrowserControlTab(tabId, {
+      assertCurrent: () => assertCurrentSocket(currentSocket),
+    }))
     return {}
   }
   if (command.method === "debugger.sendCommand") {
@@ -270,35 +301,13 @@ async function handleCommand(command: ShimCommand): Promise<JsonObject> {
   }
   if (command.method === "tabs.group") {
     const tabId = numberParam(command.params, "tabId")
-    const tab = await chrome.tabs.get(tabId)
-    if (tab.groupId !== undefined && tab.groupId !== chrome.tabGroups.TAB_GROUP_ID_NONE) {
-      const currentGroup = await chrome.tabGroups.get(tab.groupId)
-      if (currentGroup.title === tabGroupTitle && currentGroup.color === tabGroupColor) {
-        return { groupId: currentGroup.id }
-      }
-    }
-    const attachedTabIds = await getAttachedTabIds()
-    let existingGroup: chrome.tabGroups.TabGroup | undefined
-    for (const group of await chrome.tabGroups.query({ windowId: tab.windowId })) {
-      if (group.title !== tabGroupTitle || group.color !== tabGroupColor) {
-        continue
-      }
-      const groupedTabs = await chrome.tabs.query({ groupId: group.id })
-      if (groupedTabs.some((groupedTab) => typeof groupedTab.id === "number" && attachedTabIds.has(groupedTab.id))) {
-        existingGroup = group
-        break
-      }
-    }
-    const groupId = await chrome.tabs.group({
-      tabIds: [tabId],
-      ...(existingGroup ? { groupId: existingGroup.id } : {}),
-    })
-    await chrome.tabGroups.update(groupId, { title: tabGroupTitle, color: tabGroupColor })
-    return { groupId }
+    return await runTabGroupingCommand(tabId, () => groupBrowserControlTab(tabId, currentSocket))
   }
   if (command.method === "tabs.ungroup") {
     const tabId = numberParam(command.params, "tabId")
-    await guardedUngroupBrowserControlTab(tabId)
+    await runTabGroupingCommand(tabId, () => guardedUngroupBrowserControlTab(tabId, {
+      assertCurrent: () => assertCurrentSocket(currentSocket),
+    }))
     return {}
   }
   if (command.method === "action.setAttached") {
@@ -451,25 +460,32 @@ async function getTabCaptureStreamId(tabId: number): Promise<string> {
   }
 }
 
-async function reconcileBrowserControlGroups(knownAttachedTabIds?: ReadonlySet<number>): Promise<void> {
+async function reconcileBrowserControlGroups(currentGeneration: number): Promise<void> {
   if (!chrome.tabGroups) {
     return
   }
-  const attachedTabIds = knownAttachedTabIds ?? await getAttachedTabIds()
   const groups = await chrome.tabGroups.query({})
+  assertCurrentGeneration(currentGeneration)
+  const attachedTabIds = await getAttachedTabIds()
+  assertCurrentGeneration(currentGeneration)
   for (const group of groups) {
-    if (!isCurrentBrowserControlGroupTitle(group.title) && !isLegacyBrowserControlGroupTitle(group.title)) {
+    if (!isBrowserControlGroupTitle(group.title)) {
       continue
     }
     const tabs = await chrome.tabs.query({ groupId: group.id })
+    assertCurrentGeneration(currentGeneration)
     for (const tab of tabs) {
       if (typeof tab.id !== "number") {
         continue
       }
-      if (attachedTabIds.has(tab.id)) {
+      const tabId = tab.id
+      if (attachedTabIds.has(tabId)) {
         continue
       }
-      await guardedUngroupBrowserControlTab(tab.id)
+      await runTabGroupingCommand(tabId, () => guardedUngroupBrowserControlTab(tabId, {
+        assertCurrent: () => assertCurrentGeneration(currentGeneration),
+        preserveAttached: true,
+      }))
     }
   }
 }
@@ -485,9 +501,59 @@ async function getAttachedTabIds(): Promise<Set<number>> {
   return attachedTabIds
 }
 
-async function guardedUngroupBrowserControlTab(tabId: number): Promise<void> {
+async function groupBrowserControlTab(tabId: number, currentSocket: WebSocket): Promise<JsonObject> {
+  const tab = await chrome.tabs.get(tabId)
+  if (tab.groupId !== undefined && tab.groupId !== chrome.tabGroups.TAB_GROUP_ID_NONE) {
+    const currentGroup = await chrome.tabGroups.get(tab.groupId)
+    if (currentGroup.title === tabGroupTitle && currentGroup.color === tabGroupColor) {
+      return { groupId: currentGroup.id }
+    }
+  }
+  const groups = await chrome.tabGroups.query({ windowId: tab.windowId })
+  assertCurrentSocket(currentSocket)
+  const attachedTabIds = await getAttachedTabIds()
+  assertCurrentSocket(currentSocket)
+  let existingGroup: chrome.tabGroups.TabGroup | undefined
+  for (const group of groups) {
+    if (group.title !== tabGroupTitle || group.color !== tabGroupColor) continue
+    const groupedTabs = await chrome.tabs.query({ groupId: group.id })
+    if (groupedTabs.some((groupedTab) => typeof groupedTab.id === "number" && attachedTabIds.has(groupedTab.id))) {
+      existingGroup = group
+      break
+    }
+  }
+  assertCurrentSocket(currentSocket)
+  const groupId = await chrome.tabs.group({
+    tabIds: [tabId],
+    ...(existingGroup ? { groupId: existingGroup.id } : {}),
+  })
+  await finalizeBrowserControlGrouping({
+    assertCurrent: () => assertCurrentSocket(currentSocket),
+    update: () => chrome.tabGroups.update(groupId, { title: tabGroupTitle, color: tabGroupColor }).then(() => {}),
+    rollback: () => chrome.tabs.ungroup(tabId),
+  })
+  return { groupId }
+}
+
+async function runTabGroupingCommand<A>(tabId: number, command: () => Promise<A>): Promise<A> {
+  const previous = tabGroupingCommands.get(tabId) ?? Promise.resolve()
+  const current = previous.catch(() => {}).then(command)
+  tabGroupingCommands.set(tabId, current)
+  try {
+    return await current
+  } finally {
+    if (tabGroupingCommands.get(tabId) === current) tabGroupingCommands.delete(tabId)
+  }
+}
+
+async function guardedUngroupBrowserControlTab(tabId: number, options: {
+  readonly assertCurrent?: () => void
+  readonly preserveAttached?: boolean
+} = {}): Promise<void> {
+  const assertCurrent = options.assertCurrent ?? (() => {})
   try {
     const tab = await chrome.tabs.get(tabId)
+    assertCurrent()
     if (tab.groupId === undefined || tab.groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) {
       return
     }
@@ -495,15 +561,35 @@ async function guardedUngroupBrowserControlTab(tabId: number): Promise<void> {
     if (chrome.tabGroups) {
       const group = await chrome.tabGroups.get(tab.groupId)
       groupTitle = group.title
+      assertCurrent()
     }
     if (!shouldUngroupBrowserControlTab(groupTitle)) {
       return
     }
+    if (options.preserveAttached && (await getAttachedTabIds()).has(tabId)) {
+      return
+    }
+    assertCurrent()
     await chrome.tabs.ungroup(tabId)
-  } catch {
+  } catch (error) {
+    if (error instanceof ConnectionChangedError) throw error
     // Tabs and groups can disappear while detach/close/reconnect cleanup is racing
     // the browser. Ungrouping is best-effort because stale groups are reconciled
     // again on service-worker startup and relay reconnect.
+  }
+}
+
+function assertCurrentSocket(currentSocket: WebSocket): void {
+  if (!isCurrentSocket(currentSocket)) throw new ConnectionChangedError("Extension connection changed")
+}
+
+function isCurrentSocket(currentSocket: WebSocket): boolean {
+  return socket === currentSocket && currentSocket.readyState === WebSocket.OPEN
+}
+
+function assertCurrentGeneration(currentGeneration: number): void {
+  if (currentGeneration !== socketGeneration || socket?.readyState !== WebSocket.OPEN) {
+    throw new ConnectionChangedError("Extension connection changed")
   }
 }
 

--- a/extension/src/connection-lifecycle.ts
+++ b/extension/src/connection-lifecycle.ts
@@ -4,6 +4,12 @@ const socketKeepAliveIntervalMs = 20_000
 
 type AlarmApi = Pick<typeof chrome.alarms, "create" | "get">
 
+type HandshakeCompletion = {
+  readonly announceAttachedTabs: () => Promise<void>
+  readonly sendReady: () => void
+  readonly startGroupReconciliation: () => void
+}
+
 export async function ensureReconnectAlarm(alarms: AlarmApi): Promise<void> {
   if (await alarms.get(reconnectAlarmName)) return
   await alarms.create(reconnectAlarmName, { periodInMinutes: reconnectAlarmPeriodMinutes })
@@ -12,4 +18,10 @@ export async function ensureReconnectAlarm(alarms: AlarmApi): Promise<void> {
 export function startSocketKeepAlive(heartbeat: () => void): () => void {
   const timer = setInterval(heartbeat, socketKeepAliveIntervalMs)
   return () => clearInterval(timer)
+}
+
+export async function completeExtensionHandshake(options: HandshakeCompletion): Promise<void> {
+  await options.announceAttachedTabs()
+  options.sendReady()
+  options.startGroupReconciliation()
 }

--- a/extension/src/tab-groups.ts
+++ b/extension/src/tab-groups.ts
@@ -22,3 +22,19 @@ export function isBrowserControlGroupTitle(title: string | undefined): boolean {
 export function shouldUngroupBrowserControlTab(groupTitle: string | undefined): boolean {
   return isBrowserControlGroupTitle(groupTitle)
 }
+
+export async function finalizeBrowserControlGrouping(options: {
+  readonly assertCurrent: () => void
+  readonly update: () => Promise<void>
+  readonly rollback: () => Promise<void>
+}): Promise<void> {
+  try {
+    options.assertCurrent()
+  } catch (error) {
+    // chrome.tabs.group mutates before it resolves, so a stale command must
+    // remove that anonymous group before the newer per-tab command can run.
+    await options.rollback().catch(() => {})
+    throw error
+  }
+  await options.update()
+}

--- a/scripts/package-extension.ts
+++ b/scripts/package-extension.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto"
+import { createHash, createPublicKey } from "node:crypto"
 import fs from "node:fs/promises"
 import path from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
@@ -23,24 +23,43 @@ export async function makeExtensionArchive(dist: string): Promise<Uint8Array> {
     if (relativePath.endsWith(".map")) {
       throw new Error(`Chrome Web Store package must not contain source maps: ${relativePath}`)
     }
+    const contents = new Uint8Array(await fs.readFile(path.join(dist, relativePath)))
     entries[relativePath] = [
-      new Uint8Array(await fs.readFile(path.join(dist, relativePath))),
+      relativePath === "manifest.json" ? storeManifest(contents) : contents,
       { mtime: new Date(2000, 0, 1), os: 3, attrs: 0o644 << 16 },
     ]
   }
   return zipSync(entries, { level: 9, mtime: new Date(2000, 0, 1), os: 3 })
 }
 
+function storeManifest(contents: Uint8Array): Uint8Array {
+  const manifest = parseManifest(new TextDecoder().decode(contents))
+  Reflect.deleteProperty(manifest, "key")
+  return new TextEncoder().encode(`${JSON.stringify(manifest, null, 2)}\n`)
+}
+
 export async function extensionVersion(dist: string): Promise<string> {
-  const parsed: unknown = JSON.parse(await fs.readFile(path.join(dist, "manifest.json"), "utf8"))
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("Extension manifest must be an object")
-  }
-  const version = Reflect.get(parsed, "version")
+  return manifestVersion(await readManifest(dist))
+}
+
+function manifestVersion(manifest: Record<string, unknown>): string {
+  const version = manifest.version
   if (typeof version !== "string" || !isChromeExtensionVersion(version)) {
     throw new Error("Extension manifest has an invalid Chrome version")
   }
   return version
+}
+
+async function readManifest(dist: string): Promise<Record<string, unknown>> {
+  return parseManifest(await fs.readFile(path.join(dist, "manifest.json"), "utf8"))
+}
+
+function parseManifest(contents: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(contents)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Extension manifest must be an object")
+  }
+  return parsed as Record<string, unknown>
 }
 
 export function isChromeExtensionVersion(version: string): boolean {
@@ -52,27 +71,34 @@ export function isChromeExtensionVersion(version: string): boolean {
   })
 }
 
-async function validateStoreExtension(dist: string): Promise<void> {
+async function validateStoreExtension(dist: string): Promise<string> {
   const files = await listFiles(dist)
   if (files.length !== storePackageFiles.length || files.some((file, index) => file !== storePackageFiles[index])) {
     throw new Error(`Unexpected Chrome Web Store package files: ${files.join(", ")}`)
   }
-  const parsed: unknown = JSON.parse(await fs.readFile(path.join(dist, "manifest.json"), "utf8"))
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("Extension manifest must be an object")
-  }
-  if (Reflect.get(parsed, "manifest_version") !== 3 || Reflect.get(parsed, "minimum_chrome_version") !== "120") {
+  const manifest = await readManifest(dist)
+  if (manifest.manifest_version !== 3 || manifest.minimum_chrome_version !== "120") {
     throw new Error("Extension manifest must target Manifest V3 and Chrome 120 or later")
   }
-  const permissions = Reflect.get(parsed, "permissions")
+  const permissions = manifest.permissions
   const expectedPermissions = ["activeTab", "alarms", "debugger", "offscreen", "tabCapture", "tabGroups"]
   if (!Array.isArray(permissions) || permissions.join(",") !== expectedPermissions.join(",")) {
     throw new Error("Extension manifest permissions differ from the reviewed allowlist")
   }
-  if (Reflect.has(parsed, "host_permissions")) {
+  if (Reflect.has(manifest, "host_permissions")) {
     throw new Error("Extension manifest must not declare redundant host_permissions")
   }
-  await extensionVersion(dist)
+  const key = manifest.key
+  if (typeof key !== "string") {
+    throw new Error("Unpacked extension manifest must declare a stable public key")
+  }
+  try {
+    const publicKey = createPublicKey({ key: Buffer.from(key, "base64"), format: "der", type: "spki" })
+    if (publicKey.asymmetricKeyType !== "rsa") throw new Error("Expected an RSA key")
+  } catch (error) {
+    throw new Error("Unpacked extension manifest key is not a valid RSA public key", { cause: error })
+  }
+  const version = manifestVersion(manifest)
   await Promise.all([16, 32, 48, 128].map(async (size) => {
     const png = await fs.readFile(path.join(dist, "icons", `icon-${size}.png`))
     if (png.readUInt32BE(0) !== 0x89504e47 || png.toString("ascii", 1, 4) !== "PNG") {
@@ -82,6 +108,7 @@ async function validateStoreExtension(dist: string): Promise<void> {
       throw new Error(`Extension icon ${size} has incorrect dimensions`)
     }
   }))
+  return version
 }
 
 async function listFiles(directory: string, prefix = ""): Promise<string[]> {
@@ -102,8 +129,7 @@ async function listFiles(directory: string, prefix = ""): Promise<string[]> {
 
 async function main(): Promise<void> {
   const dist = path.join(root, "extension", "dist")
-  await validateStoreExtension(dist)
-  const version = await extensionVersion(dist)
+  const version = await validateStoreExtension(dist)
   const archive = await makeExtensionArchive(dist)
   const artifactDirectory = path.join(root, "artifacts")
   const artifactPath = path.join(artifactDirectory, `browser-control-extension-${version}.zip`)

--- a/src/relay-helpers.ts
+++ b/src/relay-helpers.ts
@@ -11,9 +11,11 @@ import { RelayErrorCode } from "./relay-schema.ts"
 export const defaultHost = "127.0.0.1"
 export const defaultPort = 19989
 export const chromeWebStoreExtensionOrigin = "chrome-extension://gmjpoplfomnnjipeiojccjbpjlodkjhn"
+export const stableUnpackedExtensionOrigin = "chrome-extension://eibhgjafffkigblngnhafgbcipofaeon"
 
-export function chromeExtensionOriginForPath(extensionPath: string): string {
-  const digest = crypto.createHash("sha256").update(extensionPath).digest()
+export function chromeExtensionOriginForPath(extensionPath: string, platform: NodeJS.Platform = process.platform): string {
+  const pathBytes = platform === "win32" ? Buffer.from(extensionPath, "utf16le") : extensionPath
+  const digest = crypto.createHash("sha256").update(pathBytes).digest()
   let extensionId = ""
   for (const byte of digest.subarray(0, 16)) {
     extensionId += String.fromCharCode(97 + (byte >> 4), 97 + (byte & 0x0f))
@@ -102,6 +104,7 @@ export function validateWebSocketOrigin(options: {
   }
   if (
     options.origin === chromeWebStoreExtensionOrigin
+    || options.origin === stableUnpackedExtensionOrigin
     || options.additionalChromeExtensionOrigins?.has(options.origin)
   ) {
     return undefined

--- a/src/relay-helpers.ts
+++ b/src/relay-helpers.ts
@@ -14,7 +14,10 @@ export const chromeWebStoreExtensionOrigin = "chrome-extension://gmjpoplfomnnjip
 export const stableUnpackedExtensionOrigin = "chrome-extension://eibhgjafffkigblngnhafgbcipofaeon"
 
 export function chromeExtensionOriginForPath(extensionPath: string, platform: NodeJS.Platform = process.platform): string {
-  const pathBytes = platform === "win32" ? Buffer.from(extensionPath, "utf16le") : extensionPath
+  const normalizedPath = platform === "win32" && /^[a-z]:/.test(extensionPath)
+    ? extensionPath.charAt(0).toUpperCase() + extensionPath.slice(1)
+    : extensionPath
+  const pathBytes = platform === "win32" ? Buffer.from(normalizedPath, "utf16le") : normalizedPath
   const digest = crypto.createHash("sha256").update(pathBytes).digest()
   let extensionId = ""
   for (const byte of digest.subarray(0, 16)) {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -177,6 +177,9 @@ const makeRelay = Effect.fnUntraced(function* (options: {
     verificationRetries: number
   }
   const rootReconciliationWorkers = new Map<string, RootReconciliationWorker>()
+  type TabGroupingMethod = "tabs.group" | "tabs.ungroup"
+  const pendingTabGrouping = new Map<number, TabGroupingMethod>()
+  const tabGroupingWorkers = new Map<number, Promise<void>>()
   let relayClosing = false
   let extensionGeneration = 0
   const extensionRpc = new ExtensionRpc()
@@ -214,6 +217,7 @@ const makeRelay = Effect.fnUntraced(function* (options: {
   const activeHandoffTabs = new Map<string, Set<number>>()
   const clearLiveExtensionState = (reason: string) => {
     void recordingRelay.cleanupAll(reason).catch(() => {})
+    pendingTabGrouping.clear()
     for (const target of [...registry.listRootTargets()]) {
       detachTargetState(target.tabId, { preserveSessionTarget: true, updateExtension: false })
     }
@@ -473,11 +477,31 @@ const makeRelay = Effect.fnUntraced(function* (options: {
     const sessionId = pageStatusSessionId(target) ?? activeHandoffSessionIdForTab(tabId)
     sendPageStatus(target, sessionId && sessions.isExecuting(sessionId) ? "running" : "attached", sessionId ? { sessionId } : {})
   }
+  function scheduleTabGrouping(tabId: number, method: TabGroupingMethod): void {
+    pendingTabGrouping.set(tabId, method)
+    if (tabGroupingWorkers.has(tabId)) return
+    const worker = (async () => {
+      while (true) {
+        const next = pendingTabGrouping.get(tabId)
+        if (!next) return
+        pendingTabGrouping.delete(tabId)
+        await Effect.runPromise(Effect.ignore(sendToExtension({ method: next, params: { tabId } })))
+      }
+    })().finally(() => {
+      if (tabGroupingWorkers.get(tabId) !== worker) return
+      tabGroupingWorkers.delete(tabId)
+      const next = pendingTabGrouping.get(tabId)
+      if (next) scheduleTabGrouping(tabId, next)
+    })
+    tabGroupingWorkers.set(tabId, worker)
+  }
+  function refreshTabGrouping(tabId: number): void {
+    const target = registry.tabTargets.get(tabId)
+    scheduleTabGrouping(tabId, target && pageStatusSessionId(target) ? "tabs.group" : "tabs.ungroup")
+  }
   function refreshTabPresentation(tabId: number): void {
     refreshPageStatus(tabId)
-    const target = registry.tabTargets.get(tabId)
-    const method = target && pageStatusSessionId(target) ? "tabs.group" : "tabs.ungroup"
-    Effect.runPromise(Effect.ignore(sendToExtension({ method, params: { tabId } }))).catch(() => {})
+    refreshTabGrouping(tabId)
   }
   const relayRequestHandler = createHttpRequestHandler({
     host,
@@ -754,6 +778,13 @@ const makeRelay = Effect.fnUntraced(function* (options: {
     if (extensionMethod === "hello") {
       return
     }
+    if (extensionMethod === "log") {
+      const text = typeof message.params?.message === "string" ? message.params.message : undefined
+      if (!text) return
+      const level = message.params?.level === "error" || message.params?.level === "warn" ? message.params.level : "log"
+      console[level](`[browser-control extension] ${text}`)
+      return
+    }
     if (extensionMethod === "ready") {
       const workers = Array.from(rootReconciliationWorkers.values())
         .filter((worker) => worker.generation === generation)
@@ -765,6 +796,7 @@ const makeRelay = Effect.fnUntraced(function* (options: {
             if (!announcedRootTabIds.has(target.tabId)) detachTargetState(target.tabId)
           }
           extensionRpc.markReady()
+          for (const target of registry.listRootTargets()) refreshTabGrouping(target.tabId)
         } else {
           socket.close(1011, "Target inventory reconciliation failed")
         }
@@ -1395,10 +1427,9 @@ const makeRelay = Effect.fnUntraced(function* (options: {
     if (committedTarget.browserControlSessionId) {
       pruneInvisibleAnnouncementsForSession(committedTarget.browserControlSessionId)
     }
-    yield* Effect.ignore(sendToExtension({
-      method: committedTarget.browserControlSessionId ? "tabs.group" : "tabs.ungroup",
-      params: { tabId },
-    }))
+    if (extensionRpc.connected) {
+      refreshTabGrouping(tabId)
+    }
     yield* Effect.ignore(sendToExtension({ method: "action.setAttached", params: { tabId, attached: true } }))
     const pendingHandoff = handoffs.pendingForTab(tabId)
     if (pendingHandoff) {
@@ -1612,7 +1643,7 @@ const makeRelay = Effect.fnUntraced(function* (options: {
   } = {}): void {
     if (options.updateExtension !== false) {
       Effect.runPromise(Effect.ignore(sendToExtension({ method: "pageStatus.clear", params: { tabId } }))).catch(() => {})
-      Effect.runPromise(Effect.ignore(sendToExtension({ method: "tabs.ungroup", params: { tabId } }))).catch(() => {})
+      scheduleTabGrouping(tabId, "tabs.ungroup")
       Effect.runPromise(Effect.ignore(sendToExtension({ method: "action.setAttached", params: { tabId, attached: false } }))).catch(() => {})
       void recordingRelay.abortRecordingForTab({ tabId, reason: "Tab detached" }).catch((error: unknown) => {
         console.error("Failed to abort recording for detached tab", error)

--- a/test/extension-connection-lifecycle.test.ts
+++ b/test/extension-connection-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
+  completeExtensionHandshake,
   ensureReconnectAlarm,
   reconnectAlarmName,
   startSocketKeepAlive,
@@ -41,5 +42,33 @@ describe("extension connection lifecycle", () => {
     vi.advanceTimersByTime(20_000)
 
     expect(heartbeat).toHaveBeenCalledTimes(2)
+  })
+
+  it("announces attached tabs before ready without waiting for group reconciliation", async () => {
+    let finishInventory: (() => void) | undefined
+    const inventory = new Promise<void>((resolve) => {
+      finishInventory = resolve
+    })
+    const events: string[] = []
+    const reconciliation = new Promise<void>(() => {})
+
+    const handshake = completeExtensionHandshake({
+      announceAttachedTabs: async () => {
+        events.push("inventory-started")
+        await inventory
+        events.push("inventory-finished")
+      },
+      sendReady: () => events.push("ready"),
+      startGroupReconciliation: () => {
+        events.push("groups-started")
+        void reconciliation
+      },
+    })
+
+    await Promise.resolve()
+    expect(events).toEqual(["inventory-started"])
+    finishInventory?.()
+    await handshake
+    expect(events).toEqual(["inventory-started", "inventory-finished", "ready", "groups-started"])
   })
 })

--- a/test/extension-package.test.ts
+++ b/test/extension-package.test.ts
@@ -1,16 +1,18 @@
+import { createHash, createPublicKey } from "node:crypto"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { unzipSync } from "fflate"
 import { extensionVersion, isChromeExtensionVersion, makeExtensionArchive } from "../scripts/package-extension.ts"
+import { stableUnpackedExtensionOrigin } from "../src/relay-helpers.ts"
 
 describe("Chrome Web Store extension package", () => {
   it("is deterministic and rooted at the extension manifest", async () => {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "browser-control-extension-package-"))
     try {
       await fs.mkdir(path.join(directory, "icons"))
-      await fs.writeFile(path.join(directory, "manifest.json"), JSON.stringify({ manifest_version: 3, version: "1.2.3.4" }))
+      await fs.writeFile(path.join(directory, "manifest.json"), JSON.stringify({ manifest_version: 3, version: "1.2.3.4", key: "unpacked-key" }))
       await fs.writeFile(path.join(directory, "background.js"), "export {}\n")
       await fs.writeFile(path.join(directory, "icons", "icon-16.png"), new Uint8Array([1, 2, 3]))
 
@@ -24,10 +26,27 @@ describe("Chrome Web Store extension package", () => {
         "icons/icon-16.png",
         "manifest.json",
       ])
+      const archivedManifest = JSON.parse(new TextDecoder().decode(unzipSync(first)["manifest.json"]))
+      expect(archivedManifest).not.toHaveProperty("key")
       expect(await extensionVersion(directory)).toBe("1.2.3.4")
     } finally {
       await fs.rm(directory, { recursive: true, force: true })
     }
+  })
+
+  it("pins the unpacked extension id with a valid public key", async () => {
+    const manifestPath = path.join(import.meta.dirname, "..", "extension", "manifest.json")
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as { readonly key?: unknown }
+    expect(typeof manifest.key).toBe("string")
+    const publicKeyBytes = Buffer.from(manifest.key as string, "base64")
+    expect(createPublicKey({ key: publicKeyBytes, format: "der", type: "spki" }).asymmetricKeyType).toBe("rsa")
+
+    const digest = createHash("sha256").update(publicKeyBytes).digest()
+    let extensionId = ""
+    for (const byte of digest.subarray(0, 16)) {
+      extensionId += String.fromCharCode(97 + (byte >> 4), 97 + (byte & 0x0f))
+    }
+    expect(`chrome-extension://${extensionId}`).toBe(stableUnpackedExtensionOrigin)
   })
 
   it("validates Chrome extension version components", () => {

--- a/test/extension-tab-groups.test.ts
+++ b/test/extension-tab-groups.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest"
-import { isBrowserControlGroupTitle, isCurrentBrowserControlGroupTitle, isLegacyBrowserControlGroupTitle, shouldUngroupBrowserControlTab, tabGroupTitle, tabGroupVisibleTitle } from "../extension/src/tab-groups.ts"
+import { describe, expect, it, vi } from "vitest"
+import { finalizeBrowserControlGrouping, isBrowserControlGroupTitle, isCurrentBrowserControlGroupTitle, isLegacyBrowserControlGroupTitle, shouldUngroupBrowserControlTab, tabGroupTitle, tabGroupVisibleTitle } from "../extension/src/tab-groups.ts"
 
 describe("isBrowserControlGroupTitle", () => {
   it("matches the current and legacy Browser Control group titles", () => {
@@ -42,5 +42,32 @@ describe("shouldUngroupBrowserControlTab", () => {
     expect(shouldUngroupBrowserControlTab("reading-list")).toBe(false)
     expect(shouldUngroupBrowserControlTab("control")).toBe(false)
     expect(shouldUngroupBrowserControlTab(undefined)).toBe(false)
+  })
+})
+
+describe("finalizeBrowserControlGrouping", () => {
+  it("updates a group while the originating connection is current", async () => {
+    const update = vi.fn(async () => {})
+    const rollback = vi.fn(async () => {})
+
+    await finalizeBrowserControlGrouping({ assertCurrent: () => {}, update, rollback })
+
+    expect(update).toHaveBeenCalledOnce()
+    expect(rollback).not.toHaveBeenCalled()
+  })
+
+  it("rolls back a group created by a replaced connection", async () => {
+    const replacement = new Error("connection replaced")
+    const update = vi.fn(async () => {})
+    const rollback = vi.fn(async () => {})
+
+    await expect(finalizeBrowserControlGrouping({
+      assertCurrent: () => { throw replacement },
+      update,
+      rollback,
+    })).rejects.toBe(replacement)
+
+    expect(rollback).toHaveBeenCalledOnce()
+    expect(update).not.toHaveBeenCalled()
   })
 })

--- a/test/relay-extension-handshake.test.ts
+++ b/test/relay-extension-handshake.test.ts
@@ -1,8 +1,19 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
 import { Effect } from "effect"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { WebSocket } from "ws"
-import type { CdpEvent, CdpRequest, CdpResponse } from "../src/protocol.ts"
+import type { CdpEvent, CdpRequest, CdpResponse, ExtensionCommand } from "../src/protocol.ts"
 import { startRelay } from "../src/relay.ts"
+import { SessionCatalog } from "../src/session-catalog.ts"
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true })
+})
 
 describe("relay extension handshake", () => {
   it("rejects pre-hello events and keeps them from mutating target state", async () => {
@@ -59,6 +70,65 @@ describe("relay extension handshake", () => {
     })))
   })
 
+  it("does not wait for restored-tab grouping before becoming ready", async () => {
+    const port = 24_000 + Math.floor(Math.random() * 10_000)
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "browser-control-extension-handshake-"))
+    temporaryDirectories.push(directory)
+    const sessionCatalogPath = path.join(directory, "sessions.json")
+    await new SessionCatalog(sessionCatalogPath).save([{
+      id: "restored",
+      createdAt: "2026-08-21T00:00:00.000Z",
+      updatedAt: "2026-08-21T00:01:00.000Z",
+      readOnly: false,
+      target: { id: "restored-target", owner: "user" },
+    }])
+
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port, sessionCatalogPath })
+      const extension = yield* Effect.promise(() => connectRespondingExtension(relay.url, {
+        targetId: "restored-target",
+        suspendedMethod: "tabs.group",
+      }))
+      extension.send(JSON.stringify({ method: "hello", params: { version: "0.0.23", protocolVersion: 2 } }))
+      extension.send(JSON.stringify({ method: "debugger.attached", params: { tabId: 7 } }))
+      extension.send(JSON.stringify({ method: "ready" }))
+
+      const status = yield* Effect.promise(() => waitForStatus(relay.url, (candidate) => candidate.connected === true))
+      expect(status).toMatchObject({ connected: true, activeTargets: 1 })
+      yield* Effect.promise(() => waitFor(() => extension.commands.some((command) => command.method === "tabs.group")))
+      const group = extension.commands.find((command) => command.method === "tabs.group")
+      expect(group).toBeDefined()
+
+      extension.send(JSON.stringify({ method: "debugger.detached", params: { tabId: 7, reason: "canceled_by_user" } }))
+      yield* Effect.sleep("20 millis")
+      expect(extension.commands.some((command) => command.method === "tabs.ungroup")).toBe(false)
+
+      extension.respond(group!)
+      yield* Effect.promise(() => waitFor(() => extension.commands.some((command) => command.method === "tabs.ungroup")))
+      expect(extension.commands.filter((command) => command.method === "tabs.group" || command.method === "tabs.ungroup").map((command) => command.method)).toEqual([
+        "tabs.group",
+        "tabs.ungroup",
+      ])
+      extension.close()
+    })))
+  })
+
+  it("reports extension log events", async () => {
+    const port = 24_000 + Math.floor(Math.random() * 10_000)
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port, sessionCatalogPath: null })
+      const extension = yield* Effect.promise(() => connectExtension(relay.url))
+      extension.send(JSON.stringify({ method: "hello", params: { version: "0.0.23", protocolVersion: 2 } }))
+      extension.send(JSON.stringify({ method: "log", params: { level: "error", message: "tab groups unavailable" } }))
+
+      yield* Effect.promise(() => waitFor(() => error.mock.calls.some((call) => {
+        return call[0] === "[browser-control extension] tab groups unavailable"
+      })))
+      extension.close()
+    })))
+  })
+
   it("does not let an incompatible extension replace a compatible socket before ready", async () => {
     const port = 24_000 + Math.floor(Math.random() * 10_000)
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
@@ -82,7 +152,7 @@ describe("relay extension handshake", () => {
     const port = 24_000 + Math.floor(Math.random() * 10_000)
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
       const relay = yield* startRelay({ port, sessionCatalogPath: null })
-      const first = yield* Effect.promise(() => connectRespondingExtension(relay.url, "stale-target"))
+      const first = yield* Effect.promise(() => connectRespondingExtension(relay.url, { targetId: "stale-target" }))
       first.send(JSON.stringify({ method: "hello", params: { version: "0.0.23", protocolVersion: 2 } }))
       first.send(JSON.stringify({ method: "debugger.attached", params: { tabId: 7 } }))
       first.send(JSON.stringify({ method: "ready" }))
@@ -107,7 +177,7 @@ describe("relay extension handshake", () => {
     const port = 24_000 + Math.floor(Math.random() * 10_000)
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
       const relay = yield* startRelay({ port, sessionCatalogPath: null })
-      const extension = yield* Effect.promise(() => connectRespondingExtension(relay.url, undefined, "synthetic reconciliation failure"))
+      const extension = yield* Effect.promise(() => connectRespondingExtension(relay.url, { error: "synthetic reconciliation failure" }))
       const closed = waitForClose(extension)
       extension.send(JSON.stringify({ method: "hello", params: { version: "0.0.23", protocolVersion: 2 } }))
       extension.send(JSON.stringify({ method: "debugger.attached", params: { tabId: 7 } }))
@@ -123,20 +193,35 @@ describe("relay extension handshake", () => {
 type ExtensionStatus = { readonly connected: boolean; readonly activeTargets: number }
 type CdpMessage = CdpEvent | CdpResponse
 
-async function connectRespondingExtension(relayUrl: string, targetId?: string, error?: string): Promise<WebSocket> {
+async function connectRespondingExtension(
+  relayUrl: string,
+  options: {
+    readonly targetId?: string
+    readonly error?: string
+    readonly suspendedMethod?: ExtensionCommand["method"]
+  } = {},
+): Promise<WebSocket & {
+  readonly commands: ExtensionCommand[]
+  readonly respond: (command: ExtensionCommand) => void
+}> {
   const socket = await connectExtension(relayUrl)
-  socket.on("message", (data) => {
-    const command = JSON.parse(data.toString()) as { readonly id: number; readonly method: string; readonly params?: { readonly method?: string } }
-    if (error) {
-      socket.send(JSON.stringify({ id: command.id, error }))
+  const commands: ExtensionCommand[] = []
+  const respond = (command: ExtensionCommand) => {
+    if (options.error) {
+      socket.send(JSON.stringify({ id: command.id, error: options.error }))
       return
     }
-    const result = command.method === "debugger.sendCommand" && command.params?.method === "Target.getTargetInfo" && targetId
-      ? { targetInfo: { targetId, type: "page", title: "Test", url: "https://example.com/", attached: true, canAccessOpener: false } }
+    const result = command.method === "debugger.sendCommand" && command.params?.method === "Target.getTargetInfo" && options.targetId
+      ? { targetInfo: { targetId: options.targetId, type: "page", title: "Test", url: "https://example.com/", attached: true, canAccessOpener: false } }
       : {}
     socket.send(JSON.stringify({ id: command.id, result }))
+  }
+  socket.on("message", (data) => {
+    const command = JSON.parse(data.toString()) as ExtensionCommand
+    commands.push(command)
+    if (command.method !== options.suspendedMethod) respond(command)
   })
-  return socket
+  return Object.assign(socket, { commands, respond })
 }
 
 function connectExtension(relayUrl: string): Promise<WebSocket> {

--- a/test/relay-helpers.test.ts
+++ b/test/relay-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   chromeExtensionOriginForPath,
   chromeWebStoreExtensionOrigin,
+  stableUnpackedExtensionOrigin,
   generateSessionId,
   getTargetInfo,
   isRestrictedTarget,
@@ -53,6 +54,7 @@ describe("validateBrowserFetchSite", () => {
 describe("validateWebSocketOrigin", () => {
   it("accepts the Store extension and missing origins for non-extension clients", () => {
     expect(validateWebSocketOrigin({ origin: chromeWebStoreExtensionOrigin })).toBeUndefined()
+    expect(validateWebSocketOrigin({ origin: stableUnpackedExtensionOrigin })).toBeUndefined()
     expect(validateWebSocketOrigin({ origin: undefined })).toBeUndefined()
   })
 
@@ -74,6 +76,13 @@ describe("validateWebSocketOrigin", () => {
       requireChromeExtension: true,
       additionalChromeExtensionOrigins: new Set([unpackedOrigin]),
     })).toBeDefined()
+  })
+
+  it("matches Chromium's UTF-16LE path hashing on Windows", () => {
+    const extensionPath = "C:\\Users\\USER\\AppData\\Roaming\\npm\\node_modules\\@opencode-ai\\browser-control\\extension\\dist"
+    expect(chromeExtensionOriginForPath(extensionPath, "win32")).toBe(
+      "chrome-extension://lojdoljaoemkbeamblbblebkgffocjke",
+    )
   })
 
   it("rejects web origins for the extension endpoint", () => {

--- a/test/relay-helpers.test.ts
+++ b/test/relay-helpers.test.ts
@@ -83,6 +83,9 @@ describe("validateWebSocketOrigin", () => {
     expect(chromeExtensionOriginForPath(extensionPath, "win32")).toBe(
       "chrome-extension://lojdoljaoemkbeamblbblebkgffocjke",
     )
+    expect(chromeExtensionOriginForPath(`c${extensionPath.slice(1)}`, "win32")).toBe(
+      "chrome-extension://lojdoljaoemkbeamblbblebkgffocjke",
+    )
   })
 
   it("rejects web origins for the extension endpoint", () => {


### PR DESCRIPTION
## What

Make extension connectivity stable across Arc startup stalls, package moves, and Windows path hashing differences.

- Extension shim `0.0.24` sends `ready` after debugger inventory, without waiting for tab-group APIs.
- Unpacked builds use stable extension ID `eibhgjafffkigblngnhafgbcipofaeon` regardless of install path.
- Existing path-derived Windows installs retain a platform-correct migration fallback.
- Chrome Web Store packaging strips the unpacked public key so Store ID `gmjpoplfomnnjipeiojccjbpjlodkjhn` remains unchanged.

This incorporates the Arc root cause and startup-ordering work from #42. Thanks @stephancill for the reproduction and live Arc verification there.

Closes #40
Closes #41
Closes #43

## Before / After

**Before:** Arc could leave `chrome.tabGroups.query()` pending during startup. The extension withheld `ready`; restored session-owned tabs also made relay inventory await `tabs.group`, so `status` remained `connected: false` or timed out. Separately, moving a globally installed package changed its path-derived unpacked ID, and Windows hashed the path with different bytes than the relay.

**After:** only attached-tab inventory gates `ready`. Group cleanup and presentation run afterward, serialize per tab, recheck attachment state before cleanup, and roll back stale socket mutations before a newer ownership intent runs. A manifest public key fixes the unpacked ID across paths, while UTF-16LE plus Chromium drive-letter normalization preserves compatibility for existing Windows path-derived installs.

## How

- `extension/src/background.ts` and `extension/src/connection-lifecycle.ts` separate handshake completion from best-effort group reconciliation, deduplicate pending cleanup, gate stale generations, and serialize grouping commands per tab.
- `src/relay.ts` keeps cosmetic grouping off inventory readiness, serializes presentation intents, and surfaces extension log events.
- `extension/manifest.json` pins the unpacked public key and bumps the shim to `0.0.24`.
- `src/relay-helpers.ts` accepts the stable unpacked origin and mirrors Chromium path hashing for migration fallback, including UTF-16LE and uppercase drive letters on Windows.
- `scripts/package-extension.ts` validates the unpacked key but removes it from the deterministic Store ZIP.
- Relay, extension lifecycle, group rollback, Windows hashing, stable-ID, and packaging regressions cover each boundary.

## Scope

- Keeps `BROWSER_CONTROL_EXTENSION_ORIGINS` for explicitly allowed same-host unpacked extensions.
- Keeps path-derived bundled origins only as migration compatibility; new unpacked installs use the manifest key.
- Does not change extension protocol version `2` or the Chrome Web Store assigned ID.
- Supersedes the implementation in #42 after addressing its requested relay-level readiness, stale-work, ordering, diagnostics, and versioning cases.

## Testing

- `pnpm run ci`
- TypeScript typecheck passed.
- 47 test files passed, 436 tests total.
- CLI and extension builds passed.
- Deterministic Store package passed validation: `browser-control-extension-0.0.24.zip`, SHA-256 `d34fb4a93a65ed37ab70d02508545d98d79ac54a07a939721d0cf99180e1ec8b`.
- Final focused review reported no remaining findings.

No live Arc extension reload was performed in this worktree; the Arc readiness and delayed grouping paths are covered by extension lifecycle and relay-level suspended-command regressions.

## Flow

```mermaid
sequenceDiagram
  participant E as Extension
  participant R as Relay
  participant C as Chromium tab-group API

  E->>R: hello
  loop attached debugger targets
    E->>R: debugger.attached
  end
  E->>R: ready
  R-->>E: restored-tab presentation
  Note over E,R: Relay readiness no longer waits for grouping
  E->>C: group / cleanup query
  alt connection still current
    E->>C: apply serialized latest intent
  else connection replaced
    E->>C: roll back stale mutation
  end
```