### PR TITLE
fix(execute): omit ARIA form values

### DIFF
--- a/.changeset/safe-aria-snapshots.md
+++ b/.changeset/safe-aria-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Omit text-control values from detailed ARIA snapshots so sensitive form contents do not enter agent output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,9 +125,12 @@ local Node relay.
   semantic groups, lists, tables, block code, alerts, and primary links before
   repeated metadata; text input and textarea values are omitted. Snapshot diffs
   are explicit, require a compatible prior baseline, invalidate earlier refs,
-  and expose refs only for added or changed current lines. Keep `ariaSnapshot()`
-  and raw Playwright as deeper inspection layers; do not replace the code-first
-  execute interface with many action commands.
+  and expose refs only for added or changed current lines. `ariaSnapshot()` also
+  omits text-control values while preserving the surrounding accessibility
+  tree. It temporarily masks those values in Playwright's isolated world, so do
+  not run it concurrently with other operations on the same page. Keep raw
+  Playwright as a deeper inspection layer; do not replace the code-first execute
+  interface with many action commands.
 - Authenticated network capture is owned by the persistent Execute Sandbox and
   records normalized exchanges; HAR is only an export adapter. Written
   artifacts always use route-scoped stable `BC_SECRET_N` references. Lossless

--- a/PLAN.md
+++ b/PLAN.md
@@ -312,7 +312,10 @@ reconciles existing client announcements, browser grouping, and page status.
 - `ref(id)` resolves controls from the latest valid snapshot and fails closed
   after navigation or incompatible DOM drift.
 - `ariaSnapshot()` and raw Playwright provide deeper inspection when compact
-  snapshots are insufficient.
+  snapshots are insufficient. The helper omits text-control values so password,
+  token, search, numeric, range, and textarea contents do not enter tool output.
+  It must be awaited separately from other operations on the same page while its
+  isolated-world value mask is active.
 - `screenshotWithLabels({ page, path? })` annotates likely interactive elements
   and returns label metadata.
 - `fillInput` and `fillInputs` provide a DOM-evaluation fallback when browser

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ of silently targeting a different control.
 
 Other inspection helpers include:
 
-- `ariaSnapshot()` for a deeper accessibility-tree view
+- `ariaSnapshot()` for a deeper accessibility-tree view with text-control values
+  omitted; await it separately from other operations on the same page
 - `screenshotWithLabels()` for an annotated screenshot and element metadata
 - `fillInput()` and `fillInputs()` when browser extensions interfere with
   Playwright's normal `locator.fill()`

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -10,6 +10,7 @@ import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import util from "node:util"
+import { createAriaSnapshotHelper } from "../src/execute.ts"
 import { getObject } from "../src/relay-helpers.ts"
 import { browserControlBuildId } from "../src/version.ts"
 
@@ -255,6 +256,18 @@ const cases: SmokeCase[] = [
       )
       yield* click(page.locator("#buttonGenerate"), "shadow generate")
       results.push({ challenge: "shadow-dom", generated: yield* inputValue(page.locator("#editField"), "shadow generated value") })
+
+      yield* playwright("set ARIA redaction fixture", () =>
+        page.setContent(`<main><h2>Amount <input type="number" value="aria-number-value"></h2><input role="heading" value="aria-role-value"><textarea role="combobox">aria-textarea-value</textarea><div contenteditable>aria-editor-value</div><input type="button" value="Keep label"></main>`),
+      )
+      const safeAria = yield* playwright("capture redacted ARIA snapshot", () => createAriaSnapshotHelper(page)("main"))
+      if (safeAria.includes("aria-")) throw new Error("ARIA snapshot exposed a fixture form value")
+      if (!safeAria.includes('button "Keep label"')) throw new Error("ARIA snapshot removed a native button label")
+      const restoredAria = yield* playwright("verify ARIA snapshot cleanup", () => page.locator("main").ariaSnapshot())
+      if (!restoredAria.includes("aria-role-value") || !restoredAria.includes("aria-textarea-value")) {
+        throw new Error("ARIA snapshot value access was not restored")
+      }
+      results.push({ challenge: "aria-redaction", snapshot: safeAria })
       return results
     }),
   },

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -179,7 +179,10 @@ Use the least expensive view that answers the question:
   baseline. A diff invalidates earlier refs and exposes refs only for added or
   changed current lines.
 - `ariaSnapshot(target?, { timeout })` returns Playwright's detailed YAML aria
-  tree when the compact snapshot omits needed structure.
+  tree when the compact snapshot omits needed structure. Text-control values are
+  omitted so password, token, search, numeric, range, and textarea contents do
+  not enter tool output. Await it separately; do not run other operations on the
+  same page concurrently.
 - `screenshotWithLabels({ page, path? })` adds visual labels and metadata when
   layout matters.
 

--- a/src/aria-snapshot.ts
+++ b/src/aria-snapshot.ts
@@ -1,0 +1,123 @@
+import { selectors, type Locator } from "playwright-core"
+
+const redactionSelectorName = "bcariaredact"
+const redactionSelectorSource = `({
+  query(root, body) {
+    const separator = body.indexOf("_")
+    const action = body.slice(0, separator)
+    const token = body.slice(separator + 1)
+    const stateKey = "__browserControlAriaRedactionState__"
+    let state = globalThis[stateKey]
+
+    if (action === "on") {
+      if (!state) {
+        state = {
+          tokens: new Set(),
+          nonTextInputTypes: new Set(["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"]),
+          inputValue: Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value"),
+          textareaValue: Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value"),
+          nodeValue: Object.getOwnPropertyDescriptor(Node.prototype, "nodeValue"),
+          textContent: Object.getOwnPropertyDescriptor(Node.prototype, "textContent"),
+          innerText: Object.getOwnPropertyDescriptor(HTMLElement.prototype, "innerText"),
+          getAttribute: Object.getOwnPropertyDescriptor(Element.prototype, "getAttribute"),
+        }
+        globalThis[stateKey] = state
+        Object.defineProperty(HTMLInputElement.prototype, "value", {
+          ...state.inputValue,
+          get() {
+            return state.nonTextInputTypes.has(this.type)
+              ? state.inputValue.get.call(this)
+              : ""
+          },
+        })
+        Object.defineProperty(HTMLTextAreaElement.prototype, "value", { ...state.textareaValue, get() { return "" } })
+        Object.defineProperty(Node.prototype, "nodeValue", {
+          ...state.nodeValue,
+          get() {
+            const parent = this.parentElement
+            return parent && (parent instanceof HTMLTextAreaElement || parent.isContentEditable)
+              ? ""
+              : state.nodeValue.get.call(this)
+          },
+        })
+        Object.defineProperty(Node.prototype, "textContent", {
+          ...state.textContent,
+          get() {
+            const parent = this.parentElement
+            return this instanceof HTMLTextAreaElement
+              || (this instanceof HTMLElement && this.isContentEditable)
+              || (this.nodeType === Node.TEXT_NODE && parent?.isContentEditable)
+              ? ""
+              : state.textContent.get.call(this)
+          },
+        })
+        Object.defineProperty(HTMLElement.prototype, "innerText", {
+          ...state.innerText,
+          get() {
+            return this instanceof HTMLTextAreaElement || this.isContentEditable
+              ? ""
+              : state.innerText.get.call(this)
+          },
+        })
+        Object.defineProperty(Element.prototype, "getAttribute", {
+          ...state.getAttribute,
+          value(name) {
+            const attribute = String(name).toLowerCase()
+            const sensitiveInput = this instanceof HTMLInputElement
+              && !state.nonTextInputTypes.has(this.type)
+            const sensitiveControl = sensitiveInput
+              || this instanceof HTMLTextAreaElement
+              || (this instanceof HTMLElement && this.isContentEditable)
+            return sensitiveControl && ["aria-valuenow", "aria-valuetext", "value"].includes(attribute)
+              ? null
+              : state.getAttribute.value.call(this, name)
+          },
+        })
+      }
+      state.tokens.add(token)
+    } else if (action === "off" && state) {
+      state.tokens.delete(token)
+      if (state.tokens.size === 0) {
+        Object.defineProperty(HTMLInputElement.prototype, "value", state.inputValue)
+        Object.defineProperty(HTMLTextAreaElement.prototype, "value", state.textareaValue)
+        Object.defineProperty(Node.prototype, "nodeValue", state.nodeValue)
+        Object.defineProperty(Node.prototype, "textContent", state.textContent)
+        Object.defineProperty(HTMLElement.prototype, "innerText", state.innerText)
+        Object.defineProperty(Element.prototype, "getAttribute", state.getAttribute)
+        delete globalThis[stateKey]
+      }
+    }
+
+    return root instanceof Element ? root : document.documentElement
+  },
+  queryAll(root, body) {
+    return [this.query(root, body)]
+  },
+})`
+
+await selectors.register(
+  redactionSelectorName,
+  { content: redactionSelectorSource },
+  { contentScript: true },
+)
+
+let nextRedactionToken = 0
+
+export async function ariaSnapshotWithoutTextControlValues(
+  locator: Locator,
+  options: { readonly timeout: number },
+): Promise<string> {
+  const token = String(++nextRedactionToken)
+  try {
+    return await locator
+      .locator(`${redactionSelectorName}=on_${token}`)
+      .ariaSnapshot(options)
+  } finally {
+    const cleanup = await Promise.allSettled(locator.page().frames().map(async (frame) => {
+      await frame.locator(`${redactionSelectorName}=off_${token}`).waitFor({ state: "attached", timeout: 1_000 })
+    }))
+    if (cleanup.some((result) => result.status === "rejected")) {
+      throw new Error("Browser Control could not confirm ARIA snapshot value-redaction cleanup")
+    }
+  }
+}

--- a/src/aria-snapshot.ts
+++ b/src/aria-snapshot.ts
@@ -1,6 +1,8 @@
-import { selectors, type Locator } from "playwright-core"
+import { selectors, type Locator, type Page } from "playwright-core"
 
 const redactionSelectorName = "bcariaredact"
+const redactionCleanupErrorMessage = "Browser Control could not confirm ARIA snapshot value-redaction cleanup"
+// Keep the engine as source text so bundlers cannot inject Node-only helpers into the browser function.
 const redactionSelectorSource = `({
   query(root, body) {
     const separator = body.indexOf("_")
@@ -14,6 +16,7 @@ const redactionSelectorSource = `({
         state = {
           tokens: new Set(),
           nonTextInputTypes: new Set(["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"]),
+          valueAttributes: new Set(["aria-valuenow", "aria-valuetext", "value"]),
           inputValue: Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value"),
           textareaValue: Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value"),
           nodeValue: Object.getOwnPropertyDescriptor(Node.prototype, "nodeValue"),
@@ -22,12 +25,13 @@ const redactionSelectorSource = `({
           getAttribute: Object.getOwnPropertyDescriptor(Element.prototype, "getAttribute"),
         }
         globalThis[stateKey] = state
+        const isRedactedControl = (element) => element instanceof HTMLTextAreaElement
+          || (element instanceof HTMLInputElement && !state.nonTextInputTypes.has(element.type))
+          || (element instanceof HTMLElement && element.isContentEditable)
         Object.defineProperty(HTMLInputElement.prototype, "value", {
           ...state.inputValue,
           get() {
-            return state.nonTextInputTypes.has(this.type)
-              ? state.inputValue.get.call(this)
-              : ""
+            return isRedactedControl(this) ? "" : state.inputValue.get.call(this)
           },
         })
         Object.defineProperty(HTMLTextAreaElement.prototype, "value", { ...state.textareaValue, get() { return "" } })
@@ -35,7 +39,7 @@ const redactionSelectorSource = `({
           ...state.nodeValue,
           get() {
             const parent = this.parentElement
-            return parent && (parent instanceof HTMLTextAreaElement || parent.isContentEditable)
+            return parent && isRedactedControl(parent)
               ? ""
               : state.nodeValue.get.call(this)
           },
@@ -44,9 +48,7 @@ const redactionSelectorSource = `({
           ...state.textContent,
           get() {
             const parent = this.parentElement
-            return this instanceof HTMLTextAreaElement
-              || (this instanceof HTMLElement && this.isContentEditable)
-              || (this.nodeType === Node.TEXT_NODE && parent?.isContentEditable)
+            return isRedactedControl(this) || (this.nodeType === Node.TEXT_NODE && parent && isRedactedControl(parent))
               ? ""
               : state.textContent.get.call(this)
           },
@@ -54,23 +56,16 @@ const redactionSelectorSource = `({
         Object.defineProperty(HTMLElement.prototype, "innerText", {
           ...state.innerText,
           get() {
-            return this instanceof HTMLTextAreaElement || this.isContentEditable
-              ? ""
-              : state.innerText.get.call(this)
+            return isRedactedControl(this) ? "" : state.innerText.get.call(this)
           },
         })
         Object.defineProperty(Element.prototype, "getAttribute", {
           ...state.getAttribute,
           value(name) {
-            const attribute = String(name).toLowerCase()
-            const sensitiveInput = this instanceof HTMLInputElement
-              && !state.nonTextInputTypes.has(this.type)
-            const sensitiveControl = sensitiveInput
-              || this instanceof HTMLTextAreaElement
-              || (this instanceof HTMLElement && this.isContentEditable)
-            return sensitiveControl && ["aria-valuenow", "aria-valuetext", "value"].includes(attribute)
-              ? null
-              : state.getAttribute.value.call(this, name)
+            const rawAttribute = String(name)
+            const attribute = state.valueAttributes.has(rawAttribute) ? rawAttribute : rawAttribute.toLowerCase()
+            if (!state.valueAttributes.has(attribute)) return state.getAttribute.value.call(this, name)
+            return isRedactedControl(this) ? null : state.getAttribute.value.call(this, name)
           },
         })
       }
@@ -102,22 +97,59 @@ await selectors.register(
 )
 
 let nextRedactionToken = 0
+const pageCleanup = new WeakMap<Page, {
+  readonly pendingTokens: Set<string>
+  queue: Promise<void>
+}>()
 
 export async function ariaSnapshotWithoutTextControlValues(
   locator: Locator,
   options: { readonly timeout: number },
 ): Promise<string> {
   const token = String(++nextRedactionToken)
+  let snapshot: string | undefined
+  let captureFailed = false
+  let captureError: unknown
   try {
-    return await locator
+    snapshot = await locator
       .locator(`${redactionSelectorName}=on_${token}`)
       .ariaSnapshot(options)
-  } finally {
-    const cleanup = await Promise.allSettled(locator.page().frames().map(async (frame) => {
-      await frame.locator(`${redactionSelectorName}=off_${token}`).waitFor({ state: "attached", timeout: 1_000 })
-    }))
-    if (cleanup.some((result) => result.status === "rejected")) {
-      throw new Error("Browser Control could not confirm ARIA snapshot value-redaction cleanup")
-    }
+  } catch (error) {
+    captureFailed = true
+    captureError = error
   }
+
+  try {
+    await cleanupRedaction(locator.page(), token)
+  } catch (cleanupError) {
+    if (captureFailed) {
+      const cleanupReasons = cleanupError instanceof AggregateError ? cleanupError.errors : [cleanupError]
+      throw new AggregateError([captureError, ...cleanupReasons], redactionCleanupErrorMessage)
+    }
+    throw cleanupError
+  }
+
+  if (captureFailed) throw captureError
+  return snapshot!
+}
+
+async function cleanupRedaction(page: Page, token: string): Promise<void> {
+  let state = pageCleanup.get(page)
+  if (!state) {
+    state = { pendingTokens: new Set(), queue: Promise.resolve() }
+    pageCleanup.set(page, state)
+  }
+  state.pendingTokens.add(token)
+
+  const cleanup = state.queue.then(async () => {
+    const tokens = [...state.pendingTokens]
+    const results = await Promise.allSettled(page.frames().flatMap((frame) => tokens.map(async (pendingToken) => {
+      await frame.locator(`${redactionSelectorName}=off_${pendingToken}`).waitFor({ state: "attached", timeout: 1_000 })
+    })))
+    const failures = results.flatMap((result) => result.status === "rejected" ? [result.reason] : [])
+    if (failures.length > 0) throw new AggregateError(failures, redactionCleanupErrorMessage)
+    for (const pendingToken of tokens) state.pendingTokens.delete(pendingToken)
+  })
+  state.queue = cleanup.catch(() => {})
+  await cleanup
 }

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -21,6 +21,7 @@ import * as NetworkCapture from "./network-capture.ts"
 import type { AuthenticatedJsonOutcome, AuthenticatedJsonRequest, ExecuteAftermath, ExecuteLogEntry, ExecuteLogSummary, ExecuteMedia } from "./relay-schema.ts"
 import type { SessionTarget } from "./relay-types.ts"
 import { executionContextFailureDiagnostic, runtimeFailureKind } from "./runtime-diagnostics.ts"
+import { ariaSnapshotWithoutTextControlValues } from "./aria-snapshot.ts"
 
 const nodeModules = { fs, path, os, crypto, url, util, events, stream, buffer, http, https, zlib }
 const nodeModuleAliases = Object.keys(nodeModules).join(", ")
@@ -1223,7 +1224,9 @@ function ghostCursorOptions(options: ShowGhostCursorOptions | undefined): GhostC
 export function createAriaSnapshotHelper(page: Pick<Page, "locator">): AriaSnapshotHelper {
   return async (target, options) => {
     const locator = target === undefined ? page.locator("body") : typeof target === "string" ? page.locator(target) : target
-    return await locator.ariaSnapshot({ timeout: options?.timeout ?? defaultAriaSnapshotTimeoutMs })
+    return await ariaSnapshotWithoutTextControlValues(locator, {
+      timeout: options?.timeout ?? defaultAriaSnapshotTimeoutMs,
+    })
   }
 }
 

--- a/test/execute-ergonomics.test.ts
+++ b/test/execute-ergonomics.test.ts
@@ -260,30 +260,80 @@ describe("fillInputs", () => {
 
 describe("ariaSnapshot helper", () => {
   it("uses a bounded default timeout for the default body target", async () => {
-    const ariaSnapshot = vi.fn().mockResolvedValue("snapshot")
-    const locator = { ariaSnapshot } as unknown as Locator
+    const ariaSnapshot = vi.fn().mockResolvedValue('- textbox "Password"')
+    const waitFor = vi.fn().mockResolvedValue(undefined)
+    const frame = { locator: vi.fn(() => ({ waitFor })) }
+    const safeLocator = { ariaSnapshot }
+    const locator = {
+      locator: vi.fn(() => safeLocator),
+      page: vi.fn(() => ({ frames: () => [frame] })),
+    } as unknown as Locator
     const page = { locator: vi.fn(() => locator) } as unknown as Pick<Page, "locator">
 
-    await expect(createAriaSnapshotHelper(page)()).resolves.toBe("snapshot")
+    await expect(createAriaSnapshotHelper(page)()).resolves.toBe('- textbox "Password"')
     expect(page.locator).toHaveBeenCalledWith("body")
     expect(ariaSnapshot).toHaveBeenCalledWith({ timeout: defaultAriaSnapshotTimeoutMs })
+    const activation = vi.mocked(locator.locator).mock.calls[0]?.[0]
+    expect(activation).toMatch(/^bcariaredact=on_\d+$/)
+    if (typeof activation !== "string") throw new Error("Expected redaction selector activation")
+    expect(frame.locator).toHaveBeenCalledWith(activation.replace("=on_", "=off_"))
+    expect(waitFor).toHaveBeenCalledWith({ state: "attached", timeout: 1_000 })
   })
 
   it("preserves selector and locator targets and accepts a short timeout", async () => {
-    const selectorSnapshot = vi.fn().mockResolvedValue("selector")
-    const selectorLocator = { ariaSnapshot: selectorSnapshot } as unknown as Locator
+    const selectorSnapshot = vi.fn().mockResolvedValue('- main "Selector"')
+    const selectorFrame = { locator: vi.fn(() => ({ waitFor: vi.fn().mockResolvedValue(undefined) })) }
+    const selectorLocator = {
+      locator: vi.fn(() => ({ ariaSnapshot: selectorSnapshot })),
+      page: vi.fn(() => ({ frames: () => [selectorFrame] })),
+    } as unknown as Locator
     const page = { locator: vi.fn(() => selectorLocator) } as unknown as Pick<Page, "locator">
     const helper = createAriaSnapshotHelper(page)
 
-    await expect(helper("main", { timeout: 250 })).resolves.toBe("selector")
+    await expect(helper("main", { timeout: 250 })).resolves.toBe('- main "Selector"')
     expect(page.locator).toHaveBeenCalledWith("main")
     expect(selectorSnapshot).toHaveBeenCalledWith({ timeout: 250 })
 
-    const locatorSnapshot = vi.fn().mockResolvedValue("locator")
-    const locator = { ariaSnapshot: locatorSnapshot } as unknown as Locator
-    await expect(helper(locator, { timeout: 400 })).resolves.toBe("locator")
+    const locatorSnapshot = vi.fn().mockResolvedValue('- button "Locator"')
+    const locatorFrame = { locator: vi.fn(() => ({ waitFor: vi.fn().mockResolvedValue(undefined) })) }
+    const locator = {
+      locator: vi.fn(() => ({ ariaSnapshot: locatorSnapshot })),
+      page: vi.fn(() => ({ frames: () => [locatorFrame] })),
+    } as unknown as Locator
+    await expect(helper(locator, { timeout: 400 })).resolves.toBe('- button "Locator"')
     expect(locatorSnapshot).toHaveBeenCalledWith({ timeout: 400 })
     expect(page.locator).toHaveBeenCalledTimes(1)
+  })
+
+  it("restores isolated-world value access when snapshot capture fails", async () => {
+    const captureError = new Error("target detached")
+    const ariaSnapshot = vi.fn().mockRejectedValue(captureError)
+    const waitFor = vi.fn().mockResolvedValue(undefined)
+    const frame = { locator: vi.fn(() => ({ waitFor })) }
+    const locator = {
+      locator: vi.fn(() => ({ ariaSnapshot })),
+      page: vi.fn(() => ({ frames: () => [frame] })),
+    } as unknown as Locator
+    const page = { locator: vi.fn(() => locator) } as unknown as Pick<Page, "locator">
+
+    await expect(createAriaSnapshotHelper(page)()).rejects.toThrow(captureError)
+    expect(waitFor).toHaveBeenCalledOnce()
+  })
+
+  it("does not return a snapshot when isolated-world cleanup cannot be confirmed", async () => {
+    const ariaSnapshot = vi.fn().mockResolvedValue('- textbox "Password"')
+    const frame = {
+      locator: vi.fn(() => ({ waitFor: vi.fn().mockRejectedValue(new Error("frame wedged")) })),
+    }
+    const locator = {
+      locator: vi.fn(() => ({ ariaSnapshot })),
+      page: vi.fn(() => ({ frames: () => [frame] })),
+    } as unknown as Locator
+    const page = { locator: vi.fn(() => locator) } as unknown as Pick<Page, "locator">
+
+    await expect(createAriaSnapshotHelper(page)()).rejects.toThrow(
+      "Browser Control could not confirm ARIA snapshot value-redaction cleanup",
+    )
   })
 })
 

--- a/test/execute-ergonomics.test.ts
+++ b/test/execute-ergonomics.test.ts
@@ -258,82 +258,95 @@ describe("fillInputs", () => {
   })
 })
 
+function ariaSnapshotFixture(options: {
+  readonly snapshot?: string
+  readonly captureError?: Error
+  readonly cleanupError?: Error
+} = {}) {
+  const ariaSnapshot = options.captureError
+    ? vi.fn().mockRejectedValue(options.captureError)
+    : vi.fn().mockResolvedValue(options.snapshot ?? "- main")
+  const waitFor = options.cleanupError
+    ? vi.fn().mockRejectedValue(options.cleanupError)
+    : vi.fn().mockResolvedValue(undefined)
+  const frame = { locator: vi.fn(() => ({ waitFor })) }
+  const ownerPage = { frames: () => [frame] }
+  const locator = {
+    locator: vi.fn(() => ({ ariaSnapshot })),
+    page: vi.fn(() => ownerPage),
+  } as unknown as Locator
+  const page = { locator: vi.fn(() => locator) } as unknown as Pick<Page, "locator">
+  return { ariaSnapshot, frame, locator, page, waitFor }
+}
+
 describe("ariaSnapshot helper", () => {
   it("uses a bounded default timeout for the default body target", async () => {
-    const ariaSnapshot = vi.fn().mockResolvedValue('- textbox "Password"')
-    const waitFor = vi.fn().mockResolvedValue(undefined)
-    const frame = { locator: vi.fn(() => ({ waitFor })) }
-    const safeLocator = { ariaSnapshot }
-    const locator = {
-      locator: vi.fn(() => safeLocator),
-      page: vi.fn(() => ({ frames: () => [frame] })),
-    } as unknown as Locator
-    const page = { locator: vi.fn(() => locator) } as unknown as Pick<Page, "locator">
+    const fixture = ariaSnapshotFixture({ snapshot: '- textbox "Password"' })
 
-    await expect(createAriaSnapshotHelper(page)()).resolves.toBe('- textbox "Password"')
-    expect(page.locator).toHaveBeenCalledWith("body")
-    expect(ariaSnapshot).toHaveBeenCalledWith({ timeout: defaultAriaSnapshotTimeoutMs })
-    const activation = vi.mocked(locator.locator).mock.calls[0]?.[0]
+    await expect(createAriaSnapshotHelper(fixture.page)()).resolves.toBe('- textbox "Password"')
+    expect(fixture.page.locator).toHaveBeenCalledWith("body")
+    expect(fixture.ariaSnapshot).toHaveBeenCalledWith({ timeout: defaultAriaSnapshotTimeoutMs })
+    const activation = vi.mocked(fixture.locator.locator).mock.calls[0]?.[0]
     expect(activation).toMatch(/^bcariaredact=on_\d+$/)
     if (typeof activation !== "string") throw new Error("Expected redaction selector activation")
-    expect(frame.locator).toHaveBeenCalledWith(activation.replace("=on_", "=off_"))
-    expect(waitFor).toHaveBeenCalledWith({ state: "attached", timeout: 1_000 })
+    expect(fixture.frame.locator).toHaveBeenCalledWith(activation.replace("=on_", "=off_"))
+    expect(fixture.waitFor).toHaveBeenCalledWith({ state: "attached", timeout: 1_000 })
   })
 
   it("preserves selector and locator targets and accepts a short timeout", async () => {
-    const selectorSnapshot = vi.fn().mockResolvedValue('- main "Selector"')
-    const selectorFrame = { locator: vi.fn(() => ({ waitFor: vi.fn().mockResolvedValue(undefined) })) }
-    const selectorLocator = {
-      locator: vi.fn(() => ({ ariaSnapshot: selectorSnapshot })),
-      page: vi.fn(() => ({ frames: () => [selectorFrame] })),
-    } as unknown as Locator
-    const page = { locator: vi.fn(() => selectorLocator) } as unknown as Pick<Page, "locator">
-    const helper = createAriaSnapshotHelper(page)
+    const selector = ariaSnapshotFixture({ snapshot: '- main "Selector"' })
+    const helper = createAriaSnapshotHelper(selector.page)
 
     await expect(helper("main", { timeout: 250 })).resolves.toBe('- main "Selector"')
-    expect(page.locator).toHaveBeenCalledWith("main")
-    expect(selectorSnapshot).toHaveBeenCalledWith({ timeout: 250 })
+    expect(selector.page.locator).toHaveBeenCalledWith("main")
+    expect(selector.ariaSnapshot).toHaveBeenCalledWith({ timeout: 250 })
 
-    const locatorSnapshot = vi.fn().mockResolvedValue('- button "Locator"')
-    const locatorFrame = { locator: vi.fn(() => ({ waitFor: vi.fn().mockResolvedValue(undefined) })) }
-    const locator = {
-      locator: vi.fn(() => ({ ariaSnapshot: locatorSnapshot })),
-      page: vi.fn(() => ({ frames: () => [locatorFrame] })),
-    } as unknown as Locator
-    await expect(helper(locator, { timeout: 400 })).resolves.toBe('- button "Locator"')
-    expect(locatorSnapshot).toHaveBeenCalledWith({ timeout: 400 })
-    expect(page.locator).toHaveBeenCalledTimes(1)
+    const direct = ariaSnapshotFixture({ snapshot: '- button "Locator"' })
+    await expect(helper(direct.locator, { timeout: 400 })).resolves.toBe('- button "Locator"')
+    expect(direct.ariaSnapshot).toHaveBeenCalledWith({ timeout: 400 })
+    expect(selector.page.locator).toHaveBeenCalledTimes(1)
   })
 
   it("restores isolated-world value access when snapshot capture fails", async () => {
     const captureError = new Error("target detached")
-    const ariaSnapshot = vi.fn().mockRejectedValue(captureError)
-    const waitFor = vi.fn().mockResolvedValue(undefined)
-    const frame = { locator: vi.fn(() => ({ waitFor })) }
-    const locator = {
-      locator: vi.fn(() => ({ ariaSnapshot })),
-      page: vi.fn(() => ({ frames: () => [frame] })),
-    } as unknown as Locator
-    const page = { locator: vi.fn(() => locator) } as unknown as Pick<Page, "locator">
+    const fixture = ariaSnapshotFixture({ captureError })
 
-    await expect(createAriaSnapshotHelper(page)()).rejects.toThrow(captureError)
-    expect(waitFor).toHaveBeenCalledOnce()
+    await expect(createAriaSnapshotHelper(fixture.page)()).rejects.toThrow(captureError)
+    expect(fixture.waitFor).toHaveBeenCalledOnce()
   })
 
   it("does not return a snapshot when isolated-world cleanup cannot be confirmed", async () => {
-    const ariaSnapshot = vi.fn().mockResolvedValue('- textbox "Password"')
-    const frame = {
-      locator: vi.fn(() => ({ waitFor: vi.fn().mockRejectedValue(new Error("frame wedged")) })),
-    }
-    const locator = {
-      locator: vi.fn(() => ({ ariaSnapshot })),
-      page: vi.fn(() => ({ frames: () => [frame] })),
-    } as unknown as Locator
-    const page = { locator: vi.fn(() => locator) } as unknown as Pick<Page, "locator">
+    const fixture = ariaSnapshotFixture({
+      snapshot: '- textbox "Password"',
+      cleanupError: new Error("frame wedged"),
+    })
 
-    await expect(createAriaSnapshotHelper(page)()).rejects.toThrow(
+    await expect(createAriaSnapshotHelper(fixture.page)()).rejects.toThrow(
       "Browser Control could not confirm ARIA snapshot value-redaction cleanup",
     )
+  })
+
+  it("retries stale cleanup tokens before returning a later snapshot", async () => {
+    const fixture = ariaSnapshotFixture({ snapshot: '- textbox "Password"' })
+    fixture.waitFor.mockRejectedValueOnce(new Error("frame wedged"))
+    const helper = createAriaSnapshotHelper(fixture.page)
+
+    await expect(helper()).rejects.toThrow("Browser Control could not confirm ARIA snapshot value-redaction cleanup")
+    await expect(helper()).resolves.toBe('- textbox "Password"')
+    expect(fixture.waitFor).toHaveBeenCalledTimes(3)
+  })
+
+  it("preserves capture and cleanup failures", async () => {
+    const captureError = new Error("target detached")
+    const cleanupError = new Error("frame wedged")
+    const fixture = ariaSnapshotFixture({ captureError, cleanupError })
+
+    const error = await createAriaSnapshotHelper(fixture.page)().catch((cause: unknown) => cause)
+    expect(error).toBeInstanceOf(AggregateError)
+    expect(error).toMatchObject({
+      message: "Browser Control could not confirm ARIA snapshot value-redaction cleanup",
+      errors: expect.arrayContaining([captureError, cleanupError]),
+    })
   })
 })
 


### PR DESCRIPTION
## What

Prevent `ariaSnapshot()` from returning user-entered text-control values while retaining the surrounding Playwright accessibility tree.

The helper now masks text input, textarea, numeric/range, and contenteditable values only inside Playwright's isolated utility world for the duration of serialization. The page's application world and DOM remain unchanged.

## Before / After

**Before:** `ariaSnapshot()` directly returned Playwright YAML. Values could appear as inline scalars, nested text nodes, ancestor accessible names, arbitrary explicit roles, slotted controls, or `aria-owns` targets. Regex post-processing could not recover value provenance safely after serialization.

**After:** the target locator activates a per-call isolated-world mask before Playwright builds the ARIA tree. Playwright observes empty text-control values while computing both nodes and accessible names, then Browser Control restores native descriptors in every live frame before returning. Cleanup is bounded, stale cleanup tokens are retried by later calls, and the helper fails without returning the snapshot if restoration cannot be confirmed.

## How

- `src/aria-snapshot.ts` registers an isolated custom selector before Browser Control creates browser contexts.
- Per-call tokens prevent overlapping guarded snapshots from restoring each other early.
- Utility-world getters suppress sensitive input, textarea, numeric/range, and contenteditable reads while preserving native button labels.
- Value-related `getAttribute()` reads are masked so embedded controls cannot leak through ancestor names.
- Per-page cleanup serializes restoration, retries any stale tokens, and preserves both capture and cleanup failures with an aggregate error.
- Cleanup restores native descriptors through every current page frame with a one-second bound and fails closed on any unconfirmed frame.
- `src/execute.ts` routes the existing helper through this serializer boundary.
- Agent docs record the safety behavior and require awaiting `ariaSnapshot()` separately from other same-page operations.

## Scope

- Raw Playwright calls such as `locator.ariaSnapshot()` remain raw; the safety boundary applies to Browser Control's `ariaSnapshot()` execute helper.
- The isolated utility-world mask is frame-global while active. Callers must not run unrelated Playwright operations on the same page concurrently with the helper.
- Native button, submit, reset, checkbox, radio, file, image, and hidden input semantics remain unchanged.

## Testing

- `pnpm run ci`
- 47 unit-test files passed, 440 tests total.
- TypeScript, CLI build, extension build, and deterministic Store packaging passed.
- Real Brave probes verified explicit arbitrary input roles, numeric/range values in ancestor names, textarea composites, roleless and rich contenteditable nodes, open shadow roots, slots, and `aria-owns` targets.
- Real Brave probes also verified application-world values remain unchanged, native button labels remain visible, cleanup restores raw Playwright behavior, and two concurrent guarded snapshots do not restore each other early.
- Added the same redaction/restoration regression to the `local-forms` relay smoke case.
- `SMOKE_CASE=local-forms pnpm smoke` is locally blocked at preflight because the shared detached relay reports an August 8 build while actively serving 6 CDP clients and 3 connected sessions. It was intentionally not restarted to avoid disrupting parallel work.
- Final security review reported no findings within the documented non-concurrent usage.

## Flow

```mermaid
sequenceDiagram
  participant A as Agent helper
  participant U as Playwright utility world
  participant P as Page application world

  A->>U: activate token-scoped value mask
  Note over U,P: Native DOM state in P is unchanged
  A->>U: Playwright ariaSnapshot(target)
  U-->>A: YAML without text-control values
  A->>U: restore pending tokens in every live frame
  alt all frames confirm cleanup
    A-->>A: return snapshot
  else cleanup fails or times out
    A-->>A: retain token for retry and fail without returning snapshot
  end
```