### PR TITLE
fix(relay): route browser context commands

### DIFF
--- a/.changeset/route-browser-context-cdp.md
+++ b/.changeset/route-browser-context-cdp.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Route Playwright browser-context permission and cookie commands through the correct session-owned tab.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,9 @@ local Node relay.
 - CDP guardrails are pure logic in `src/cdp-guardrails.ts`, enforced at the top
   of `routeCdpCommand`. Destructive browser-state methods are always blocked;
   read-only sessions additionally reject `Input.*`.
+- Browser-context CDP methods route through a session-owned root for named
+  clients or exactly one visible root for raw clients. A named client never
+  falls back to an unrelated unowned tab.
 - Human handoff waiters live in `src/handoff.ts`; derive their stable CDP target
   id from the actual Playwright `Page`, then bind the exact registry
   target/tab/session. The relay resolves only a matching handoff id from that

--- a/PLAN.md
+++ b/PLAN.md
@@ -108,7 +108,10 @@ explicit target and session routing now rechecks client visibility, including
 session-scoped auto-attach. Root teardown emits each announced child detach
 before detaching the root so clients cannot retain orphaned sessions. The
 browser-free `CdpRouter` module keeps these visibility, alias, and generation
-rules out of relay transport orchestration.
+rules out of relay transport orchestration. Browser-context permission and
+cookie commands route through a session-owned root for named clients, including
+multi-page sessions and browser CDP aliases, or exactly one visible root for raw
+clients, without falling through from a named client to an unrelated tab.
 
 ### CDP client state is isolated per connection
 

--- a/src/cdp-router.ts
+++ b/src/cdp-router.ts
@@ -5,6 +5,18 @@ import { isRestrictedTarget } from "./relay-helpers.ts"
 import type { ChildTarget, ConnectedTarget } from "./relay-types.ts"
 import { shouldExposeChildTarget, type TargetRegistry } from "./target-registry.ts"
 
+const rootRoutableBrowserContextMethods = new Set([
+  "Browser.grantPermissions",
+  "Browser.resetPermissions",
+  "Storage.getCookies",
+  "Storage.setCookies",
+  "Storage.clearCookies",
+])
+
+export function isRootRoutableBrowserContextMethod(method: string): boolean {
+  return rootRoutableBrowserContextMethods.has(method)
+}
+
 export type CdpRoutedSession = {
   readonly tabId: number
   readonly rootSessionId?: string
@@ -37,9 +49,24 @@ export class CdpRouter<Client extends object> {
     return rootTarget ? this.canSeeTarget(client, rootTarget) : false
   }
 
-  singleVisibleRoot(client: Client): ConnectedTarget | undefined {
-    const visible = this.visibleRoots(client)
-    return visible.length === 1 ? visible[0] : undefined
+  preferredRoot(client: Client): ConnectedTarget | undefined {
+    const clientSessionId = this.clients.sessionId(client)
+    let preferred: ConnectedTarget | undefined
+    for (const target of this.registry.listRootTargets()) {
+      if (clientSessionId !== undefined) {
+        if (target.browserControlSessionId === clientSessionId) return target
+        continue
+      }
+      const matches = this.canSeeTarget(client, target)
+      if (!matches) continue
+      if (preferred) return undefined
+      preferred = target
+    }
+    return preferred
+  }
+
+  isBrowserAlias(client: Client, sessionId: string): boolean {
+    return this.clients.alias(client, sessionId)?.kind === "browser"
   }
 
   visibleRoots(client: Client): ConnectedTarget[] {

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -15,7 +15,7 @@ import {
   sendAttachedToTarget,
 } from "./cdp-shims.ts"
 import { CdpClientPool } from "./cdp-client-pool.ts"
-import { CdpRouter } from "./cdp-router.ts"
+import { CdpRouter, isRootRoutableBrowserContextMethod } from "./cdp-router.ts"
 import { ExtensionRpc } from "./extension-rpc.ts"
 import { createHttpRequestHandler } from "./http-api.ts"
 import type { CdpEvent, CdpRequest, JsonObject, PageStatus } from "./protocol.ts"
@@ -570,7 +570,7 @@ const makeRelay = Effect.fnUntraced(function* (options: {
   function diagnosticTargetForClient(socket: WebSocket, sessionId: string | undefined): ConnectedTarget | ChildTarget | undefined {
     return sessionId
       ? cdpRouter.targetInfo(socket, { sessionId })
-      : cdpRouter.singleVisibleRoot(socket)
+      : cdpRouter.preferredRoot(socket)
   }
 
   function isRuntimeEvaluationMethod(method: string): boolean {
@@ -1299,9 +1299,20 @@ const makeRelay = Effect.fnUntraced(function* (options: {
       }
       return result
     }
-    const route = message.sessionId ? cdpRouter.session(socket, message.sessionId) : undefined
+    const browserAlias = message.sessionId !== undefined && cdpRouter.isBrowserAlias(socket, message.sessionId)
+    const rootRoutable = isRootRoutableBrowserContextMethod(message.method) && (!message.sessionId || browserAlias)
+    const preferredRoot = rootRoutable ? cdpRouter.preferredRoot(socket) : undefined
+    const route = rootRoutable && preferredRoot
+      ? { tabId: preferredRoot.tabId, rootSessionId: preferredRoot.sessionId }
+      : message.sessionId
+      ? cdpRouter.session(socket, message.sessionId)
+      : undefined
     if (!route) {
-      return yield* Effect.fail(new Error(message.sessionId
+      return yield* Effect.fail(new Error(rootRoutable
+        ? clientBrowserControlSessionId === undefined
+          ? `Exactly one visible root target is required for ${message.method}`
+          : `A session-owned root target is required for ${message.method}`
+        : message.sessionId
         ? `Unknown CDP session ${message.sessionId} for ${message.method}`
         : `CDP sessionId is required for ${message.method}`))
     }

--- a/test/cdp-router.test.ts
+++ b/test/cdp-router.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { CdpClientPool } from "../src/cdp-client-pool.ts"
-import { CdpRouter } from "../src/cdp-router.ts"
+import { CdpRouter, isRootRoutableBrowserContextMethod } from "../src/cdp-router.ts"
 import type { ConnectedTarget } from "../src/relay-types.ts"
 import { TargetRegistry } from "../src/target-registry.ts"
 
@@ -35,6 +35,85 @@ function setup() {
 }
 
 describe("CdpRouter", () => {
+  it("classifies browser-context methods that Chrome routes through a root tab", () => {
+    for (const method of [
+      "Browser.grantPermissions",
+      "Browser.resetPermissions",
+      "Storage.getCookies",
+      "Storage.setCookies",
+      "Storage.clearCookies",
+    ]) {
+      expect(isRootRoutableBrowserContextMethod(method)).toBe(true)
+    }
+    expect(isRootRoutableBrowserContextMethod("Runtime.evaluate")).toBe(false)
+  })
+
+  it("prefers a session-owned root for a named client", () => {
+    const { clients, registry, router } = setup()
+    const client = {}
+    clients.register(client, "session-a")
+    const owned = root({
+      tabId: 1,
+      sessionId: "owned-root",
+      targetId: "owned-target",
+      browserControlSessionId: "session-a",
+    })
+    registry.addRootTarget(owned)
+    registry.addRootTarget(root({
+      tabId: 2,
+      sessionId: "unrelated-root",
+      targetId: "unrelated-target",
+      owner: "user",
+    }))
+
+    expect(router.preferredRoot(client)).toBe(owned)
+
+    registry.addRootTarget(root({
+      tabId: 3,
+      sessionId: "second-owned-root",
+      targetId: "second-owned-target",
+      browserControlSessionId: "session-a",
+    }))
+    expect(router.preferredRoot(client)).toBe(owned)
+  })
+
+  it("recognizes browser session aliases", () => {
+    const { clients, router } = setup()
+    const client = {}
+    clients.register(client, "session-a")
+    const browserAlias = clients.createBrowserAlias(client)
+
+    expect(router.isBrowserAlias(client, browserAlias)).toBe(true)
+    expect(router.isBrowserAlias(client, "unknown-session")).toBe(false)
+  })
+
+  it("does not fall through from an empty named session to an unrelated root", () => {
+    const { clients, registry, router } = setup()
+    const client = {}
+    clients.register(client, "session-a")
+    registry.addRootTarget(root({
+      tabId: 1,
+      sessionId: "unrelated-root",
+      targetId: "unrelated-target",
+    }))
+
+    expect(router.visibleRoots(client)).toHaveLength(1)
+    expect(router.preferredRoot(client)).toBeUndefined()
+  })
+
+  it("selects exactly one visible root for a raw client", () => {
+    const { clients, registry, router } = setup()
+    const client = {}
+    clients.register(client)
+    const visible = root({ tabId: 1, sessionId: "root-1", targetId: "target-1" })
+    registry.addRootTarget(visible)
+
+    expect(router.preferredRoot(client)).toBe(visible)
+
+    registry.addRootTarget(root({ tabId: 2, sessionId: "root-2", targetId: "target-2" }))
+    expect(router.preferredRoot(client)).toBeUndefined()
+  })
+
   it("resolves only targets visible to the client", () => {
     const { clients, registry, router } = setup()
     const owner = {}

--- a/test/relay-visibility-prune.test.ts
+++ b/test/relay-visibility-prune.test.ts
@@ -2,11 +2,138 @@ import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import { WebSocket } from "ws"
 import { startRelay } from "../src/relay.ts"
-import type { CdpEvent, CdpRequest, JsonObject } from "../src/protocol.ts"
+import { parseExtensionCommand, type CdpEvent, type CdpRequest, type ExtensionCommand, type JsonObject } from "../src/protocol.ts"
 
 type CdpMessage = CdpEvent | { readonly id: number; readonly result?: JsonObject; readonly error?: { readonly message: string } }
 
 describe("relay target visibility pruning", () => {
+  it("routes browser-context commands only through the client's preferred root", async () => {
+    const port = 24_000 + Math.floor(Math.random() * 10_000)
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port, sessionCatalogPath: null })
+      const extension = yield* Effect.promise(() => connectFakeExtension(relay.url))
+      const rawClient = yield* Effect.promise(() => connectCdpClient(relay.url))
+      const sessionClient = yield* Effect.promise(() => connectCdpClient(relay.url, "session-a"))
+
+      try {
+        const rawCreate = yield* Effect.promise(() => sendCdp(rawClient, {
+          id: 1,
+          method: "Target.createTarget",
+          params: { url: "about:blank" },
+        }))
+        expect(rawCreate.result?.targetId).toBe("target-1")
+
+        extension.commands.length = 0
+        yield* Effect.promise(() => sendCdp(rawClient, {
+          id: 2,
+          method: "Storage.getCookies",
+          params: { browserContextId: "raw-context" },
+        }))
+        expect(extension.commands).toContainEqual(expect.objectContaining({
+          method: "debugger.sendCommand",
+          params: {
+            tabId: 1,
+            method: "Storage.getCookies",
+            params: { browserContextId: "raw-context" },
+          },
+        }))
+
+        extension.commands.length = 0
+        yield* Effect.promise(async () => {
+          await expect(sendCdp(sessionClient, {
+            id: 3,
+            method: "Storage.getCookies",
+            params: { browserContextId: "session-context" },
+          })).rejects.toThrow("A session-owned root target is required for Storage.getCookies")
+        })
+        expect(extension.commands).toEqual([])
+
+        const ownedCreate = yield* Effect.promise(() => sendCdp(sessionClient, {
+          id: 4,
+          method: "Target.createTarget",
+          params: { url: "about:blank" },
+        }))
+        expect(ownedCreate.result?.targetId).toBe("target-2")
+
+        const browserAttach = yield* Effect.promise(() => sendCdp(sessionClient, {
+          id: 5,
+          method: "Target.attachToBrowserTarget",
+        }))
+        const browserAlias = typeof browserAttach.result?.sessionId === "string"
+          ? browserAttach.result.sessionId
+          : undefined
+        expect(browserAlias).toBeDefined()
+        if (!browserAlias) throw new Error("Expected browser session alias")
+
+        const secondOwnedCreate = yield* Effect.promise(() => sendCdp(sessionClient, {
+          id: 6,
+          method: "Target.createTarget",
+          params: { url: "about:blank" },
+        }))
+        expect(secondOwnedCreate.result?.targetId).toBe("target-3")
+
+        extension.commands.length = 0
+        const routedCommands: CdpRequest[] = [
+          {
+            id: 7,
+            method: "Browser.grantPermissions",
+            params: {
+              browserContextId: "session-context",
+              origin: "https://example.com",
+              permissions: ["geolocation"],
+            },
+          },
+          {
+            id: 8,
+            sessionId: browserAlias,
+            method: "Browser.resetPermissions",
+            params: { browserContextId: "session-context" },
+          },
+          {
+            id: 9,
+            method: "Storage.getCookies",
+            params: { browserContextId: "session-context" },
+          },
+          {
+            id: 10,
+            method: "Storage.setCookies",
+            params: {
+              browserContextId: "session-context",
+              cookies: [{ name: "theme", value: "dark", domain: "example.com", path: "/" }],
+            },
+          },
+        ]
+        for (const command of routedCommands) {
+          yield* Effect.promise(() => sendCdp(sessionClient, command))
+        }
+
+        const forwarded = extension.commands.filter((command) => command.method === "debugger.sendCommand")
+        expect(forwarded).toHaveLength(routedCommands.length)
+        for (const [index, command] of routedCommands.entries()) {
+          expect(forwarded[index]?.params).toEqual({
+            tabId: 2,
+            method: command.method,
+            params: command.params,
+          })
+          expect(forwarded[index]?.params).not.toHaveProperty("sessionId")
+        }
+
+        yield* Effect.promise(async () => {
+          await expect(sendCdp(sessionClient, {
+            id: 11,
+            method: "Storage.clearCookies",
+            params: { browserContextId: "session-context" },
+          })).rejects.toThrow("Browser Control blocked Storage.clearCookies")
+        })
+        expect(extension.commands.filter((command) => command.method === "debugger.sendCommand")).toHaveLength(routedCommands.length)
+      } finally {
+        rawClient.close()
+        sessionClient.close()
+        extension.close()
+      }
+    })))
+  })
+
   it("detaches raw relay targets from a session client once that session gains an owned target", async () => {
     const port = 24_000 + Math.floor(Math.random() * 10_000)
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
@@ -170,12 +297,6 @@ describe("relay target visibility pruning", () => {
   })
 })
 
-type ExtensionCommand = {
-  readonly id: number
-  readonly method: string
-  readonly params?: { readonly tabId?: number; readonly method?: string; readonly params?: JsonObject }
-}
-
 function connectFakeExtension(relayUrl: string): Promise<WebSocket & { readonly commands: ExtensionCommand[] }> {
   return new Promise((resolve, reject) => {
     let nextTabId = 1
@@ -187,7 +308,7 @@ function connectFakeExtension(relayUrl: string): Promise<WebSocket & { readonly 
     })
     socket.on("error", reject)
     socket.on("message", (data) => {
-      const command = JSON.parse(data.toString()) as ExtensionCommand
+      const command = parseExtensionCommand(data.toString())
       commands.push(command)
       const params = command.params
       let result: JsonObject = {}
@@ -195,7 +316,7 @@ function connectFakeExtension(relayUrl: string): Promise<WebSocket & { readonly 
         result = { tabId: nextTabId++ }
       }
       if (command.method === "debugger.sendCommand" && params?.method === "Target.getTargetInfo") {
-        const tabId = params.tabId ?? 0
+        const tabId = typeof params.tabId === "number" ? params.tabId : 0
         result = {
           targetInfo: {
             targetId: `target-${tabId}`,


### PR DESCRIPTION
## What

Restore Playwright browser-context permission and cookie APIs over the extension-backed CDP relay.

`context.cookies()`, `context.addCookies()`, `context.grantPermissions()`, and `context.clearPermissions()` now reach Chrome through a root tab owned by the calling Browser Control session. Raw CDP clients retain a fail-closed route only when exactly one root is visible.

## Before / After

**Before:** Playwright sends these APIs as browser-scoped CDP commands without a page `sessionId`. The relay rejected them with `CDP sessionId is required`. `Browser.resetPermissions`, used by `context.clearPermissions()`, was not classified at all.

**After:** the relay recognizes Playwright's five browser-context methods and routes allowed commands through a safe root. Named clients use their own root even when the context has multiple pages; they never fall through to an unrelated visible tab. Valid browser CDP aliases use the same route. Unknown aliases and ambiguous raw clients still fail closed, and `Storage.clearCookies` remains blocked before routing.

## How

- `src/cdp-router.ts` owns the browser-context method classification, owner-aware preferred-root selection, and browser-alias recognition.
- Named clients select a session-owned root; raw clients require exactly one visible root.
- `src/relay.ts` applies guardrails first, converts a preferred root into a root CDP route, and forwards no Chrome child `sessionId`.
- `test/cdp-router.test.ts` covers method classification, named ownership, multi-page selection, browser aliases, empty named sessions, and raw ambiguity.
- `test/relay-visibility-prune.test.ts` exercises the complete CDP websocket to relay to extension path, including parameter preservation and no-forwarding failures.

## Scope

- This is not generic routing for every browser-scoped CDP command; it covers the exact permission and cookie methods Playwright 1.61 uses.
- `Storage.clearCookies` is recognized for routing compatibility but remains intentionally blocked because it would log the user out of every site.
- No extension or wire-protocol change is required; the existing extension command forwarder already accepts these CDP methods.

## Testing

- `pnpm run ci`
- 47 test files passed, 446 tests total.
- TypeScript, CLI build, extension build, and deterministic Store packaging passed.
- Relay integration verified:
  - a named client with no owned root cannot route through an unrelated raw tab;
  - a multi-page named session continues using its first owned root;
  - `Browser.resetPermissions` works through `Target.attachToBrowserTarget` aliases;
  - all allowed commands preserve parameters and omit a Chrome child `sessionId`;
  - `Storage.clearCookies` emits no extension command.
- Final focused review reported no remaining findings.

## Flow

```mermaid
flowchart TD
  A[Browser-context CDP request] --> B{Guardrail allows it?}
  B -- No --> X[Return blocked error]
  B -- Yes --> C{Named client?}
  C -- Yes --> D[Select a session-owned root]
  C -- No --> E{Exactly one visible root?}
  E -- No --> Y[Fail closed]
  E -- Yes --> F[Select visible root]
  D --> G[Forward through root tab]
  F --> G
  G --> H[Preserve params; omit child sessionId]
```