### PR TITLE
fix(aria): register selectors after CDP connect

### DIFF
--- a/.changeset/register-context-aria.md
+++ b/.changeset/register-context-aria.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Register ARIA snapshot redaction selectors on each connected Playwright context so `ariaSnapshot()` works through `connectOverCDP`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,8 +130,11 @@ local Node relay.
   are explicit, require a compatible prior baseline, invalidate earlier refs,
   and expose refs only for added or changed current lines. `ariaSnapshot()` also
   omits text-control values while preserving the surrounding accessibility
-  tree. It temporarily masks those values in Playwright's isolated world, so do
-  not run it concurrently with other operations on the same page. Keep raw
+  tree. Register its unique selector engine for each connected Playwright
+  context before any page or locator work; pre-connect registration does not
+  reach the default context returned by `connectOverCDP`. It temporarily masks
+  those values in Playwright's isolated world, so do not run it concurrently
+  with other operations on the same page. Keep raw
   Playwright as a deeper inspection layer; do not replace the code-first execute
   interface with many action commands.
 - Authenticated network capture is owned by the persistent Execute Sandbox and

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -10,6 +10,7 @@ import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import util from "node:util"
+import { registerAriaSnapshotSelector } from "../src/aria-snapshot.ts"
 import { createAriaSnapshotHelper } from "../src/execute.ts"
 import { getObject } from "../src/relay-helpers.ts"
 import { browserControlBuildId } from "../src/version.ts"
@@ -1590,6 +1591,7 @@ const withPage = Effect.fnUntraced(function* <A>(run: (page: Page) => Effect.Eff
     Effect.gen(function* () {
       const browser = yield* scopedBrowser()
       const context = yield* playwright("get browser context", () => getBrowserContext(browser))
+      yield* playwright("register ARIA snapshot selector", () => registerAriaSnapshotSelector(context))
       const page = yield* playwright("create page", () => context.newPage())
       return yield* run(page).pipe(Effect.ensuring(boundedCleanup("close smoke page", () => page.close())))
     }),

--- a/src/aria-snapshot.ts
+++ b/src/aria-snapshot.ts
@@ -1,6 +1,5 @@
-import { selectors, type Locator, type Page } from "playwright-core"
+import { selectors, type BrowserContext, type Locator, type Page } from "playwright-core"
 
-const redactionSelectorName = "bcariaredact"
 const redactionCleanupErrorMessage = "Browser Control could not confirm ARIA snapshot value-redaction cleanup"
 // Keep the engine as source text so bundlers cannot inject Node-only helpers into the browser function.
 const redactionSelectorSource = `({
@@ -90,13 +89,9 @@ const redactionSelectorSource = `({
   },
 })`
 
-await selectors.register(
-  redactionSelectorName,
-  { content: redactionSelectorSource },
-  { contentScript: true },
-)
-
+let nextRedactionSelector = 0
 let nextRedactionToken = 0
+const contextSelectors = new WeakMap<BrowserContext, Promise<string>>()
 const pageCleanup = new WeakMap<Page, {
   readonly pendingTokens: Set<string>
   queue: Promise<void>
@@ -106,6 +101,8 @@ export async function ariaSnapshotWithoutTextControlValues(
   locator: Locator,
   options: { readonly timeout: number },
 ): Promise<string> {
+  const page = locator.page()
+  const redactionSelectorName = await selectorForContext(page.context())
   const token = String(++nextRedactionToken)
   let snapshot: string | undefined
   let captureFailed = false
@@ -120,7 +117,7 @@ export async function ariaSnapshotWithoutTextControlValues(
   }
 
   try {
-    await cleanupRedaction(locator.page(), token)
+    await cleanupRedaction(page, redactionSelectorName, token)
   } catch (cleanupError) {
     if (captureFailed) {
       const cleanupReasons = cleanupError instanceof AggregateError ? cleanupError.errors : [cleanupError]
@@ -133,7 +130,28 @@ export async function ariaSnapshotWithoutTextControlValues(
   return snapshot!
 }
 
-async function cleanupRedaction(page: Page, token: string): Promise<void> {
+export async function registerAriaSnapshotSelector(context: BrowserContext): Promise<void> {
+  await selectorForContext(context)
+}
+
+async function selectorForContext(context: BrowserContext): Promise<string> {
+  const existing = contextSelectors.get(context)
+  if (existing) return existing
+
+  const name = `bcariaredact${++nextRedactionSelector}`
+  const registration = selectors.register(
+    name,
+    { content: redactionSelectorSource },
+    { contentScript: true },
+  ).then(() => name, (error) => {
+    contextSelectors.delete(context)
+    throw error
+  })
+  contextSelectors.set(context, registration)
+  return registration
+}
+
+async function cleanupRedaction(page: Page, redactionSelectorName: string, token: string): Promise<void> {
   let state = pageCleanup.get(page)
   if (!state) {
     state = { pendingTokens: new Set(), queue: Promise.resolve() }

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -21,7 +21,7 @@ import * as NetworkCapture from "./network-capture.ts"
 import type { AuthenticatedJsonOutcome, AuthenticatedJsonRequest, ExecuteAftermath, ExecuteLogEntry, ExecuteLogSummary, ExecuteMedia } from "./relay-schema.ts"
 import type { SessionTarget } from "./relay-types.ts"
 import { executionContextFailureDiagnostic, runtimeFailureKind } from "./runtime-diagnostics.ts"
-import { ariaSnapshotWithoutTextControlValues } from "./aria-snapshot.ts"
+import { ariaSnapshotWithoutTextControlValues, registerAriaSnapshotSelector } from "./aria-snapshot.ts"
 
 const nodeModules = { fs, path, os, crypto, url, util, events, stream, buffer, http, https, zlib }
 const nodeModuleAliases = Object.keys(nodeModules).join(", ")
@@ -690,6 +690,10 @@ export class ExecuteSandbox {
         label: "Create a browser context for session adoption",
         run: () => browser.newContext(),
       }))
+      yield* Effect.tryPromise({
+        try: () => registerAriaSnapshotSelector(context),
+        catch: (cause) => cause instanceof Error ? cause : new Error("Register ARIA snapshot selector", { cause }),
+      })
       const selected = yield* Effect.tryPromise({
         try: () => waitForPageTarget({ context, targetId: target.targetId, timeoutMs: sessionPageHealthCheckTimeoutMs }),
         catch: (cause) => cause instanceof Error ? cause : new Error("Select page for session adoption", { cause }),
@@ -744,6 +748,7 @@ export class ExecuteSandbox {
       }
     }
     const context = this.browser.contexts()[0] ?? (await this.browser.newContext())
+    await registerAriaSnapshotSelector(context)
     installDownloadCapabilityGuards(context)
     const targetSelection = options.targetSelection
     const page = await this.getSessionPage({ context, ...(targetSelection ? { targetSelection } : {}) })

--- a/test/execute-ergonomics.test.ts
+++ b/test/execute-ergonomics.test.ts
@@ -270,7 +270,8 @@ function ariaSnapshotFixture(options: {
     ? vi.fn().mockRejectedValue(options.cleanupError)
     : vi.fn().mockResolvedValue(undefined)
   const frame = { locator: vi.fn(() => ({ waitFor })) }
-  const ownerPage = { frames: () => [frame] }
+  const context = {}
+  const ownerPage = { context: () => context, frames: () => [frame] }
   const locator = {
     locator: vi.fn(() => ({ ariaSnapshot })),
     page: vi.fn(() => ownerPage),
@@ -287,10 +288,25 @@ describe("ariaSnapshot helper", () => {
     expect(fixture.page.locator).toHaveBeenCalledWith("body")
     expect(fixture.ariaSnapshot).toHaveBeenCalledWith({ timeout: defaultAriaSnapshotTimeoutMs })
     const activation = vi.mocked(fixture.locator.locator).mock.calls[0]?.[0]
-    expect(activation).toMatch(/^bcariaredact=on_\d+$/)
+    expect(activation).toMatch(/^bcariaredact\d+=on_\d+$/)
     if (typeof activation !== "string") throw new Error("Expected redaction selector activation")
     expect(fixture.frame.locator).toHaveBeenCalledWith(activation.replace("=on_", "=off_"))
     expect(fixture.waitFor).toHaveBeenCalledWith({ state: "attached", timeout: 1_000 })
+  })
+
+  it("reuses the selector engine for the same browser context", async () => {
+    const fixture = ariaSnapshotFixture()
+    const helper = createAriaSnapshotHelper(fixture.page)
+
+    await helper()
+    await helper()
+
+    const activations = vi.mocked(fixture.locator.locator).mock.calls.map(([selector]) => selector)
+    expect(activations).toHaveLength(2)
+    const [first, second] = activations
+    if (typeof first !== "string" || typeof second !== "string") throw new Error("Expected redaction selector activations")
+    expect(first.split("=")[0]).toBe(second.split("=")[0])
+    expect(first).not.toBe(second)
   })
 
   it("preserves selector and locator targets and accepts a short timeout", async () => {


### PR DESCRIPTION
## What

Make the safe `ariaSnapshot()` helper available in Playwright contexts returned by `connectOverCDP`.

## Before / After

**Before:** Browser Control registered its redaction selector before connecting. Playwright did not install that engine into the already-existing default CDP context, so `ariaSnapshot()` failed with an unknown selector engine.

**After:** Each connected context gets a uniquely named redaction engine before page or locator work. Repeated snapshots in the same context reuse that registration, and a failed registration remains retryable.

## How

- `src/aria-snapshot.ts` stores the registration promise in a per-context `WeakMap` and carries the selected engine name through activation and cleanup.
- `src/execute.ts` registers immediately after normal connections and adoption connections.
- `scripts/smoke.ts` applies the same ordering in browser smoke fixtures.
- Unit coverage verifies selector reuse within one context.

## Scope

This does not expand the redaction contract for custom range controls or rich editable descendants. That broader hardening remains tracked in #51.

PR #45 should remain draft until this fix and the release-blocking ARIA hardening are incorporated.

## Testing

- `pnpm typecheck`
- `pnpm test -- test/execute-ergonomics.test.ts` (Vitest ran all 447 tests)
- `pnpm build:cli`
- Earlier extraction verification: `SMOKE_CASE=local-forms pnpm smoke` passed against the same production implementation in the primary worktree; it was not rerun from this isolated worktree.

## Flow

```mermaid
sequenceDiagram
  participant Sandbox
  participant Playwright
  participant Context
  Sandbox->>Playwright: connectOverCDP()
  Playwright-->>Sandbox: existing default Context
  Sandbox->>Playwright: register unique redaction engine
  Playwright->>Context: install selector engine
  Sandbox->>Context: resolve page and expose ariaSnapshot()
```