### PR TITLE
fix(aria): harden snapshot value redaction

### DIFF
--- a/.changeset/safe-editable-aria.md
+++ b/.changeset/safe-editable-aria.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Harden `ariaSnapshot()` redaction for custom ARIA value controls, rich editable content, concurrent callers, and frame lifecycle changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,12 +129,15 @@ local Node relay.
   repeated metadata; text input and textarea values are omitted. Snapshot diffs
   are explicit, require a compatible prior baseline, invalidate earlier refs,
   and expose refs only for added or changed current lines. `ariaSnapshot()` also
-  omits text-control values while preserving the surrounding accessibility
-  tree. Register its unique selector engine for each connected Playwright
-  context before any page or locator work; pre-connect registration does not
-  reach the default context returned by `connectOverCDP`. It temporarily masks
-  those values in Playwright's isolated world, so do not run it concurrently
-  with other operations on the same page. Keep raw
+  omits native text-control values, custom ARIA range values, and editable
+  composed-tree content while preserving surrounding structure. Register its
+  unique selector engine for each connected Playwright context before any page
+  or locator work; pre-connect registration does not reach the default context
+  returned by `connectOverCDP`. Track each mask with a module-unique token and
+  clean it only through the frame where it was activated; a destroyed execution
+  context is already clean. It temporarily masks those values in Playwright's
+  isolated world, so do not run it concurrently with other operations on the
+  same page. Keep raw
   Playwright as a deeper inspection layer; do not replace the code-first execute
   interface with many action commands.
 - Authenticated network capture is owned by the persistent Execute Sandbox and

--- a/PLAN.md
+++ b/PLAN.md
@@ -315,10 +315,12 @@ reconciles existing client announcements, browser grouping, and page status.
 - `ref(id)` resolves controls from the latest valid snapshot and fails closed
   after navigation or incompatible DOM drift.
 - `ariaSnapshot()` and raw Playwright provide deeper inspection when compact
-  snapshots are insufficient. The helper omits text-control values so password,
-  token, search, numeric, range, and textarea contents do not enter tool output.
-  It must be awaited separately from other operations on the same page while its
-  isolated-world value mask is active.
+  snapshots are insufficient. The helper omits native text-control values,
+  custom ARIA range values, and editable content across SVG and open-shadow
+  boundaries. Each isolated-world mask is scoped to its activation frame and a
+  module-unique token, so concurrent guarded snapshots restore safely without
+  depending on unrelated frames. It must be awaited separately from other page
+  operations while the mask is active.
 - `screenshotWithLabels({ page, path? })` annotates likely interactive elements
   and returns label metadata.
 - `fillInput` and `fillInputs` provide a DOM-evaluation fallback when browser

--- a/README.md
+++ b/README.md
@@ -243,8 +243,9 @@ of silently targeting a different control.
 
 Other inspection helpers include:
 
-- `ariaSnapshot()` for a deeper accessibility-tree view with text-control values
-  omitted; await it separately from other operations on the same page
+- `ariaSnapshot()` for a deeper accessibility-tree view with native text-control
+  values, custom ARIA range values, and editable content omitted; await it
+  separately from other operations on the same page
 - `screenshotWithLabels()` for an annotated screenshot and element metadata
 - `fillInput()` and `fillInputs()` when browser extensions interfere with
   Playwright's normal `locator.fill()`

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -259,16 +259,34 @@ const cases: SmokeCase[] = [
       results.push({ challenge: "shadow-dom", generated: yield* inputValue(page.locator("#editField"), "shadow generated value") })
 
       yield* playwright("set ARIA redaction fixture", () =>
-        page.setContent(`<main><h2>Amount <input type="number" value="aria-number-value"></h2><input role="heading" value="aria-role-value"><textarea role="combobox">aria-textarea-value</textarea><div contenteditable>aria-editor-value</div><input type="button" value="Keep label"></main>`),
+        page.setContent(`<main><h2>Amount <input type="number" value="aria-secret-number"></h2><input role="heading" value="aria-secret-role"><textarea role="combobox">aria-secret-textarea</textarea><h3>Volume <div role="slider" aria-label="Volume" aria-valuenow="73" aria-valuetext="aria-secret-slider"></div></h3><h3>Quantity <div role="spinbutton" aria-label="Quantity" aria-valuenow="4" aria-valuetext="aria-secret-spin"></div></h3><div contenteditable aria-label="Editor"><svg><title>aria-secret-svg-title</title><text>aria-secret-svg-text</text></svg><img alt="aria-secret-alt" title="aria-secret-title"><span aria-label="aria-secret-label">aria-secret-editor</span><div id="aria-shadow-host"></div></div><input type="button" value="Keep label"><select aria-label="Keep select"><option selected>Keep option</option></select><iframe id="aria-editor-frame" srcdoc="<div contenteditable>aria-secret-frame</div>"></iframe></main>`),
       )
-      const safeAria = yield* playwright("capture redacted ARIA snapshot", () => createAriaSnapshotHelper(page)("main"))
-      if (safeAria.includes("aria-")) throw new Error("ARIA snapshot exposed a fixture form value")
+      yield* playwright("attach editable shadow fixture", () =>
+        page.locator("#aria-shadow-host").evaluate((host) => {
+          host.attachShadow({ mode: "open" }).innerHTML = `<span aria-label="aria-secret-shadow-label">aria-secret-shadow-text</span>`
+        }),
+      )
+      const ariaSnapshot = createAriaSnapshotHelper(page)
+      const [safeAria, safeFrameAria] = yield* playwright("capture concurrent redacted ARIA snapshots", () =>
+        Promise.all([
+          ariaSnapshot("main"),
+          ariaSnapshot(page.frameLocator("#aria-editor-frame").locator("body")),
+        ]),
+      )
+      if (`${safeAria}\n${safeFrameAria}`.includes("aria-secret-")) throw new Error("ARIA snapshot exposed a fixture form value")
       if (!safeAria.includes('button "Keep label"')) throw new Error("ARIA snapshot removed a native button label")
-      const restoredAria = yield* playwright("verify ARIA snapshot cleanup", () => page.locator("main").ariaSnapshot())
-      if (!restoredAria.includes("aria-role-value") || !restoredAria.includes("aria-textarea-value")) {
-        throw new Error("ARIA snapshot value access was not restored")
+      if (!safeAria.includes('combobox "Keep select"') || !safeAria.includes("Keep option")) throw new Error("ARIA snapshot removed a select value")
+      const [restoredAria, restoredFrameAria] = yield* playwright("verify ARIA snapshot cleanup", () =>
+        Promise.all([
+          page.locator("main").ariaSnapshot(),
+          page.frameLocator("#aria-editor-frame").locator("body").ariaSnapshot(),
+        ]),
+      )
+      const restored = `${restoredAria}\n${restoredFrameAria}`
+      for (const value of ["aria-secret-role", "aria-secret-textarea", "aria-secret-slider", "aria-secret-spin", "aria-secret-svg-text", "aria-secret-alt", "aria-secret-shadow-text", "aria-secret-frame"]) {
+        if (!restored.includes(value)) throw new Error(`ARIA snapshot value access was not restored for ${value}`)
       }
-      results.push({ challenge: "aria-redaction", snapshot: safeAria })
+      results.push({ challenge: "aria-redaction", snapshot: safeAria, frameSnapshot: safeFrameAria })
       return results
     }),
   },

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -179,10 +179,10 @@ Use the least expensive view that answers the question:
   baseline. A diff invalidates earlier refs and exposes refs only for added or
   changed current lines.
 - `ariaSnapshot(target?, { timeout })` returns Playwright's detailed YAML aria
-  tree when the compact snapshot omits needed structure. Text-control values are
-  omitted so password, token, search, numeric, range, and textarea contents do
-  not enter tool output. Await it separately; do not run other operations on the
-  same page concurrently.
+  tree when the compact snapshot omits needed structure. Native text-control
+  values, custom ARIA range values, and editable content are omitted so they do
+  not enter tool output. Await it separately; do not run other operations on
+  the same page concurrently.
 - `screenshotWithLabels({ page, path? })` adds visual labels and metadata when
   layout matters.
 

--- a/src/aria-snapshot.ts
+++ b/src/aria-snapshot.ts
@@ -1,4 +1,5 @@
-import { selectors, type BrowserContext, type Locator, type Page } from "playwright-core"
+import { selectors, type BrowserContext, type Frame, type Locator, type Page } from "playwright-core"
+import { runtimeFailureKind } from "./runtime-diagnostics.ts"
 
 const redactionCleanupErrorMessage = "Browser Control could not confirm ARIA snapshot value-redaction cleanup"
 // Keep the engine as source text so bundlers cannot inject Node-only helpers into the browser function.
@@ -14,8 +15,10 @@ const redactionSelectorSource = `({
       if (!state) {
         state = {
           tokens: new Set(),
+          editableNameAttributes: new Set(["alt", "aria-description", "aria-describedby", "aria-label", "aria-labelledby", "aria-placeholder", "placeholder", "title"]),
           nonTextInputTypes: new Set(["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"]),
           valueAttributes: new Set(["aria-valuenow", "aria-valuetext", "value"]),
+          valueRoles: new Set(["meter", "progressbar", "scrollbar", "separator", "slider", "spinbutton"]),
           inputValue: Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value"),
           textareaValue: Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value"),
           nodeValue: Object.getOwnPropertyDescriptor(Node.prototype, "nodeValue"),
@@ -24,21 +27,51 @@ const redactionSelectorSource = `({
           getAttribute: Object.getOwnPropertyDescriptor(Element.prototype, "getAttribute"),
         }
         globalThis[stateKey] = state
-        const isRedactedControl = (element) => element instanceof HTMLTextAreaElement
+        const getAttribute = (element, name) => state.getAttribute.value.call(element, name)
+        const explicitEditableState = (element) => {
+          const value = getAttribute(element, "contenteditable")
+          if (value === null) return undefined
+          const normalized = value.trim().toLowerCase()
+          if (normalized === "false") return false
+          return normalized === "" || normalized === "true" || normalized === "plaintext-only" ? true : undefined
+        }
+        const composedParent = (node) => {
+          if (node.parentNode) return node.parentNode
+          const treeRoot = node.getRootNode?.()
+          return treeRoot instanceof ShadowRoot ? treeRoot.host : null
+        }
+        const isInEditableSubtree = (node) => {
+          let current = node.nodeType === Node.TEXT_NODE ? node.parentNode : node
+          while (current) {
+            if (current instanceof Element) {
+              const explicit = explicitEditableState(current)
+              if (explicit !== undefined) return explicit
+              if (current instanceof HTMLElement && current.isContentEditable) return true
+            }
+            current = composedParent(current)
+          }
+          return false
+        }
+        const isEditableDescendant = (element) => explicitEditableState(element) !== true && isInEditableSubtree(element)
+        const isNativeTextControl = (element) => element instanceof HTMLTextAreaElement
           || (element instanceof HTMLInputElement && !state.nonTextInputTypes.has(element.type))
-          || (element instanceof HTMLElement && element.isContentEditable)
+        const isValueRole = (element) => {
+          const role = getAttribute(element, "role")
+          return role !== null && role.trim().toLowerCase().split(/\\s+/).some((candidate) => state.valueRoles.has(candidate))
+        }
+        const hasRedactedText = (node) => isInEditableSubtree(node)
+          || (node.nodeType === Node.TEXT_NODE && node.parentElement && isNativeTextControl(node.parentElement))
         Object.defineProperty(HTMLInputElement.prototype, "value", {
           ...state.inputValue,
           get() {
-            return isRedactedControl(this) ? "" : state.inputValue.get.call(this)
+            return isNativeTextControl(this) ? "" : state.inputValue.get.call(this)
           },
         })
         Object.defineProperty(HTMLTextAreaElement.prototype, "value", { ...state.textareaValue, get() { return "" } })
         Object.defineProperty(Node.prototype, "nodeValue", {
           ...state.nodeValue,
           get() {
-            const parent = this.parentElement
-            return parent && isRedactedControl(parent)
+            return this.nodeType === Node.TEXT_NODE && hasRedactedText(this)
               ? ""
               : state.nodeValue.get.call(this)
           },
@@ -46,8 +79,7 @@ const redactionSelectorSource = `({
         Object.defineProperty(Node.prototype, "textContent", {
           ...state.textContent,
           get() {
-            const parent = this.parentElement
-            return isRedactedControl(this) || (this.nodeType === Node.TEXT_NODE && parent && isRedactedControl(parent))
+            return (this instanceof Element && isNativeTextControl(this)) || hasRedactedText(this)
               ? ""
               : state.textContent.get.call(this)
           },
@@ -55,16 +87,17 @@ const redactionSelectorSource = `({
         Object.defineProperty(HTMLElement.prototype, "innerText", {
           ...state.innerText,
           get() {
-            return isRedactedControl(this) ? "" : state.innerText.get.call(this)
+            return isNativeTextControl(this) || isInEditableSubtree(this) ? "" : state.innerText.get.call(this)
           },
         })
         Object.defineProperty(Element.prototype, "getAttribute", {
           ...state.getAttribute,
           value(name) {
-            const rawAttribute = String(name)
-            const attribute = state.valueAttributes.has(rawAttribute) ? rawAttribute : rawAttribute.toLowerCase()
-            if (!state.valueAttributes.has(attribute)) return state.getAttribute.value.call(this, name)
-            return isRedactedControl(this) ? null : state.getAttribute.value.call(this, name)
+            const attribute = String(name).toLowerCase()
+            if (state.valueAttributes.has(attribute)
+              && (isNativeTextControl(this) || isValueRole(this) || isInEditableSubtree(this))) return null
+            if (state.editableNameAttributes.has(attribute) && isEditableDescendant(this)) return null
+            return state.getAttribute.value.call(this, name)
           },
         })
       }
@@ -89,11 +122,12 @@ const redactionSelectorSource = `({
   },
 })`
 
+const redactionModuleId = globalThis.crypto.randomUUID().replaceAll("-", "")
 let nextRedactionSelector = 0
 let nextRedactionToken = 0
 const contextSelectors = new WeakMap<BrowserContext, Promise<string>>()
 const pageCleanup = new WeakMap<Page, {
-  readonly pendingTokens: Set<string>
+  readonly pendingTokens: Map<string, { readonly frame: Frame; readonly selectorName: string }>
   queue: Promise<void>
 }>()
 
@@ -103,7 +137,11 @@ export async function ariaSnapshotWithoutTextControlValues(
 ): Promise<string> {
   const page = locator.page()
   const redactionSelectorName = await selectorForContext(page.context())
-  const token = String(++nextRedactionToken)
+  const token = `${redactionModuleId}${++nextRedactionToken}`
+  const handle = await locator.elementHandle({ timeout: options.timeout })
+  if (!handle) throw new Error("ARIA snapshot target did not resolve to an element")
+  const frame = await handle.ownerFrame().finally(() => handle.dispose())
+  if (!frame) throw new Error("ARIA snapshot target is not attached to a frame")
   let snapshot: string | undefined
   let captureFailed = false
   let captureError: unknown
@@ -117,7 +155,7 @@ export async function ariaSnapshotWithoutTextControlValues(
   }
 
   try {
-    await cleanupRedaction(page, redactionSelectorName, token)
+    await cleanupRedaction(page, frame, redactionSelectorName, token)
   } catch (cleanupError) {
     if (captureFailed) {
       const cleanupReasons = cleanupError instanceof AggregateError ? cleanupError.errors : [cleanupError]
@@ -138,7 +176,7 @@ async function selectorForContext(context: BrowserContext): Promise<string> {
   const existing = contextSelectors.get(context)
   if (existing) return existing
 
-  const name = `bcariaredact${++nextRedactionSelector}`
+  const name = `bcariaredact${redactionModuleId}${++nextRedactionSelector}`
   const registration = selectors.register(
     name,
     { content: redactionSelectorSource },
@@ -151,23 +189,36 @@ async function selectorForContext(context: BrowserContext): Promise<string> {
   return registration
 }
 
-async function cleanupRedaction(page: Page, redactionSelectorName: string, token: string): Promise<void> {
+async function cleanupRedaction(page: Page, frame: Frame, redactionSelectorName: string, token: string): Promise<void> {
   let state = pageCleanup.get(page)
   if (!state) {
-    state = { pendingTokens: new Set(), queue: Promise.resolve() }
+    state = { pendingTokens: new Map(), queue: Promise.resolve() }
     pageCleanup.set(page, state)
   }
-  state.pendingTokens.add(token)
+  state.pendingTokens.set(token, { frame, selectorName: redactionSelectorName })
 
   const cleanup = state.queue.then(async () => {
-    const tokens = [...state.pendingTokens]
-    const results = await Promise.allSettled(page.frames().flatMap((frame) => tokens.map(async (pendingToken) => {
-      await frame.locator(`${redactionSelectorName}=off_${pendingToken}`).waitFor({ state: "attached", timeout: 1_000 })
-    })))
-    const failures = results.flatMap((result) => result.status === "rejected" ? [result.reason] : [])
+    const pending = [...state.pendingTokens]
+    const results = await Promise.allSettled(pending.map(async ([pendingToken, target]) => {
+      await target.frame.locator(`${target.selectorName}=off_${pendingToken}`).waitFor({ state: "attached", timeout: 1_000 })
+    }))
+    const failures: unknown[] = []
+    for (let index = 0; index < results.length; index++) {
+      const result = results[index]!
+      const pendingToken = pending[index]![0]
+      if (result.status === "fulfilled" || redactionContextIsGone(result.reason)) {
+        state.pendingTokens.delete(pendingToken)
+      } else {
+        failures.push(result.reason)
+      }
+    }
     if (failures.length > 0) throw new AggregateError(failures, redactionCleanupErrorMessage)
-    for (const pendingToken of tokens) state.pendingTokens.delete(pendingToken)
   })
   state.queue = cleanup.catch(() => {})
   await cleanup
+}
+
+function redactionContextIsGone(cause: unknown): boolean {
+  const kind = runtimeFailureKind(cause)
+  return kind === "context-destroyed" || kind === "context-missing" || kind === "target-closed"
 }

--- a/src/runtime-diagnostics.ts
+++ b/src/runtime-diagnostics.ts
@@ -14,7 +14,7 @@ export function runtimeFailureKind(cause: unknown): RuntimeFailureKind {
     if (/execution context was destroyed|context.*destroyed/i.test(message)) {
       return "context-destroyed"
     }
-    if (/cannot find context with (?:specified )?id|execution context.*(?:not found|not available|does not exist)|context.*detached frame/i.test(message)) {
+    if (/cannot find context with (?:specified )?id|execution context.*(?:not found|not available|does not exist)|context.*detached frame|frame (?:was|got) detached/i.test(message)) {
       return "context-missing"
     }
     if (/target page, context or browser has been closed|target closed|session closed/i.test(message)) {

--- a/test/execute-ergonomics.test.ts
+++ b/test/execute-ergonomics.test.ts
@@ -270,14 +270,19 @@ function ariaSnapshotFixture(options: {
     ? vi.fn().mockRejectedValue(options.cleanupError)
     : vi.fn().mockResolvedValue(undefined)
   const frame = { locator: vi.fn(() => ({ waitFor })) }
+  const unrelatedWaitFor = vi.fn().mockRejectedValue(new Error("Frame was detached"))
+  const unrelatedFrame = { locator: vi.fn(() => ({ waitFor: unrelatedWaitFor })) }
+  const dispose = vi.fn().mockResolvedValue(undefined)
+  const ownerFrame = vi.fn().mockResolvedValue(frame)
   const context = {}
-  const ownerPage = { context: () => context, frames: () => [frame] }
+  const ownerPage = { context: () => context, frames: () => [frame, unrelatedFrame] }
   const locator = {
+    elementHandle: vi.fn().mockResolvedValue({ dispose, ownerFrame }),
     locator: vi.fn(() => ({ ariaSnapshot })),
     page: vi.fn(() => ownerPage),
   } as unknown as Locator
   const page = { locator: vi.fn(() => locator) } as unknown as Pick<Page, "locator">
-  return { ariaSnapshot, frame, locator, page, waitFor }
+  return { ariaSnapshot, dispose, frame, locator, ownerFrame, page, unrelatedFrame, waitFor }
 }
 
 describe("ariaSnapshot helper", () => {
@@ -286,9 +291,11 @@ describe("ariaSnapshot helper", () => {
 
     await expect(createAriaSnapshotHelper(fixture.page)()).resolves.toBe('- textbox "Password"')
     expect(fixture.page.locator).toHaveBeenCalledWith("body")
+    expect(fixture.ownerFrame).toHaveBeenCalledOnce()
+    expect(fixture.dispose).toHaveBeenCalledOnce()
     expect(fixture.ariaSnapshot).toHaveBeenCalledWith({ timeout: defaultAriaSnapshotTimeoutMs })
     const activation = vi.mocked(fixture.locator.locator).mock.calls[0]?.[0]
-    expect(activation).toMatch(/^bcariaredact\d+=on_\d+$/)
+    expect(activation).toMatch(/^bcariaredact[a-f0-9]+=on_[a-f0-9]+$/)
     if (typeof activation !== "string") throw new Error("Expected redaction selector activation")
     expect(fixture.frame.locator).toHaveBeenCalledWith(activation.replace("=on_", "=off_"))
     expect(fixture.waitFor).toHaveBeenCalledWith({ state: "attached", timeout: 1_000 })
@@ -307,6 +314,24 @@ describe("ariaSnapshot helper", () => {
     if (typeof first !== "string" || typeof second !== "string") throw new Error("Expected redaction selector activations")
     expect(first.split("=")[0]).toBe(second.split("=")[0])
     expect(first).not.toBe(second)
+  })
+
+  it("keeps selector names and tokens unique across duplicate module instances", async () => {
+    const duplicateUrl = new URL("../src/aria-snapshot.ts?duplicate-test", import.meta.url).href
+    const duplicate = await import(duplicateUrl) as typeof import("../src/aria-snapshot.ts")
+    const fixture = ariaSnapshotFixture()
+
+    await Promise.all([
+      createAriaSnapshotHelper(fixture.page)(),
+      duplicate.ariaSnapshotWithoutTextControlValues(fixture.locator, { timeout: defaultAriaSnapshotTimeoutMs }),
+    ])
+
+    const activations = vi.mocked(fixture.locator.locator).mock.calls.map(([selector]) => selector)
+    expect(activations).toHaveLength(2)
+    if (!activations.every((activation) => typeof activation === "string")) throw new Error("Expected redaction selector activations")
+    const parts = activations.map((activation) => activation.split("=on_"))
+    expect(new Set(parts.map(([name]) => name)).size).toBe(2)
+    expect(new Set(parts.map(([, token]) => token)).size).toBe(2)
   })
 
   it("preserves selector and locator targets and accepts a short timeout", async () => {
@@ -340,6 +365,23 @@ describe("ariaSnapshot helper", () => {
     await expect(createAriaSnapshotHelper(fixture.page)()).rejects.toThrow(
       "Browser Control could not confirm ARIA snapshot value-redaction cleanup",
     )
+  })
+
+  it("does not clean an unrelated frame", async () => {
+    const fixture = ariaSnapshotFixture({ snapshot: '- textbox "Password"' })
+
+    await expect(createAriaSnapshotHelper(fixture.page)()).resolves.toBe('- textbox "Password"')
+    expect(fixture.unrelatedFrame.locator).not.toHaveBeenCalled()
+  })
+
+  it("treats a destroyed activation context as already cleaned", async () => {
+    const fixture = ariaSnapshotFixture({
+      snapshot: '- textbox "Password"',
+      cleanupError: new Error("Frame was detached"),
+    })
+
+    await expect(createAriaSnapshotHelper(fixture.page)()).resolves.toBe('- textbox "Password"')
+    expect(fixture.waitFor).toHaveBeenCalledOnce()
   })
 
   it("retries stale cleanup tokens before returning a later snapshot", async () => {

--- a/test/runtime-diagnostics.test.ts
+++ b/test/runtime-diagnostics.test.ts
@@ -21,6 +21,7 @@ describe("runtime diagnostics", () => {
       pageErrorCount: 0,
       handoffs: 0,
     })).toBe("execution-context/context-destroyed; pageClosed=false; urlChanged=true; mainFrameNavigations=1")
+    expect(runtimeFailureKind(new Error("Frame was detached"))).toBe("context-missing")
   })
 
   it("classifies cross-extension navigation failures", () => {


### PR DESCRIPTION
## What

Harden Browser Control `ariaSnapshot()` so custom ARIA value controls and rich editable content cannot enter tool output. This closes #51.

## Before / After

**Before:** the isolated-world mask recognized native text controls and the editable element itself. Custom slider/spinbutton values could contaminate ancestor accessible names, while SVG text, image labels, and open-shadow content below an editor remained visible. Cleanup also sent every token to every live frame, so unrelated frame churn could fail an otherwise successful snapshot.

**After:** value-bearing ARIA range roles are masked by role, editable containment follows the composed tree across SVG and open shadow roots, and accessible-name sources inside editors are omitted. Each module instance uses unique selector names and tokens. Cleanup runs only in the activation frame; a destroyed execution context is already clean, while other failures remain fail-closed and retryable.

Native button labels, select values, contenteditable root labels, and raw Playwright `locator.ariaSnapshot()` remain outside the redaction boundary.

## How

- `src/aria-snapshot.ts` separates native text controls, ARIA range roles, and editable descendants; tracks composed parents through shadow hosts; and stores pending cleanup against the exact Playwright `Frame`.
- `src/runtime-diagnostics.ts` classifies detached frames as missing execution contexts.
- `scripts/smoke.ts` covers custom values, SVG/image/shadow content, iframe content, concurrent guarded snapshots, restoration, and preserved labels.
- Unit tests cover unrelated frames, destroyed contexts, retry behavior, and duplicate module instances.
- README, PLAN, AGENTS, the installed skill contract, and a patch changeset are updated together.

## Scope

This changes only Browser Control’s guarded helper. It does not redact raw Playwright snapshots, select values, native button labels, or closed-shadow content.

PR #45 should remain draft until this release blocker is incorporated.

## Testing

- `pnpm typecheck`
- `pnpm test` (47 files, 450 tests)
- `pnpm build:cli`
- Independent headless Brave probe with synthetic slider/spinbutton, SVG, image, open-shadow, iframe, concurrent capture, and restoration assertions
- Duplicate-module concurrent real-browser probe using two loaded source module instances
- `SMOKE_CASE=local-forms pnpm smoke` was not run because the shared packaged `0.4.0` relay owns port `19989`; the test case was expanded without replacing that relay.

## Flow

```mermaid
sequenceDiagram
  participant Helper as ariaSnapshot helper
  participant Frame as Activation frame
  participant World as Isolated world
  Helper->>Frame: resolve target owner frame
  Helper->>World: activate unique redaction token
  Helper->>World: capture accessibility tree
  Helper->>Frame: deactivate only that token
  alt frame navigated or detached
    Frame-->>Helper: execution context gone
    Helper->>Helper: treat mask as already cleared
  else cleanup failed with live context
    Frame-->>Helper: cleanup error
    Helper->>Helper: retain token and fail closed
  end
```