### PR TITLE
chore(deps): update Effect to rc.111

### DIFF
--- a/.changeset/current-effect-rc.md
+++ b/.changeset/current-effect-rc.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Update Effect and the Node platform package from `4.0.0-beta.97` to `4.0.0-rc.111`, including current tagged errors and explicit MCP protocol adapters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,9 @@ local Node relay.
 - Each Browser Control session owns one default page and persistent JavaScript
   `state`; do not default to arbitrary shared tabs for normal execute calls.
 - Use stock `playwright-core` for v1.
-- Use Effect v4 / `effect-smol` for Node-side code. Treat
-  a local `effect-smol` checkout as the source of truth for
-  Effect APIs and patterns.
+- Use Effect v4 for Node-side code. Treat a local `Effect-TS/effect` checkout as
+  the source of truth for current Effect APIs and patterns; `effect-smol` is the
+  archived former v4 repository.
 - Prefer `Effect.fn` / `Effect.fnUntraced` for functions that return Effects,
   and use scoped resources (`Effect.acquireRelease`, `Effect.scoped`) for
   Playwright and relay lifecycles.

--- a/PLAN.md
+++ b/PLAN.md
@@ -371,8 +371,8 @@ reconciles existing client announcements, browser grouping, and page status.
 
 ### The relay owns orchestration
 
-- Node-side code uses Effect v4, with
-  a local `effect-smol` checkout as the API and pattern reference.
+- Node-side code uses Effect v4, with a local `Effect-TS/effect` checkout as the
+  current API and pattern reference.
 - Effect-returning functions prefer `Effect.fn` or `Effect.fnUntraced`.
 - Playwright and relay resources use scoped lifecycles.
 - Application configuration uses Effect `Config`; direct environment access is

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.97",
+    "@effect/platform-node": "4.0.0-rc.111",
     "acorn": "^8.17.0",
-    "effect": "4.0.0-beta.97",
+    "effect": "4.0.0-rc.111",
     "playwright-core": "^1.57.0",
     "ws": "^8.18.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.97
-        version: 4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1)
+        specifier: 4.0.0-rc.111
+        version: 4.0.0-rc.111(effect@4.0.0-rc.111)(redis@6.2.1)
       acorn:
         specifier: ^8.17.0
         version: 8.17.0
       effect:
-        specifier: 4.0.0-beta.97
-        version: 4.0.0-beta.97
+        specifier: 4.0.0-rc.111
+        version: 4.0.0-rc.111
       playwright-core:
         specifier: ^1.57.0
         version: 1.61.1
@@ -113,18 +113,18 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@effect/platform-node-shared@4.0.0-beta.97':
-    resolution: {integrity: sha512-sAlygOlDLLERk7fC24f7Aa4G3wkEbGyyMEileHTHU2fThiPYSGMqNRK1LLnNr17m2+JR7BHbycwXkJkM18BAQw==}
+  '@effect/platform-node-shared@4.0.0-rc.111':
+    resolution: {integrity: sha512-iES0Q9vmjhaUKqeW9ceonuD45MUg/Ouk08LzRSptZ+B5qB0w9WlRjDmUz5TJmY2betNop5FRI5k4AD4mtQt3Bw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.97
+      effect: ^4.0.0-rc.111
 
-  '@effect/platform-node@4.0.0-beta.97':
-    resolution: {integrity: sha512-Vd40VLh+Y08Bs37KWtbe9AgO2+t3RKZKGX9YC6ZKAcswu4tXR3CwSI7V2MN+GgS+ez/GLmqH1WrzDDlaIAxKPA==}
+  '@effect/platform-node@4.0.0-rc.111':
+    resolution: {integrity: sha512-oy1i7HsOGg/5r+DuBe5+ddmnUhnXmyZFPFPXZCBdO/RQpHK3PIFe1/2UMGxZE+ngDymrSksuQTSgQLF6P+MLqw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.97
-      ioredis: ^5.7.0
+      effect: ^4.0.0-rc.111
+      redis: '>=5.0.0 <7.0.0'
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -456,9 +456,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@ioredis/commands@1.10.0':
-    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -518,6 +515,42 @@ packages:
 
   '@oxc-project/types@0.137.0':
     resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+
+  '@redis/bloom@6.2.1':
+    resolution: {integrity: sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/client@6.2.1':
+    resolution: {integrity: sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@6.2.1':
+    resolution: {integrity: sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/search@6.2.1':
+    resolution: {integrity: sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
+
+  '@redis/time-series@6.2.1':
+    resolution: {integrity: sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.2.1
 
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
@@ -724,8 +757,8 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
-  cluster-key-slot@1.1.1:
-    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
   convert-source-map@2.0.0:
@@ -734,19 +767,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -760,8 +780,8 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  effect@4.0.0-beta.97:
-    resolution: {integrity: sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg==}
+  effect@4.0.0-rc.111:
+    resolution: {integrity: sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -822,9 +842,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  find-my-way-ts@0.1.6:
-    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -865,14 +882,6 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  ini@7.0.0:
-    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
-
-  ioredis@5.11.1:
-    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
-    engines: {node: '>=12.22.0'}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -906,9 +915,6 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-
-  kubernetes-types@1.30.0:
-    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1011,18 +1017,12 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
   msgpackr-extract@3.0.4:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
-  msgpackr@2.0.4:
-    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
-
-  multipasta@0.2.8:
-    resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
+  msgpackr@2.0.5:
+    resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
@@ -1120,13 +1120,9 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
-  redis-errors@1.2.0:
-    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
-    engines: {node: '>=4'}
-
-  redis-parser@3.0.0:
-    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
-    engines: {node: '>=4'}
+  redis@6.2.1:
+    resolution: {integrity: sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==}
+    engines: {node: '>= 20.0.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1184,9 +1180,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  standard-as-callback@2.1.0:
-    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
-
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -1221,10 +1214,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toml@4.1.2:
-    resolution: {integrity: sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==}
-    engines: {node: '>=20'}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1241,17 +1230,13 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.7.0:
-    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
-
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
-    hasBin: true
 
   vite@8.1.2:
     resolution: {integrity: sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==}
@@ -1349,6 +1334,18 @@ packages:
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1511,22 +1508,22 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@effect/platform-node-shared@4.0.0-beta.97(effect@4.0.0-beta.97)':
+  '@effect/platform-node-shared@4.0.0-rc.111(effect@4.0.0-rc.111)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.97
-      ws: 8.21.0
+      effect: 4.0.0-rc.111
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1)':
+  '@effect/platform-node@4.0.0-rc.111(effect@4.0.0-rc.111)(redis@6.2.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.97(effect@4.0.0-beta.97)
-      effect: 4.0.0-beta.97
-      ioredis: 5.11.1
+      '@effect/platform-node-shared': 4.0.0-rc.111(effect@4.0.0-rc.111)
+      effect: 4.0.0-rc.111
       mime: 4.1.0
-      undici: 8.7.0
+      redis: 6.2.1
+      undici: 8.10.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -1710,8 +1707,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.4
 
-  '@ioredis/commands@1.10.0': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@manypkg/find-root@1.1.0':
@@ -1768,6 +1763,26 @@ snapshots:
       fastq: 1.20.1
 
   '@oxc-project/types@0.137.0': {}
+
+  '@redis/bloom@6.2.1(@redis/client@6.2.1)':
+    dependencies:
+      '@redis/client': 6.2.1
+
+  '@redis/client@6.2.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@6.2.1(@redis/client@6.2.1)':
+    dependencies:
+      '@redis/client': 6.2.1
+
+  '@redis/search@6.2.1(@redis/client@6.2.1)':
+    dependencies:
+      '@redis/client': 6.2.1
+
+  '@redis/time-series@6.2.1(@redis/client@6.2.1)':
+    dependencies:
+      '@redis/client': 6.2.1
 
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
@@ -1928,7 +1943,7 @@ snapshots:
 
   chardet@2.2.0: {}
 
-  cluster-key-slot@1.1.1: {}
+  cluster-key-slot@1.1.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -1938,12 +1953,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
-  denque@2.1.0: {}
-
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -1952,18 +1961,11 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  effect@4.0.0-beta.97:
+  effect@4.0.0-rc.111:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0
-      find-my-way-ts: 0.1.6
-      ini: 7.0.0
-      kubernetes-types: 1.30.0
-      msgpackr: 2.0.4
-      multipasta: 0.2.8
-      toml: 4.1.2
-      uuid: 14.0.1
-      yaml: 2.9.0
+      msgpackr: 2.0.5
 
   enquirer@2.4.1:
     dependencies:
@@ -2066,8 +2068,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-my-way-ts@0.1.6: {}
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -2111,20 +2111,6 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  ini@7.0.0: {}
-
-  ioredis@5.11.1:
-    dependencies:
-      '@ioredis/commands': 1.10.0
-      cluster-key-slot: 1.1.1
-      debug: 4.4.3
-      denque: 2.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2153,8 +2139,6 @@ snapshots:
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  kubernetes-types@1.30.0: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2226,8 +2210,6 @@ snapshots:
 
   mri@1.2.0: {}
 
-  ms@2.1.3: {}
-
   msgpackr-extract@3.0.4:
     dependencies:
       node-gyp-build-optional-packages: 5.2.2
@@ -2240,11 +2222,9 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
-  msgpackr@2.0.4:
+  msgpackr@2.0.5:
     optionalDependencies:
       msgpackr-extract: 3.0.4
-
-  multipasta@0.2.8: {}
 
   nanoid@3.3.15: {}
 
@@ -2316,11 +2296,16 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  redis-errors@1.2.0: {}
-
-  redis-parser@3.0.0:
+  redis@6.2.1:
     dependencies:
-      redis-errors: 1.2.0
+      '@redis/bloom': 6.2.1(@redis/client@6.2.1)
+      '@redis/client': 6.2.1
+      '@redis/json': 6.2.1(@redis/client@6.2.1)
+      '@redis/search': 6.2.1(@redis/client@6.2.1)
+      '@redis/time-series': 6.2.1(@redis/client@6.2.1)
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   resolve-from@5.0.0: {}
 
@@ -2378,8 +2363,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  standard-as-callback@2.1.0: {}
-
   std-env@4.1.0: {}
 
   strip-ansi@6.0.1:
@@ -2405,8 +2388,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toml@4.1.2: {}
-
   tslib@2.8.1:
     optional: true
 
@@ -2420,11 +2401,9 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.7.0: {}
+  undici@8.10.0: {}
 
   universalify@0.1.2: {}
-
-  uuid@14.0.1: {}
 
   vite@8.1.2(@types/node@25.9.4)(esbuild@0.27.7)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -2478,4 +2457,7 @@ snapshots:
 
   ws@8.21.0: {}
 
-  yaml@2.9.0: {}
+  ws@8.21.3: {}
+
+  yaml@2.9.0:
+    optional: true

--- a/src/auth-profile.ts
+++ b/src/auth-profile.ts
@@ -51,7 +51,7 @@ export type AuthRunResult = {
   readonly durationMs: number
 }
 
-export class AuthProfileError extends Schema.TaggedErrorClass<AuthProfileError>()(
+export class AuthProfileError extends Schema.TaggedError<AuthProfileError>()(
   "AuthProfile.Error",
   {
     message: Schema.String,

--- a/src/authenticated-origin.ts
+++ b/src/authenticated-origin.ts
@@ -9,7 +9,7 @@ import type {
 const defaultTimeoutMs = 30_000
 const defaultMaxResponseBytes = 2_000_000
 
-export class AuthenticatedOriginError extends Schema.TaggedErrorClass<AuthenticatedOriginError>()(
+export class AuthenticatedOriginError extends Schema.TaggedError<AuthenticatedOriginError>()(
   "AuthenticatedOrigin.Error",
   {
     message: Schema.String,

--- a/src/browser-control-client.ts
+++ b/src/browser-control-client.ts
@@ -12,7 +12,7 @@ import type {
 
 export type Json = Schema.Schema.Type<typeof Schema.Json>
 
-export class ClientError extends Schema.TaggedErrorClass<ClientError>()(
+export class ClientError extends Schema.TaggedError<ClientError>()(
   "BrowserControlClient.Error",
   {
     message: Schema.String,
@@ -22,7 +22,7 @@ export class ClientError extends Schema.TaggedErrorClass<ClientError>()(
   },
 ) {}
 
-export class OriginMismatch extends Schema.TaggedErrorClass<OriginMismatch>()(
+export class OriginMismatch extends Schema.TaggedError<OriginMismatch>()(
   "AuthenticatedOrigin.OriginMismatch",
   {
     expectedOrigin: Schema.String,
@@ -31,7 +31,7 @@ export class OriginMismatch extends Schema.TaggedErrorClass<OriginMismatch>()(
   },
 ) {}
 
-export class HttpError extends Schema.TaggedErrorClass<HttpError>()(
+export class HttpError extends Schema.TaggedError<HttpError>()(
   "AuthenticatedOrigin.HttpError",
   {
     status: Schema.Number,
@@ -40,7 +40,7 @@ export class HttpError extends Schema.TaggedErrorClass<HttpError>()(
   },
 ) {}
 
-export class RequestFailed extends Schema.TaggedErrorClass<RequestFailed>()(
+export class RequestFailed extends Schema.TaggedError<RequestFailed>()(
   "AuthenticatedOrigin.RequestFailed",
   {
     method: Schema.String,
@@ -48,7 +48,7 @@ export class RequestFailed extends Schema.TaggedErrorClass<RequestFailed>()(
   },
 ) {}
 
-export class RequestOutcomeUnknown extends Schema.TaggedErrorClass<RequestOutcomeUnknown>()(
+export class RequestOutcomeUnknown extends Schema.TaggedError<RequestOutcomeUnknown>()(
   "AuthenticatedOrigin.RequestOutcomeUnknown",
   {
     method: Schema.String,
@@ -56,7 +56,7 @@ export class RequestOutcomeUnknown extends Schema.TaggedErrorClass<RequestOutcom
   },
 ) {}
 
-export class InvalidResponse extends Schema.TaggedErrorClass<InvalidResponse>()(
+export class InvalidResponse extends Schema.TaggedError<InvalidResponse>()(
   "AuthenticatedOrigin.InvalidResponse",
   {
     reason: Schema.Literals(["invalid-json", "too-large"]),
@@ -66,14 +66,14 @@ export class InvalidResponse extends Schema.TaggedErrorClass<InvalidResponse>()(
   },
 ) {}
 
-export class ResponseDecodeFailed extends Schema.TaggedErrorClass<ResponseDecodeFailed>()(
+export class ResponseDecodeFailed extends Schema.TaggedError<ResponseDecodeFailed>()(
   "AuthenticatedOrigin.ResponseDecodeFailed",
   {
     message: Schema.String,
   },
 ) {}
 
-export class SensitiveCaptureActive extends Schema.TaggedErrorClass<SensitiveCaptureActive>()(
+export class SensitiveCaptureActive extends Schema.TaggedError<SensitiveCaptureActive>()(
   "AuthenticatedOrigin.SensitiveCaptureActive",
   {
     message: Schema.String,

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -35,7 +35,7 @@ export const downloadCapabilityErrorMessage = "Downloads are unavailable in Brow
 const downloadGuardedPages = new WeakSet<Page>()
 const downloadGuardedContexts = new WeakSet<BrowserContext>()
 
-export class PlaywrightOperationError extends Schema.TaggedErrorClass<PlaywrightOperationError>()(
+export class PlaywrightOperationError extends Schema.TaggedError<PlaywrightOperationError>()(
   "Execute.PlaywrightOperationError",
   {
     message: Schema.String,
@@ -45,7 +45,7 @@ export class PlaywrightOperationError extends Schema.TaggedErrorClass<Playwright
   },
 ) {}
 
-export class SessionPageRecoveryError extends Schema.TaggedErrorClass<SessionPageRecoveryError>()(
+export class SessionPageRecoveryError extends Schema.TaggedError<SessionPageRecoveryError>()(
   "Execute.SessionPageRecoveryError",
   {
     message: Schema.String,
@@ -54,7 +54,7 @@ export class SessionPageRecoveryError extends Schema.TaggedErrorClass<SessionPag
   },
 ) {}
 
-export class TargetSelectionError extends Schema.TaggedErrorClass<TargetSelectionError>()(
+export class TargetSelectionError extends Schema.TaggedError<TargetSelectionError>()(
   "Execute.TargetSelectionError",
   {
     message: Schema.String,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,6 +1,6 @@
 import { NodeStdio } from "@effect/platform-node"
 import { Config, Context, Effect, Layer, Option } from "effect"
-import { McpSchema, McpServer } from "effect/unstable/ai"
+import { McpProtocol, McpSchema, McpServer } from "effect/unstable/ai"
 import fs from "node:fs/promises"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -435,7 +435,16 @@ export const runMcpServer: Effect.Effect<never, Error> = Layer.launch(
     relayLayer,
     Layer.effectDiscard(registerTools),
   ).pipe(
-    Layer.provide(McpServer.layerStdio({ name: "browser-control", version: browserControlVersion })),
+    Layer.provide(McpServer.layerStdio({
+      name: "browser-control",
+      version: browserControlVersion,
+      protocols: [
+        McpProtocol.v2025_06_18,
+        McpProtocol.v2025_11_25,
+        McpProtocol.v2025_03_26,
+        McpProtocol.v2024_11_05,
+      ],
+    })),
     Layer.provide(NodeStdio.layer),
     Layer.provide(RelayClient.layerFetch),
   ),

--- a/src/network-capture.ts
+++ b/src/network-capture.ts
@@ -44,7 +44,7 @@ export type NetworkCaptureResult = NetworkCaptureStatus & {
   readonly observedSecretRefs: readonly string[]
 }
 
-export class NetworkCaptureError extends Schema.TaggedErrorClass<NetworkCaptureError>()(
+export class NetworkCaptureError extends Schema.TaggedError<NetworkCaptureError>()(
   "NetworkCapture.Error",
   {
     message: Schema.String,

--- a/src/relay-client.ts
+++ b/src/relay-client.ts
@@ -56,7 +56,7 @@ export const extensionOriginsConfig = Config.string("BROWSER_CONTROL_EXTENSION_O
 
 export const endpointForPort = (port: number): string => `http://127.0.0.1:${port}`
 
-export class RelayUnreachable extends Schema.TaggedErrorClass<RelayUnreachable>()(
+export class RelayUnreachable extends Schema.TaggedError<RelayUnreachable>()(
   "RelayClient.RelayUnreachable",
   {
     message: Schema.String,
@@ -66,7 +66,7 @@ export class RelayUnreachable extends Schema.TaggedErrorClass<RelayUnreachable>(
   },
 ) {}
 
-export class RelayRejected extends Schema.TaggedErrorClass<RelayRejected>()(
+export class RelayRejected extends Schema.TaggedError<RelayRejected>()(
   "RelayClient.RelayRejected",
   {
     message: Schema.String,
@@ -76,7 +76,7 @@ export class RelayRejected extends Schema.TaggedErrorClass<RelayRejected>()(
   },
 ) {}
 
-export class RelayDecodeFailed extends Schema.TaggedErrorClass<RelayDecodeFailed>()(
+export class RelayDecodeFailed extends Schema.TaggedError<RelayDecodeFailed>()(
   "RelayClient.RelayDecodeFailed",
   {
     message: Schema.String,
@@ -85,7 +85,7 @@ export class RelayDecodeFailed extends Schema.TaggedErrorClass<RelayDecodeFailed
   },
 ) {}
 
-export class RelayEncodeFailed extends Schema.TaggedErrorClass<RelayEncodeFailed>()(
+export class RelayEncodeFailed extends Schema.TaggedError<RelayEncodeFailed>()(
   "RelayClient.RelayEncodeFailed",
   {
     message: Schema.String,
@@ -94,7 +94,7 @@ export class RelayEncodeFailed extends Schema.TaggedErrorClass<RelayEncodeFailed
   },
 ) {}
 
-export class RelayConfigInvalid extends Schema.TaggedErrorClass<RelayConfigInvalid>()(
+export class RelayConfigInvalid extends Schema.TaggedError<RelayConfigInvalid>()(
   "RelayClient.RelayConfigInvalid",
   {
     message: Schema.String,

--- a/src/relay-helpers.ts
+++ b/src/relay-helpers.ts
@@ -56,7 +56,7 @@ export function parseAdditionalExtensionOrigins(raw: string | undefined): string
 
 const maxCliBodyBytes = 1_000_000
 
-export class HttpRouteError extends Schema.TaggedErrorClass<HttpRouteError>()(
+export class HttpRouteError extends Schema.TaggedError<HttpRouteError>()(
   "HttpApi.HttpRouteError",
   { message: Schema.String, status: Schema.Number, code: RelayErrorCode },
 ) {}

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -20,7 +20,7 @@ export type EnsureRelayOptions = {
   readonly retryDelayMs?: number
 }
 
-export class RelayStartFailed extends Schema.TaggedErrorClass<RelayStartFailed>()(
+export class RelayStartFailed extends Schema.TaggedError<RelayStartFailed>()(
   "RelayLifecycle.RelayStartFailed",
   {
     message: Schema.String,
@@ -29,12 +29,12 @@ export class RelayStartFailed extends Schema.TaggedErrorClass<RelayStartFailed>(
   },
 ) {}
 
-export class ExtensionDisconnected extends Schema.TaggedErrorClass<ExtensionDisconnected>()(
+export class ExtensionDisconnected extends Schema.TaggedError<ExtensionDisconnected>()(
   "RelayLifecycle.ExtensionDisconnected",
   { message: Schema.String },
 ) {}
 
-export class ExtensionProtocolIncompatible extends Schema.TaggedErrorClass<ExtensionProtocolIncompatible>()(
+export class ExtensionProtocolIncompatible extends Schema.TaggedError<ExtensionProtocolIncompatible>()(
   "RelayLifecycle.ExtensionProtocolIncompatible",
   {
     message: Schema.String,

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -38,7 +38,7 @@ export type SessionHooks = {
   readonly onSessionsChanged?: (sessions: readonly PersistedSession[]) => unknown | Promise<unknown>
 }
 
-export class SessionError extends Schema.TaggedErrorClass<SessionError>()(
+export class SessionError extends Schema.TaggedError<SessionError>()(
   "BrowserControlSessions.SessionError",
   {
     message: Schema.String,

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -12,7 +12,7 @@ import { endpointForPort, portConfig } from "./relay-client.ts"
  * endpoint and migrated on the next write.
  */
 
-export class SessionStoreError extends Schema.TaggedErrorClass<SessionStoreError>()(
+export class SessionStoreError extends Schema.TaggedError<SessionStoreError>()(
   "SessionStore.SessionStoreError",
   {
     message: Schema.String,

--- a/src/target-registry.ts
+++ b/src/target-registry.ts
@@ -25,7 +25,7 @@ export interface TargetOwnership {
   releaseTargetOwnership(targetId: string, sessionId: string): TargetOwnershipChange
 }
 
-export class TargetOwnershipError extends Schema.TaggedErrorClass<TargetOwnershipError>()(
+export class TargetOwnershipError extends Schema.TaggedError<TargetOwnershipError>()(
   "TargetRegistry.TargetOwnershipError",
   {
     message: Schema.String,


### PR DESCRIPTION
## What

Update Browser Control from Effect `4.0.0-beta.97` to `4.0.0-rc.111`, keeping the Node platform package on the matching release candidate.

## How

- update `effect` and `@effect/platform-node` together and refresh the lockfile
- migrate schema-backed errors from `Schema.TaggedErrorClass` to the current `Schema.TaggedError` API
- explicitly configure MCP protocol adapters while preserving the prior `2025-06-18` fallback and dated compatibility revisions
- update repository guidance to use the current `Effect-TS/effect` checkout instead of archived `effect-smol`
- add a patch changeset

## Scope

This is only the Effect dependency/API migration. It does not change Browser Control relay, extension, or session behavior.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm run ci` (typecheck, 450 tests, CLI build, extension build, extension package)
- built MCP stdio initialization for `2025-11-25`, `2025-06-18`, `2025-03-26`, and `2024-11-05`
- `pnpm pack` and clean-consumer checks for the CLI, skill command, and public exports

Real-browser smoke was not run because the shared packaged relay owns port `19989`; this change does not replace or interrupt it.