### PR TITLE
fix(relay): replace stale managed relays

### DIFF
--- a/.changeset/fresh-relays-restart.md
+++ b/.changeset/fresh-relays-restart.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Automatically replace a stale detached relay with the current CLI build before running operational commands.

--- a/.changeset/fresh-relays-restart.md
+++ b/.changeset/fresh-relays-restart.md
@@ -2,4 +2,4 @@
 "@opencode-ai/browser-control": patch
 ---
 
-Automatically replace a stale detached relay with the current CLI build before running operational commands.
+Automatically replace a stale detached relay that supports guarded shutdown with the current CLI build before running operational commands, while older and foreground relays continue to fail closed with restart guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,9 @@ local Node relay.
   managed-relay process-fault diagnostics are retained with mode `0600` in
   `~/.browser-control/relay.log` so same-build restarts and session loss are
   diagnosable instead of appearing as eviction.
+- Operational commands may replace only an older managed relay after confirming
+  its exact instance id, and must wait for it to exit before starting the
+  current build. Never auto-stop source, foreground, or newer relays.
 - `dist/mcp.js` self-runs via the dedicated `src/mcp-main.ts` entrypoint. Do not
   add `process.argv[1] === import.meta.url` self-run guards to modules that get
   bundled into `dist/cli.js`; esbuild inlining makes the guard fire inside the

--- a/PLAN.md
+++ b/PLAN.md
@@ -464,6 +464,10 @@ relay reports both values so `doctor` can identify a stale long-running relay.
 It also reports an instance id, start time, and PID; bounded managed-relay
 process-fault diagnostics are retained locally so unexpected same-build
 restarts can be distinguished from session eviction.
+Operational commands replace an older managed relay only after confirming its
+exact instance id, then wait for that process to exit before starting the
+current build. Source runs, foreground relays, and newer builds fail closed with
+restart guidance instead of being terminated automatically.
 
 ## Known Limitations
 

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -346,8 +346,8 @@ Common diagnoses:
 - Incompatible extension protocol: update either the extension or npm package;
   exact extension and relay release versions do not need to match.
 - Stale relay build: operational commands automatically replace an older
-  detached managed relay. Source, foreground, and newer relays fail closed with
-  restart guidance instead of being stopped.
+  detached managed relay that advertises guarded shutdown. Older unsupported,
+  source, foreground, and newer relays fail closed with restart guidance.
 - `Target not found`: attach the intended tab, then select or adopt it using a
   unique URL substring or explicit index.
 - All targets disappeared: dismissing Chromium's debugging banner detaches every

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -345,8 +345,9 @@ Common diagnoses:
   extension only if its reconnect loop does not recover.
 - Incompatible extension protocol: update either the extension or npm package;
   exact extension and relay release versions do not need to match.
-- Stale relay build: operational commands reject it with restart guidance;
-  rebuild the CLI and restart the relay.
+- Stale relay build: operational commands automatically replace an older
+  detached managed relay. Source, foreground, and newer relays fail closed with
+  restart guidance instead of being stopped.
 - `Target not found`: attach the intended tab, then select or adopt it using a
   unique URL substring or explicit index.
 - All targets disappeared: dismissing Chromium's debugging banner detaches every

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { NodeRuntime, NodeServices } from "@effect/platform-node"
-import { Config, Console, Effect, FileSystem, Layer, Option } from "effect"
+import { Config, Console, Deferred, Effect, FileSystem, Layer, Option } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import path from "node:path"
 import process from "node:process"
@@ -200,10 +200,15 @@ const serve = Command.make(
     const additionalExtensionOrigins = parseAdditionalExtensionOrigins(yield* RelayClient.extensionOriginsConfig)
     yield* Effect.scoped(
       Effect.gen(function* () {
-        const relay = yield* startRelay({ port, additionalExtensionOrigins })
+        const shutdown = yield* Deferred.make<void>()
+        const relay = yield* startRelay({
+          port,
+          additionalExtensionOrigins,
+          shutdown: () => { Effect.runFork(Deferred.succeed(shutdown, undefined)) },
+        })
         yield* Console.log(`browser-control relay listening at ${relay.url}`)
         yield* Console.log("Load extension/dist as an unpacked extension and click the toolbar button to attach a tab.")
-        yield* Effect.never
+        yield* Deferred.await(shutdown)
       }),
     )
   }),

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -27,6 +27,7 @@ import {
   NetworkStopRequest,
   RecordingStartRequest,
   RecordingTargetRequest,
+  RelayShutdownRequest,
   SessionAdoptRequest,
   SessionIdRequest,
   SessionEnsureRequest,
@@ -43,7 +44,8 @@ export function createHttpRequestHandler(options: {
   readonly host: string
   readonly port: number
   readonly browserId: string
-  readonly relayInstance: { readonly id: string; readonly startedAt: string; readonly pid: number }
+  readonly relayInstance: { readonly id: string; readonly startedAt: string; readonly pid: number; readonly managed: boolean }
+  readonly shutdown: () => void
   readonly extensionStatus: () => Pick<ExtensionStatus,
     "connected" | "version" | "protocolVersion" | "protocolCompatible" | "protocolLegacy" | "cdpClients"
   >
@@ -76,7 +78,23 @@ export function createHttpRequestHandler(options: {
         instanceId: options.relayInstance.id,
         startedAt: options.relayInstance.startedAt,
         pid: options.relayInstance.pid,
+        managed: options.relayInstance.managed,
       })
+      return
+    }
+    if (pathname === "/shutdown" && request.method === "POST") {
+      runRequestEffect(response, Effect.gen(function* () {
+        const body = yield* decodeRequest(RelayShutdownRequest, yield* readJsonBody(request), "relay shutdown")
+        if (!options.relayInstance.managed || body.instanceId !== options.relayInstance.id) {
+          return yield* Effect.fail(new HttpRouteError({
+            message: "Relay shutdown does not match the active managed instance",
+            status: 409,
+            code: "invalid-request",
+          }))
+        }
+        response.once("finish", options.shutdown)
+        sendJson(response, { stopping: true })
+      }))
       return
     }
     if (pathname === "/json/version") {

--- a/src/relay-client.ts
+++ b/src/relay-client.ts
@@ -108,7 +108,7 @@ export type RelayClientError = RelayUnreachable | RelayRejected | RelayDecodeFai
 export interface Interface {
   readonly endpoint: string
   readonly version: Effect.Effect<RelayVersion, RelayClientError>
-  readonly shutdown: (instanceId: string) => Effect.Effect<RelayShutdownResponse, RelayClientError>
+  readonly shutdown?: (instanceId: string) => Effect.Effect<RelayShutdownResponse, RelayClientError>
   readonly extensionStatus: Effect.Effect<ExtensionStatus, RelayClientError>
   readonly targets: Effect.Effect<readonly TargetSummary[], RelayClientError>
   readonly sessions: Effect.Effect<readonly SessionSummary[], RelayClientError>

--- a/src/relay-client.ts
+++ b/src/relay-client.ts
@@ -25,6 +25,7 @@ import {
   RecordingStopResponse,
   type RecordingTargetRequest,
   RelayErrorCode,
+  RelayShutdownResponse,
   RelayVersion,
   SessionAdoptResponse,
   SessionContainer,
@@ -107,6 +108,7 @@ export type RelayClientError = RelayUnreachable | RelayRejected | RelayDecodeFai
 export interface Interface {
   readonly endpoint: string
   readonly version: Effect.Effect<RelayVersion, RelayClientError>
+  readonly shutdown: (instanceId: string) => Effect.Effect<RelayShutdownResponse, RelayClientError>
   readonly extensionStatus: Effect.Effect<ExtensionStatus, RelayClientError>
   readonly targets: Effect.Effect<readonly TargetSummary[], RelayClientError>
   readonly sessions: Effect.Effect<readonly SessionSummary[], RelayClientError>
@@ -241,6 +243,7 @@ export const make = Effect.fn("RelayClient.make")(function* (options?: { readonl
   return Service.of({
     endpoint,
     version: getJson("/version", RelayVersion),
+    shutdown: (instanceId) => postJson("/shutdown", { instanceId }, RelayShutdownResponse),
     extensionStatus: getJson("/extension/status", ExtensionStatus),
     targets: getJson("/json/list", TargetSummaries),
     sessions: getJson("/cli/sessions", SessionsContainer).pipe(Effect.map((container) => container.sessions)),

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -15,10 +15,13 @@ export type RelayReadiness = {
 export type EnsureRelayOptions = {
   readonly relay: RelayClient.Interface
   readonly start?: Effect.Effect<void, Error>
+  readonly stop?: (version: RelayVersion) => Effect.Effect<void, Error>
   readonly buildId?: string
   readonly retryTimes?: number
   readonly retryDelayMs?: number
 }
+
+class RelayStillRunning extends Error {}
 
 export class RelayStartFailed extends Schema.TaggedError<RelayStartFailed>()(
   "RelayLifecycle.RelayStartFailed",
@@ -58,7 +61,51 @@ export const ensureRelay = Effect.fn("RelayLifecycle.ensureRelay")(function* (op
   const initial = yield* Effect.result(probe)
   if (initial._tag === "Success") {
     const buildProblem = relayBuildProblem(initial.success, buildId)
-    return { version: initial.success, started: false, ...(buildProblem ? { buildProblem } : {}) } satisfies RelayReadiness
+    if (!buildProblem) {
+      return { version: initial.success, started: false } satisfies RelayReadiness
+    }
+
+    const restart = yield* prepareStaleRelayRestart({
+      relay: options.relay,
+      version: initial.success,
+      currentBuildId: buildId,
+      ...(options.stop ? { stop: options.stop } : {}),
+    })
+    if (restart._tag === "Unsupported") {
+      return { version: initial.success, started: false, buildProblem } satisfies RelayReadiness
+    }
+    if (restart._tag === "Changed") {
+      const replacementProblem = relayBuildProblem(restart.version, buildId)
+      return {
+        version: restart.version,
+        started: false,
+        ...(replacementProblem ? { buildProblem: replacementProblem } : {}),
+      } satisfies RelayReadiness
+    }
+
+    const replacement = yield* waitForRelayExitOrReplacement({
+      relay: options.relay,
+      version: initial.success,
+      ...(options.retryTimes === undefined ? {} : { retryTimes: options.retryTimes }),
+      ...(options.retryDelayMs === undefined ? {} : { retryDelayMs: options.retryDelayMs }),
+    })
+    if (replacement) {
+      const replacementProblem = relayBuildProblem(replacement, buildId)
+      return {
+        version: replacement,
+        started: false,
+        ...(replacementProblem ? { buildProblem: replacementProblem } : {}),
+      } satisfies RelayReadiness
+    }
+
+    yield* options.start ?? startManagedRelay()
+    const version = yield* waitForRelayReady(options)
+    const replacementProblem = relayBuildProblem(version, buildId)
+    return {
+      version,
+      started: true,
+      ...(replacementProblem ? { buildProblem: replacementProblem } : {}),
+    } satisfies RelayReadiness
   }
   const relayWasAbsent = isRelayUnreachable(initial.failure)
   if (!relayWasAbsent && !isRelayStarting(initial.failure)) {
@@ -66,7 +113,13 @@ export const ensureRelay = Effect.fn("RelayLifecycle.ensureRelay")(function* (op
   }
 
   if (relayWasAbsent) yield* options.start ?? startManagedRelay()
-  const version = yield* probe.pipe(
+  const version = yield* waitForRelayReady(options)
+  const buildProblem = relayBuildProblem(version, buildId)
+  return { version, started: relayWasAbsent, ...(buildProblem ? { buildProblem } : {}) } satisfies RelayReadiness
+})
+
+function waitForRelayReady(options: EnsureRelayOptions): Effect.Effect<RelayVersion, Error | RelayClient.RelayClientError> {
+  return options.relay.version.pipe(
     Effect.retry({
       times: options.retryTimes ?? 200,
       schedule: Schedule.spaced(options.retryDelayMs ?? 50),
@@ -80,9 +133,81 @@ export const ensureRelay = Effect.fn("RelayLifecycle.ensureRelay")(function* (op
       })
       : error),
   )
-  const buildProblem = relayBuildProblem(version, buildId)
-  return { version, started: relayWasAbsent, ...(buildProblem ? { buildProblem } : {}) } satisfies RelayReadiness
-})
+}
+
+function prepareStaleRelayRestart(options: {
+  readonly relay: RelayClient.Interface
+  readonly version: RelayVersion
+  readonly currentBuildId: string
+  readonly stop?: (version: RelayVersion) => Effect.Effect<void, Error>
+}): Effect.Effect<
+  { readonly _tag: "Stopped" } | { readonly _tag: "Changed"; readonly version: RelayVersion } | { readonly _tag: "Unsupported" },
+  Error | RelayClient.RelayClientError
+> {
+  return Effect.gen(function* () {
+    const confirmed = yield* Effect.result(options.relay.version)
+    if (confirmed._tag === "Failure") {
+      if (isRelayUnreachable(confirmed.failure)) return { _tag: "Stopped" } as const
+      return yield* Effect.fail(confirmed.failure)
+    }
+    if (!isSameRelayInstance(options.version, confirmed.success)) {
+      return { _tag: "Changed", version: confirmed.success } as const
+    }
+    if (options.stop) {
+      yield* options.stop(confirmed.success)
+    } else {
+      const instanceId = confirmed.success.instanceId
+      if (
+        confirmed.success.managed !== true
+        || !instanceId
+        || !isNewerBuild(options.currentBuildId, confirmed.success.buildId)
+      ) {
+        return { _tag: "Unsupported" } as const
+      }
+      yield* options.relay.shutdown(instanceId).pipe(
+        Effect.catch((error) => isRelayUnreachable(error) || isRelayInstanceChanged(error)
+          ? Effect.void
+          : Effect.fail(error)),
+      )
+    }
+    return { _tag: "Stopped" } as const
+  })
+}
+
+function waitForRelayExitOrReplacement(options: {
+  readonly relay: RelayClient.Interface
+  readonly version: RelayVersion
+  readonly retryTimes?: number
+  readonly retryDelayMs?: number
+}): Effect.Effect<RelayVersion | undefined, Error | RelayClient.RelayClientError> {
+  return options.relay.version.pipe(
+    Effect.flatMap((version) => isSameRelayInstance(options.version, version)
+      ? Effect.fail(new RelayStillRunning("Stale Browser Control relay is still running"))
+      : Effect.succeed(version)),
+    Effect.catch((error) => isRelayUnreachable(error) ? Effect.succeed(undefined) : Effect.fail(error)),
+    Effect.retry({
+      times: options.retryTimes ?? 200,
+      schedule: Schedule.spaced(options.retryDelayMs ?? 50),
+      while: (error) => error instanceof RelayStillRunning || isRelayStarting(error),
+    }),
+  )
+}
+
+function isSameRelayInstance(left: RelayVersion, right: RelayVersion): boolean {
+  if (left.instanceId || right.instanceId) return left.instanceId !== undefined && left.instanceId === right.instanceId
+  return left.pid !== undefined && right.pid !== undefined && left.pid === right.pid
+}
+
+function isNewerBuild(current: string, running: string | undefined): boolean {
+  if (!running) return false
+  const currentTime = Date.parse(current)
+  const runningTime = Date.parse(running)
+  return Number.isFinite(currentTime) && Number.isFinite(runningTime) && currentTime > runningTime
+}
+
+function isRelayInstanceChanged(error: unknown): boolean {
+  return error instanceof RelayClient.RelayRejected && error.status === 409
+}
 
 export const ensureExtensionConnected = Effect.fn("RelayLifecycle.ensureExtensionConnected")(function* (options: {
   readonly relay: RelayClient.Interface

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -15,7 +15,6 @@ export type RelayReadiness = {
 export type EnsureRelayOptions = {
   readonly relay: RelayClient.Interface
   readonly start?: Effect.Effect<void, Error>
-  readonly stop?: (version: RelayVersion) => Effect.Effect<void, Error>
   readonly buildId?: string
   readonly retryTimes?: number
   readonly retryDelayMs?: number
@@ -69,7 +68,6 @@ export const ensureRelay = Effect.fn("RelayLifecycle.ensureRelay")(function* (op
       relay: options.relay,
       version: initial.success,
       currentBuildId: buildId,
-      ...(options.stop ? { stop: options.stop } : {}),
     })
     if (restart._tag === "Unsupported") {
       return { version: initial.success, started: false, buildProblem } satisfies RelayReadiness
@@ -139,7 +137,6 @@ function prepareStaleRelayRestart(options: {
   readonly relay: RelayClient.Interface
   readonly version: RelayVersion
   readonly currentBuildId: string
-  readonly stop?: (version: RelayVersion) => Effect.Effect<void, Error>
 }): Effect.Effect<
   { readonly _tag: "Stopped" } | { readonly _tag: "Changed"; readonly version: RelayVersion } | { readonly _tag: "Unsupported" },
   Error | RelayClient.RelayClientError
@@ -153,23 +150,19 @@ function prepareStaleRelayRestart(options: {
     if (!isSameRelayInstance(options.version, confirmed.success)) {
       return { _tag: "Changed", version: confirmed.success } as const
     }
-    if (options.stop) {
-      yield* options.stop(confirmed.success)
-    } else {
-      const instanceId = confirmed.success.instanceId
-      if (
-        confirmed.success.managed !== true
-        || !instanceId
-        || !isNewerBuild(options.currentBuildId, confirmed.success.buildId)
-      ) {
-        return { _tag: "Unsupported" } as const
-      }
-      yield* options.relay.shutdown(instanceId).pipe(
-        Effect.catch((error) => isRelayUnreachable(error) || isRelayInstanceChanged(error)
-          ? Effect.void
-          : Effect.fail(error)),
-      )
+    const instanceId = confirmed.success.instanceId
+    if (
+      confirmed.success.managed !== true
+      || !instanceId
+      || !isNewerBuild(options.currentBuildId, confirmed.success.buildId)
+    ) {
+      return { _tag: "Unsupported" } as const
     }
+    yield* options.relay.shutdown(instanceId).pipe(
+      Effect.catch((error) => isRelayUnreachable(error) || isRelayInstanceChanged(error)
+        ? Effect.void
+        : Effect.fail(error)),
+    )
     return { _tag: "Stopped" } as const
   })
 }

--- a/src/relay-lifecycle.ts
+++ b/src/relay-lifecycle.ts
@@ -151,14 +151,16 @@ function prepareStaleRelayRestart(options: {
       return { _tag: "Changed", version: confirmed.success } as const
     }
     const instanceId = confirmed.success.instanceId
+    const shutdown = options.relay.shutdown
     if (
       confirmed.success.managed !== true
       || !instanceId
+      || !shutdown
       || !isNewerBuild(options.currentBuildId, confirmed.success.buildId)
     ) {
       return { _tag: "Unsupported" } as const
     }
-    yield* options.relay.shutdown(instanceId).pipe(
+    yield* shutdown(instanceId).pipe(
       Effect.catch((error) => isRelayUnreachable(error) || isRelayInstanceChanged(error)
         ? Effect.void
         : Effect.fail(error)),

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -257,9 +257,22 @@ export const RelayVersion = Schema.Struct({
   instanceId: Schema.optionalKey(Schema.String),
   startedAt: Schema.optionalKey(Schema.String),
   pid: Schema.optionalKey(Schema.Number),
+  managed: Schema.optionalKey(Schema.Boolean),
 })
 
 export interface RelayVersion extends Schema.Schema.Type<typeof RelayVersion> {}
+
+export const RelayShutdownRequest = Schema.Struct({
+  instanceId: Schema.NonEmptyString,
+})
+
+export interface RelayShutdownRequest extends Schema.Schema.Type<typeof RelayShutdownRequest> {}
+
+export const RelayShutdownResponse = Schema.Struct({
+  stopping: Schema.Literal(true),
+})
+
+export interface RelayShutdownResponse extends Schema.Schema.Type<typeof RelayShutdownResponse> {}
 
 export const NetworkContentMode = Schema.Literals(["omit", "embed"])
 

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -67,6 +67,7 @@ export const startRelay = Effect.fn("Relay.start")(function* (options: {
   readonly releaseTargetGraceMs?: number
   readonly sessionCatalogPath?: string | null
   readonly additionalExtensionOrigins?: readonly string[]
+  readonly shutdown?: () => void
 } = {}) {
   yield* installRelayProcessGuard
   return yield* Effect.acquireRelease(makeRelay(options), (server) => {
@@ -151,6 +152,7 @@ const makeRelay = Effect.fnUntraced(function* (options: {
   readonly releaseTargetGraceMs?: number
   readonly sessionCatalogPath?: string | null
   readonly additionalExtensionOrigins?: readonly string[]
+  readonly shutdown?: () => void
 } = {}) {
   const host = defaultHost
   const port = options.port ?? defaultPort
@@ -503,13 +505,14 @@ const makeRelay = Effect.fnUntraced(function* (options: {
     refreshPageStatus(tabId)
     refreshTabGrouping(tabId)
   }
-  const managed = yield* Config.boolean("BROWSER_CONTROL_MANAGED_RELAY").pipe(Config.withDefault(false))
+  const managed = options.shutdown !== undefined
+    && (yield* Config.boolean("BROWSER_CONTROL_MANAGED_RELAY").pipe(Config.withDefault(false)))
   const relayRequestHandler = createHttpRequestHandler({
     host,
     port,
     browserId,
     relayInstance: { id: browserId, startedAt: new Date().toISOString(), pid: process.pid, managed },
-    shutdown: () => process.kill(process.pid, "SIGTERM"),
+    shutdown: options.shutdown ?? (() => {}),
     registry,
     recordingRelay,
     sessions,

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -503,11 +503,13 @@ const makeRelay = Effect.fnUntraced(function* (options: {
     refreshPageStatus(tabId)
     refreshTabGrouping(tabId)
   }
+  const managed = yield* Config.boolean("BROWSER_CONTROL_MANAGED_RELAY").pipe(Config.withDefault(false))
   const relayRequestHandler = createHttpRequestHandler({
     host,
     port,
     browserId,
-    relayInstance: { id: browserId, startedAt: new Date().toISOString(), pid: process.pid },
+    relayInstance: { id: browserId, startedAt: new Date().toISOString(), pid: process.pid, managed },
+    shutdown: () => process.kill(process.pid, "SIGTERM"),
     registry,
     recordingRelay,
     sessions,

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -37,7 +37,8 @@ describe("HTTP request schemas", () => {
     const sessions = new BrowserControlSessions(`http://127.0.0.1:${port}`, undefined, undefined, registry)
     sessions.createNew("beta")
     handler = createHttpRequestHandler({
-      relayInstance: { id: "relay-test", startedAt: "2026-07-19T00:00:00.000Z", pid: 123 },
+      relayInstance: { id: "relay-test", startedAt: "2026-07-19T00:00:00.000Z", pid: 123, managed: false },
+      shutdown: () => {},
       host: "127.0.0.1",
       port,
       browserId: "test-browser",

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -64,6 +64,11 @@ describe("HTTP request schemas", () => {
         instanceId: "relay-test",
         startedAt: "2026-07-19T00:00:00.000Z",
         pid: 123,
+        managed: false,
+      })
+      await expect(postJson(port, "/shutdown", { instanceId: "relay-test" })).resolves.toMatchObject({
+        status: 409,
+        body: { error: expect.stringContaining("does not match the active managed instance"), code: "invalid-request" },
       })
       const extension = await fetch(`http://127.0.0.1:${port}/extension/status`).then((response) => response.json())
       expect(extension).toMatchObject({
@@ -137,6 +142,54 @@ describe("HTTP request schemas", () => {
         status: 409,
         body: { error: expect.stringContaining("already adopted by session alpha"), code: "target-owned" },
       })
+    } finally {
+      await close(server)
+    }
+  })
+
+  it("shuts down only the matching managed relay instance", async () => {
+    let handler: ReturnType<typeof createHttpRequestHandler> | undefined
+    let shutdowns = 0
+    const server = http.createServer((request, response) => {
+      if (!handler) {
+        response.writeHead(503).end()
+        return
+      }
+      handler(request, response)
+    })
+    await listen(server)
+    const address = server.address()
+    if (!address || typeof address === "string") throw new Error("test server did not bind a TCP port")
+    const port = address.port
+    const registry = new TargetRegistry()
+    handler = createHttpRequestHandler({
+      relayInstance: { id: "managed-relay", startedAt: "2026-08-23T00:00:00.000Z", pid: 456, managed: true },
+      shutdown: () => { shutdowns++ },
+      host: "127.0.0.1",
+      port,
+      browserId: "test-browser",
+      extensionStatus: () => ({ connected: false, version: null, protocolVersion: null, protocolCompatible: null, protocolLegacy: null }),
+      recordingRelay: new RecordingRelay({
+        isExtensionConnected: () => false,
+        sendToExtension: async () => ({}),
+        sendDebuggerCommand: async () => ({}),
+      }),
+      registry,
+      sessions: new BrowserControlSessions(`http://127.0.0.1:${port}`, undefined, undefined, registry),
+    })
+
+    try {
+      await expect(postJson(port, "/shutdown", { instanceId: "other-relay" })).resolves.toMatchObject({
+        status: 409,
+        body: { code: "invalid-request" },
+      })
+      expect(shutdowns).toBe(0)
+
+      await expect(postJson(port, "/shutdown", { instanceId: "managed-relay" })).resolves.toEqual({
+        status: 200,
+        body: { stopping: true },
+      })
+      expect(shutdowns).toBe(1)
     } finally {
       await close(server)
     }

--- a/test/relay-client.test.ts
+++ b/test/relay-client.test.ts
@@ -68,7 +68,7 @@ const session = {
 describe("RelayClient", () => {
   it("sends the guarded relay shutdown request", async () => {
     routes.set("POST /shutdown", { status: 200, body: { stopping: true } })
-    const result = await withClient((client) => client.shutdown("relay-instance"))
+    const result = await withClient((client) => client.shutdown!("relay-instance"))
     expect(result).toEqual({ stopping: true })
     expect(lastRequestBody).toEqual({ instanceId: "relay-instance" })
   })

--- a/test/relay-client.test.ts
+++ b/test/relay-client.test.ts
@@ -66,6 +66,13 @@ const session = {
 }
 
 describe("RelayClient", () => {
+  it("sends the guarded relay shutdown request", async () => {
+    routes.set("POST /shutdown", { status: 200, body: { stopping: true } })
+    const result = await withClient((client) => client.shutdown("relay-instance"))
+    expect(result).toEqual({ stopping: true })
+    expect(lastRequestBody).toEqual({ instanceId: "relay-instance" })
+  })
+
   it("decodes sessions", async () => {
     routes.set("GET /cli/sessions", { status: 200, body: { sessions: [session] } })
     const sessions = await withClient((client) => client.sessions)

--- a/test/relay-lifecycle.test.ts
+++ b/test/relay-lifecycle.test.ts
@@ -130,15 +130,16 @@ describe("relay lifecycle", () => {
     let starts = 0
     const client = relay({
       version: Effect.suspend(() => running ? Effect.succeed(running) : Effect.fail(unreachable())),
+      shutdown: () => Effect.sync(() => {
+        stops++
+        running = undefined
+        return { stopping: true as const }
+      }),
     })
 
     const result = await Effect.runPromise(ensureRelay({
       relay: client,
       buildId: current.buildId,
-      stop: () => Effect.sync(() => {
-        stops++
-        running = undefined
-      }),
       start: Effect.sync(() => {
         starts++
         running = current
@@ -158,12 +159,15 @@ describe("relay lifecycle", () => {
     let stops = 0
     const client = relay({
       version: Effect.sync(() => ++probes === 1 ? stale : current),
+      shutdown: () => Effect.sync(() => {
+        stops++
+        return { stopping: true as const }
+      }),
     })
 
     const result = await Effect.runPromise(ensureRelay({
       relay: client,
       buildId: current.buildId,
-      stop: () => Effect.sync(() => { stops++ }),
       start: Effect.die("should not start"),
       retryDelayMs: 0,
     }))

--- a/test/relay-lifecycle.test.ts
+++ b/test/relay-lifecycle.test.ts
@@ -17,10 +17,12 @@ const version = { version: "0.1.0", buildId: "build-current" }
 function relay(options: {
   readonly version: Effect.Effect<typeof version, RelayClient.RelayClientError>
   readonly extensionStatus?: RelayClient.Interface["extensionStatus"]
+  readonly shutdown?: RelayClient.Interface["shutdown"]
 }): RelayClient.Interface {
   return {
     endpoint: "http://127.0.0.1:19989",
     version: options.version,
+    shutdown: options.shutdown ?? (() => Effect.die("unexpected relay shutdown")),
     extensionStatus: options.extensionStatus ?? Effect.succeed({ connected: true, version: "0.0.11", activeTargets: 0 }),
   } as RelayClient.Interface
 }
@@ -110,7 +112,7 @@ describe("relay lifecycle", () => {
     expect(starts).toBe(0)
   })
 
-  it("reports a stale relay instead of silently using it", async () => {
+  it("reports a stale relay that has no safe process identity", async () => {
     const result = await Effect.runPromise(ensureRelay({
       relay: relay({ version: Effect.succeed({ ...version, buildId: "build-old" }) }),
       buildId: "build-current",
@@ -118,6 +120,102 @@ describe("relay lifecycle", () => {
     }))
 
     expect(result.buildProblem).toContain("does not match CLI build")
+  })
+
+  it("replaces a stale relay with the current build", async () => {
+    const current = { ...version, buildId: "2026-08-04T12:00:00.000Z" }
+    const stale = { ...version, buildId: "2026-08-03T12:00:00.000Z", instanceId: "stale", pid: 123, managed: true }
+    let running: typeof stale | typeof current | undefined = stale
+    let stops = 0
+    let starts = 0
+    const client = relay({
+      version: Effect.suspend(() => running ? Effect.succeed(running) : Effect.fail(unreachable())),
+    })
+
+    const result = await Effect.runPromise(ensureRelay({
+      relay: client,
+      buildId: current.buildId,
+      stop: () => Effect.sync(() => {
+        stops++
+        running = undefined
+      }),
+      start: Effect.sync(() => {
+        starts++
+        running = current
+      }),
+      retryDelayMs: 0,
+    }))
+
+    expect(result).toEqual({ version: current, started: true })
+    expect(stops).toBe(1)
+    expect(starts).toBe(1)
+  })
+
+  it("does not stop a relay instance that changed after the stale probe", async () => {
+    const stale = { ...version, buildId: "2026-08-03T12:00:00.000Z", instanceId: "stale", pid: 123, managed: true }
+    const current = { ...version, buildId: "2026-08-04T12:00:00.000Z", pid: 123, managed: true }
+    let probes = 0
+    let stops = 0
+    const client = relay({
+      version: Effect.sync(() => ++probes === 1 ? stale : current),
+    })
+
+    const result = await Effect.runPromise(ensureRelay({
+      relay: client,
+      buildId: current.buildId,
+      stop: () => Effect.sync(() => { stops++ }),
+      start: Effect.die("should not start"),
+      retryDelayMs: 0,
+    }))
+
+    expect(result).toEqual({ version: current, started: false })
+    expect(stops).toBe(0)
+  })
+
+  it("observes a concurrent replacement when stale shutdown loses the race", async () => {
+    const stale = { ...version, buildId: "2026-08-03T12:00:00.000Z", instanceId: "stale", pid: 123, managed: true }
+    const current = { ...version, buildId: "2026-08-04T12:00:00.000Z", instanceId: "current", pid: 456, managed: true }
+    let probes = 0
+    const client = relay({
+      version: Effect.sync(() => ++probes <= 2 ? stale : current),
+      shutdown: () => Effect.fail(new RelayClient.RelayRejected({
+        message: "Relay shutdown does not match the active managed instance",
+        status: 409,
+        path: "/shutdown",
+        code: "invalid-request",
+      })),
+    })
+
+    const result = await Effect.runPromise(ensureRelay({
+      relay: client,
+      buildId: current.buildId,
+      start: Effect.die("should not start"),
+      retryDelayMs: 0,
+    }))
+
+    expect(result).toEqual({ version: current, started: false })
+  })
+
+  it("does not replace a managed relay with an older CLI build", async () => {
+    const newer = { ...version, buildId: "2026-08-04T12:00:00.000Z", instanceId: "newer", pid: 456, managed: true }
+    let shutdowns = 0
+    const client = relay({
+      version: Effect.succeed(newer),
+      shutdown: () => Effect.sync(() => {
+        shutdowns++
+        return { stopping: true as const }
+      }),
+    })
+
+    const result = await Effect.runPromise(ensureRelay({
+      relay: client,
+      buildId: "2026-08-03T12:00:00.000Z",
+      start: Effect.die("should not start"),
+      retryDelayMs: 0,
+    }))
+
+    expect(result.buildProblem).toContain("does not match CLI build")
+    expect(shutdowns).toBe(0)
   })
 
   it("waits for the extension to reconnect after relay startup", async () => {


### PR DESCRIPTION
## What

Operational commands now replace an older detached managed relay with the current CLI build instead of failing with manual restart guidance. Replacement is guarded by build ordering and exact relay instance identity.

## Before / After

**Before:** A rebuilt or updated CLI could find the old detached relay still occupying the endpoint. Operational commands rejected that relay as stale, requiring a manual process restart before Browser Control could continue.

**After:** If the older relay advertises guarded managed shutdown, the CLI confirms its exact instance, asks it to close through its normal Effect scope, waits for the endpoint to become free, and starts the current build. Unsupported old relays, source runs, foreground relays, and newer builds still fail closed with restart guidance.

## How

- `src/relay-schema.ts` and `src/relay-client.ts` add an optional, instance-guarded shutdown capability
- `src/http-api.ts` accepts shutdown only for the matching managed instance and acknowledges before cleanup starts
- `src/cli.ts` uses a deferred shutdown latch so relay finalizers run on every platform instead of relying on process signals
- `src/relay-lifecycle.ts` re-probes identity, rejects unsafe replacements, waits for exit or a concurrent replacement, then starts only when the endpoint is free
- relay, HTTP, and client tests cover production shutdown, races, downgrade protection, and fail-closed cases

## Scope

This does not auto-stop foreground relays, source runs, newer builds, or older relays that predate the guarded shutdown capability. It does not touch the shared relay on port `19989`.

## Testing

- `pnpm run ci` (typecheck, 456 tests, CLI build, extension build, extension package)
- isolated real-process test on port `21991`: launched an older built managed relay, ran a newer CLI operational command, verified the old instance exited, the new build took ownership, and sessions remained readable
- shut down the isolated replacement through the guarded endpoint and verified the port was released

## Flow

```mermaid
sequenceDiagram
  participant CLI as Current CLI
  participant Old as Older managed relay
  participant New as Current managed relay
  CLI->>Old: GET /version
  Old-->>CLI: older build + managed + instanceId
  CLI->>Old: re-probe exact instance
  CLI->>Old: POST /shutdown { instanceId }
  Old-->>CLI: { stopping: true }
  Old->>Old: resolve serve latch and run scoped cleanup
  CLI->>Old: poll until exit
  CLI->>New: start current build
  New-->>CLI: current build ready
```