### PR TITLE
fix(client): tolerate extension reconnect windows

### DIFF
--- a/.changeset/calm-client-reconnect.md
+++ b/.changeset/calm-client-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Wait through transient extension reconnects when constructing the TypeScript client and report sessions connected only when they have a live default page.

--- a/PLAN.md
+++ b/PLAN.md
@@ -79,6 +79,13 @@ inventory: Arc tab-group queries and restored-tab presentation run afterward,
 cannot mutate from stale sockets, serialize ownership changes per tab, and
 report failures through relay diagnostics.
 
+### Public clients tolerate extension reconnect windows
+
+`BrowserControlClient.make` gives a matching pre-existing relay the same bounded
+extension reconnect grace used after relay startup. Session summaries report
+connected only when the Playwright transport and a live default page are both
+available.
+
 ### Tab-capture recordings stream with intrinsic framing
 
 Extension protocol `2` sends each recording chunk as a sequenced `BCRD` binary

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ journals and are rejected while session network capture is active. Reveal a
 sensitive result with `BrowserControlClient.reveal`; this keeps unwrapping in
 the same Effect runtime that created the redacted value, including when an
 application and Browser Control resolve separate Effect package instances.
+Client construction waits through a bounded extension reconnect window even
+when the matching relay was already running. A session summary reports
+`connected: true` only when its Playwright transport and live default page are
+both available.
 Use `resetSession(id)` to replace a persisted session generation that is no
 longer connected before creating a new authenticated-origin capability.
 

--- a/src/browser-control-client.ts
+++ b/src/browser-control-client.ts
@@ -167,7 +167,7 @@ export const make = Effect.fn("BrowserControlClient.make")(function* (options: M
   }
   yield* RelayLifecycle.ensureExtensionConnected({
     relay,
-    waitForReconnect: readiness.started,
+    waitForReconnect: true,
   }).pipe(Effect.mapError((error) => clientError("connect", error)))
 
   const ensureSession = Effect.fn("BrowserControlClient.ensureSession")(function* (

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -173,6 +173,13 @@ export async function waitForPageContext(options: {
   throw lastError ?? new Error(`Execution context did not become available within ${options.timeoutMs}ms`)
 }
 
+export function isSessionPageConnected(options: {
+  readonly browserConnected: boolean
+  readonly pageUrl: string | null
+}): boolean {
+  return options.browserConnected && options.pageUrl !== null
+}
+
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
@@ -917,10 +924,11 @@ export class ExecuteSandbox {
   }
 
   getStatus(): { readonly sessionId?: string; readonly connected: boolean; readonly pageUrl: string | null; readonly stateKeys: string[] } {
+    const pageUrl = this.page && !this.page.isClosed() ? this.page.url() : null
     return {
       ...(this.options.sessionId ? { sessionId: this.options.sessionId } : {}),
-      connected: Boolean(this.browser?.isConnected()),
-      pageUrl: this.page && !this.page.isClosed() ? this.page.url() : null,
+      connected: isSessionPageConnected({ browserConnected: Boolean(this.browser?.isConnected()), pageUrl }),
+      pageUrl,
       stateKeys: Object.keys(this.state),
     }
   }

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -176,8 +176,9 @@ export async function waitForPageContext(options: {
 export function isSessionPageConnected(options: {
   readonly browserConnected: boolean
   readonly pageUrl: string | null
+  readonly healthCheckRequired: boolean
 }): boolean {
-  return options.browserConnected && options.pageUrl !== null
+  return options.browserConnected && options.pageUrl !== null && !options.healthCheckRequired
 }
 
 function delay(milliseconds: number): Promise<void> {
@@ -927,7 +928,11 @@ export class ExecuteSandbox {
     const pageUrl = this.page && !this.page.isClosed() ? this.page.url() : null
     return {
       ...(this.options.sessionId ? { sessionId: this.options.sessionId } : {}),
-      connected: isSessionPageConnected({ browserConnected: Boolean(this.browser?.isConnected()), pageUrl }),
+      connected: isSessionPageConnected({
+        browserConnected: Boolean(this.browser?.isConnected()),
+        pageUrl,
+        healthCheckRequired: this.pageHealthCheckRequired,
+      }),
       pageUrl,
       stateKeys: Object.keys(this.state),
     }

--- a/test/browser-control-client.test.ts
+++ b/test/browser-control-client.test.ts
@@ -1,5 +1,5 @@
 import http from "node:http"
-import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { Effect, Schema } from "effect"
 import * as BrowserControlClient from "../src/browser-control-client.ts"
 import { browserControlBuildId, browserControlVersion } from "../src/version.ts"
@@ -7,6 +7,8 @@ import { browserControlBuildId, browserControlVersion } from "../src/version.ts"
 let server: http.Server
 let endpoint: string
 let authenticatedOutcome: unknown
+let extensionFailuresRemaining = 0
+let extensionChecks = 0
 
 const session = {
   id: "x-live-chat-auth",
@@ -26,7 +28,10 @@ beforeAll(async () => {
       return
     }
     if (path === "/extension/status") {
-      response.end(JSON.stringify({ connected: true, version: "test", activeTargets: 1 }))
+      extensionChecks += 1
+      const connected = extensionFailuresRemaining === 0
+      extensionFailuresRemaining = Math.max(0, extensionFailuresRemaining - 1)
+      response.end(JSON.stringify({ connected, version: "test", activeTargets: connected ? 1 : 0 }))
       return
     }
     const chunks: Buffer[] = []
@@ -58,6 +63,11 @@ afterAll(async () => {
   await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
 })
 
+beforeEach(() => {
+  extensionFailuresRemaining = 0
+  extensionChecks = 0
+})
+
 const makeOrigin = Effect.gen(function* () {
   const client = yield* BrowserControlClient.make({ endpoint })
   const liveSession = yield* client.ensureSession({ id: session.id })
@@ -68,6 +78,12 @@ const makeOrigin = Effect.gen(function* () {
 })
 
 describe("BrowserControlClient", () => {
+  it("waits through a transient extension reconnect on an existing relay", async () => {
+    extensionFailuresRemaining = 2
+    await Effect.runPromise(BrowserControlClient.make({ endpoint }))
+    expect(extensionChecks).toBe(3)
+  })
+
   it("resets a named session", async () => {
     const result = await Effect.runPromise(Effect.gen(function* () {
       const client = yield* BrowserControlClient.make({ endpoint })

--- a/test/execute-lifecycle.test.ts
+++ b/test/execute-lifecycle.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest"
 import { Effect } from "effect"
-import { recoverSessionPage, runPlaywrightOperation, waitForPageContext } from "../src/execute.ts"
+import { isSessionPageConnected, recoverSessionPage, runPlaywrightOperation, waitForPageContext } from "../src/execute.ts"
 
 describe("execute lifecycle", () => {
+  it("reports a session connected only when it has a live default page", () => {
+    expect(isSessionPageConnected({ browserConnected: true, pageUrl: null })).toBe(false)
+    expect(isSessionPageConnected({ browserConnected: true, pageUrl: "about:blank" })).toBe(true)
+    expect(isSessionPageConnected({ browserConnected: false, pageUrl: "about:blank" })).toBe(false)
+  })
+
   it("bounds a Playwright operation that never settles", async () => {
     const error = await Effect.runPromise(runPlaywrightOperation({
       label: "Close test page",

--- a/test/execute-lifecycle.test.ts
+++ b/test/execute-lifecycle.test.ts
@@ -4,9 +4,10 @@ import { isSessionPageConnected, recoverSessionPage, runPlaywrightOperation, wai
 
 describe("execute lifecycle", () => {
   it("reports a session connected only when it has a live default page", () => {
-    expect(isSessionPageConnected({ browserConnected: true, pageUrl: null })).toBe(false)
-    expect(isSessionPageConnected({ browserConnected: true, pageUrl: "about:blank" })).toBe(true)
-    expect(isSessionPageConnected({ browserConnected: false, pageUrl: "about:blank" })).toBe(false)
+    expect(isSessionPageConnected({ browserConnected: true, pageUrl: null, healthCheckRequired: false })).toBe(false)
+    expect(isSessionPageConnected({ browserConnected: true, pageUrl: "about:blank", healthCheckRequired: false })).toBe(true)
+    expect(isSessionPageConnected({ browserConnected: false, pageUrl: "about:blank", healthCheckRequired: false })).toBe(false)
+    expect(isSessionPageConnected({ browserConnected: true, pageUrl: "about:blank", healthCheckRequired: true })).toBe(false)
   })
 
   it("bounds a Playwright operation that never settles", async () => {


### PR DESCRIPTION
## What

Make the public TypeScript client tolerate the bounded interval where a matching relay is already running but the browser extension is reconnecting. Session summaries now report `connected: true` only when the Playwright transport has a usable live default page and that page is not awaiting crash recovery.

## Before / After

**Before:** `BrowserControlClient.make` retried extension discovery only when it had just started the relay. If another process had already started the matching relay and the MV3 extension was between workers or sockets, client construction failed immediately. Separately, a session could report connected from its CDP transport alone even when its default page was missing or known-crashed.

**After:** client construction gives every matching relay the same bounded extension reconnect grace. Session status stays disconnected until both the transport and live default page are available, and becomes disconnected while a known-crashed page awaits its health check.

## How

- `src/browser-control-client.ts` always enables the existing bounded retry policy for extension readiness.
- `src/execute.ts` derives session connectivity from transport, default-page, and pending-health-check state.
- `test/browser-control-client.test.ts` covers a transient reconnect against an already-running relay.
- `test/execute-lifecycle.test.ts` covers absent, disconnected, and known-crashed page states.
- `PLAN.md`, `README.md`, and `.changeset/calm-client-reconnect.md` document and release the behavior.

## Scope

This does not change the extension worker reconnect algorithm or its startup lifecycle. It only makes public-client construction and reported session connectivity correct during those existing reconnect windows.

## Testing

- `pnpm run ci`: typecheck, 458 unit tests, CLI build, extension build, and extension package validation passed.
- Isolated built-artifact integration on port `21992`: started an existing relay without an extension, began `BrowserControlClient.make`, connected a protocol-v2 extension after 650 ms, and observed client construction complete successfully at 846 ms.
- Shared real-browser smoke on port `19989` was intentionally not run because that packaged relay is in active use and must not be replaced.

## Flow

```mermaid
sequenceDiagram
    participant App as TypeScript client
    participant Relay
    participant Extension
    App->>Relay: Verify matching relay build
    App->>Relay: Check extension status
    Relay-->>App: Disconnected
    loop Bounded reconnect grace
        App->>Relay: Retry extension status
    end
    Extension->>Relay: hello + ready
    Relay-->>App: Connected
    App-->>App: Construct client
```