### PR TITLE
fix(extension): reconnect after browser startup

### DIFF
--- a/.changeset/warm-browser-starts.md
+++ b/.changeset/warm-browser-starts.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Wake the extension service worker and reconnect to the relay after a full browser restart.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,9 +269,11 @@ browser-control skill
   stale-group cleanup are best-effort and must never block extension readiness.
   Serialize group and ungroup presentation per tab so delayed browser APIs
   cannot apply an older ownership state after a newer one.
-- Repair the reconnect alarm whenever the MV3 worker starts and send heartbeat
-  traffic every 20 seconds while its relay socket is open. Chrome may clear
-  persisted alarms and retires idle extension workers even with an open socket.
+- Register `runtime.onStartup` at global scope so a full browser restart wakes
+  the MV3 worker. Repair the reconnect alarm whenever the worker starts and send
+  heartbeat traffic every 20 seconds while its relay socket is open. Chrome may
+  clear persisted alarms and retires idle extension workers even with an open
+  socket.
 - The relay dedupes target announcements per CDP client by targetId: a
   re-announce under a new sessionId emits `Target.detachedFromTarget` for the
   old session first. Never announce the same targetId twice to one client

--- a/PLAN.md
+++ b/PLAN.md
@@ -71,6 +71,13 @@ Verification:
 
 ## Recently Shipped
 
+### Browser restarts wake extension reconnection
+
+The extension registers a global `runtime.onStartup` listener so restarting the
+browser profile wakes its MV3 worker, repairs the reconnect alarm, and opens a
+fresh relay socket. The existing 20-second heartbeat keeps that socket active
+after reconnection.
+
 ### Unpacked extension connectivity survives browser and path differences
 
 The unpacked manifest carries a stable public key, while Store packaging strips

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -10,7 +10,7 @@ import type {
 import { finalizeBrowserControlGrouping, isBrowserControlGroupTitle, shouldUngroupBrowserControlTab, tabGroupColor, tabGroupTitle } from "./tab-groups.ts"
 import { pageStatusFromJson } from "./page-status.ts"
 import { debuggerDetachedEvent } from "./debugger-detach.ts"
-import { completeExtensionHandshake, ensureReconnectAlarm, reconnectAlarmName, startSocketKeepAlive } from "./connection-lifecycle.ts"
+import { completeExtensionHandshake, reconnectAlarmName, startConnectionLifecycle, startSocketKeepAlive } from "./connection-lifecycle.ts"
 
 const relayHost = "127.0.0.1"
 const relayPort = 19989
@@ -34,9 +34,12 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   void ensureConnection().catch(() => {})
 })
 
-// Chrome can clear persisted alarms, so repair the reconnect wake-up whenever
-// the MV3 service worker starts rather than only on install or browser startup.
-void ensureReconnectAlarm(chrome.alarms).catch(() => {})
+startConnectionLifecycle({
+  alarms: chrome.alarms,
+  addStartupListener: (listener) => chrome.runtime.onStartup.addListener(listener),
+  addInstalledListener: (listener) => chrome.runtime.onInstalled.addListener(listener),
+  connect,
+})
 
 chrome.action.onClicked.addListener((tab) => {
   if (tab.id) sendMessage({ method: "toolbar.clicked", params: { tabId: tab.id } })
@@ -82,8 +85,6 @@ chrome.runtime.onMessage.addListener((message: unknown, sender, sendResponse) =>
   )
   return true
 })
-
-connect()
 
 function connect(): void {
   void ensureConnection().catch(() => {})

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -37,7 +37,6 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 startConnectionLifecycle({
   alarms: chrome.alarms,
   addStartupListener: (listener) => chrome.runtime.onStartup.addListener(listener),
-  addInstalledListener: (listener) => chrome.runtime.onInstalled.addListener(listener),
   connect,
 })
 

--- a/extension/src/connection-lifecycle.ts
+++ b/extension/src/connection-lifecycle.ts
@@ -3,6 +3,7 @@ const reconnectAlarmPeriodMinutes = 0.5
 const socketKeepAliveIntervalMs = 20_000
 
 type AlarmApi = Pick<typeof chrome.alarms, "create" | "get">
+type AddListener = (listener: () => void) => void
 
 type HandshakeCompletion = {
   readonly announceAttachedTabs: () => Promise<void>
@@ -13,6 +14,23 @@ type HandshakeCompletion = {
 export async function ensureReconnectAlarm(alarms: AlarmApi): Promise<void> {
   if (await alarms.get(reconnectAlarmName)) return
   await alarms.create(reconnectAlarmName, { periodInMinutes: reconnectAlarmPeriodMinutes })
+}
+
+export function startConnectionLifecycle(options: {
+  readonly alarms: AlarmApi
+  readonly addStartupListener: AddListener
+  readonly addInstalledListener: AddListener
+  readonly connect: () => void
+}): void {
+  const activate = () => {
+    void ensureReconnectAlarm(options.alarms).catch(() => {})
+    options.connect()
+  }
+  // Global registration wakes the MV3 worker after a full browser restart;
+  // the alarm alone is not reliably persisted before Chrome 150.
+  options.addStartupListener(activate)
+  options.addInstalledListener(activate)
+  activate()
 }
 
 export function startSocketKeepAlive(heartbeat: () => void): () => void {

--- a/extension/src/connection-lifecycle.ts
+++ b/extension/src/connection-lifecycle.ts
@@ -19,7 +19,6 @@ export async function ensureReconnectAlarm(alarms: AlarmApi): Promise<void> {
 export function startConnectionLifecycle(options: {
   readonly alarms: AlarmApi
   readonly addStartupListener: AddListener
-  readonly addInstalledListener: AddListener
   readonly connect: () => void
 }): void {
   const activate = () => {
@@ -27,9 +26,8 @@ export function startConnectionLifecycle(options: {
     options.connect()
   }
   // Global registration wakes the MV3 worker after a full browser restart;
-  // the alarm alone is not reliably persisted before Chrome 150.
+  // Chrome does not guarantee that persisted alarms survive a restart.
   options.addStartupListener(activate)
-  options.addInstalledListener(activate)
   activate()
 }
 

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -341,8 +341,9 @@ existence, and report the viewport, state, and interaction path actually tested.
 
 Common diagnoses:
 
-- `connected:false`: run a relay-backed command, then reload the unpacked
-  extension only if its reconnect loop does not recover.
+- `connected:false`: run a relay-backed command and allow the extension startup
+  or alarm wake-up to reconnect. Reload the unpacked extension only if that loop
+  does not recover.
 - Incompatible extension protocol: update either the extension or npm package;
   exact extension and relay release versions do not need to match.
 - Stale relay build: operational commands automatically replace an older

--- a/test/extension-connection-lifecycle.test.ts
+++ b/test/extension-connection-lifecycle.test.ts
@@ -36,19 +36,22 @@ describe("extension connection lifecycle", () => {
   it("wakes and reconnects when the browser profile starts", () => {
     let onStartup: (() => void) | undefined
     const connect = vi.fn()
+    const getAlarm = vi.fn(async () => undefined)
 
     startConnectionLifecycle({
       alarms: {
         create: vi.fn(async () => {}),
-        get: vi.fn(async () => undefined),
+        get: getAlarm,
       },
       addStartupListener: (listener) => { onStartup = listener },
       connect,
     })
 
     expect(connect).toHaveBeenCalledTimes(1)
+    expect(getAlarm).toHaveBeenCalledTimes(1)
     onStartup?.()
     expect(connect).toHaveBeenCalledTimes(2)
+    expect(getAlarm).toHaveBeenCalledTimes(2)
   })
 
   it("runs a heartbeat every 20 seconds and stops cleanly", () => {

--- a/test/extension-connection-lifecycle.test.ts
+++ b/test/extension-connection-lifecycle.test.ts
@@ -3,6 +3,7 @@ import {
   completeExtensionHandshake,
   ensureReconnectAlarm,
   reconnectAlarmName,
+  startConnectionLifecycle,
   startSocketKeepAlive,
 } from "../extension/src/connection-lifecycle.ts"
 
@@ -30,6 +31,28 @@ describe("extension connection lifecycle", () => {
     await ensureReconnectAlarm({ create, get })
 
     expect(create).not.toHaveBeenCalled()
+  })
+
+  it("wakes and reconnects when the browser profile starts", () => {
+    let onStartup: (() => void) | undefined
+    let onInstalled: (() => void) | undefined
+    const connect = vi.fn()
+
+    startConnectionLifecycle({
+      alarms: {
+        create: vi.fn(async () => {}),
+        get: vi.fn(async () => undefined),
+      },
+      addStartupListener: (listener) => { onStartup = listener },
+      addInstalledListener: (listener) => { onInstalled = listener },
+      connect,
+    })
+
+    expect(connect).toHaveBeenCalledTimes(1)
+    onStartup?.()
+    expect(connect).toHaveBeenCalledTimes(2)
+    onInstalled?.()
+    expect(connect).toHaveBeenCalledTimes(3)
   })
 
   it("runs a heartbeat every 20 seconds and stops cleanly", () => {

--- a/test/extension-connection-lifecycle.test.ts
+++ b/test/extension-connection-lifecycle.test.ts
@@ -35,7 +35,6 @@ describe("extension connection lifecycle", () => {
 
   it("wakes and reconnects when the browser profile starts", () => {
     let onStartup: (() => void) | undefined
-    let onInstalled: (() => void) | undefined
     const connect = vi.fn()
 
     startConnectionLifecycle({
@@ -44,15 +43,12 @@ describe("extension connection lifecycle", () => {
         get: vi.fn(async () => undefined),
       },
       addStartupListener: (listener) => { onStartup = listener },
-      addInstalledListener: (listener) => { onInstalled = listener },
       connect,
     })
 
     expect(connect).toHaveBeenCalledTimes(1)
     onStartup?.()
     expect(connect).toHaveBeenCalledTimes(2)
-    onInstalled?.()
-    expect(connect).toHaveBeenCalledTimes(3)
   })
 
   it("runs a heartbeat every 20 seconds and stops cleanly", () => {


### PR DESCRIPTION
## What

Wake the Browser Control MV3 service worker when its Chromium profile starts, repair the reconnect alarm, and immediately reconnect to the local relay. This closes the full-browser-restart gap without adding another install-time activation path.

## Before / After

**Before:** worker evaluation repaired the alarm and opened the relay socket, but no global `runtime.onStartup` listener was registered. After a full browser restart, if Chrome had not preserved the alarm, no Browser Control event necessarily woke the worker; the extension could remain disconnected until a toolbar action, reload, or another event happened to start it.

**After:** Chrome can wake the worker through the globally registered startup event. Both normal worker evaluation and browser startup check the reconnect alarm and request a connection; the existing `ensureConnection` path deduplicates concurrent socket work.

## How

- `extension/src/connection-lifecycle.ts` owns synchronous startup-listener registration and the shared alarm-repair/connection activation.
- `extension/src/background.ts` installs that lifecycle at global scope.
- `test/extension-connection-lifecycle.test.ts` verifies initial activation, startup activation, and alarm checks on both paths.
- `PLAN.md`, `AGENTS.md`, `skills/browser-control/SKILL.md`, and `.changeset/warm-browser-starts.md` document and release the behavior.

## Scope

This does not change socket retry timing, heartbeat behavior, relay protocol, or extension installation behavior. The redundant `runtime.onInstalled` activation from the preserved draft was deliberately removed because install already evaluates the worker.

## Testing

- `pnpm run ci`: typecheck, 459 unit tests, CLI build, extension build, and extension package validation passed.
- `pnpm exec vitest run test/extension-connection-lifecycle.test.ts`: 5 focused lifecycle tests passed after strengthening the alarm assertions.
- Verified the packaged `extension/dist/background.js` contains `runtime.onStartup.addListener`.
- A real browser-start smoke was intentionally not run because it requires reloading the unpacked extension and restarting the user's active browser.

## Flow

```mermaid
sequenceDiagram
    participant Chrome
    participant Worker as MV3 service worker
    participant Alarm as Reconnect alarm
    participant Relay
    Chrome->>Worker: runtime.onStartup
    Worker->>Alarm: Check and recreate if absent
    Worker->>Relay: Request connection
    Note over Worker,Relay: Existing ensureConnection deduplicates socket work
    Worker->>Relay: Heartbeat every 20 seconds after handshake
```