### PR TITLE
fix(handoff): wait for destination context

### DIFF
--- a/.changeset/calm-handoffs-settle.md
+++ b/.changeset/calm-handoffs-settle.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Wait for the destination page execution context before returning from a navigation-triggering human handoff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,11 @@ local Node relay.
   targets must preserve the handoff UI.
 - Handoff `start` actions run only after the waiter and WAIT UI are registered.
   Require extension acknowledgement of WAIT before invoking `start`. Human
-  completion waits for the action to settle. Timeout or target cancellation
-  disconnects the sandbox before releasing its execute permit, preventing a
-  non-settling prompt action from mutating the page later. Cancel the waiter if
-  WAIT presentation or action startup fails.
+  completion waits for the action to settle and for the destination execution
+  context to become available. Timeout or target cancellation disconnects the
+  sandbox before releasing its execute permit, preventing a non-settling prompt
+  action from mutating the page later. Cancel the waiter if WAIT presentation or
+  action startup fails.
 - `TargetRegistry` is the sole production live target-ownership authority.
   Session state keeps one durable default-target identity and owner. Adoption reserves,
   commits, or rolls back registry ownership transactionally and reconciles CDP

--- a/PLAN.md
+++ b/PLAN.md
@@ -71,6 +71,13 @@ Verification:
 
 ## Recently Shipped
 
+### Handoffs return on a live destination context
+
+After a human completes a navigation-triggering handoff, Browser Control waits
+through transient execution-context replacement before returning to user code.
+The same execute can immediately inspect and verify the authenticated
+destination without repeating the human action.
+
 ### Browser restarts wake extension reconnection
 
 The extension registers a global `runtime.onStartup` listener so restarting the

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1025,7 +1025,7 @@ return { result: await page.locator('#class-result').textContent() }
             "execute",
             "--session",
             smokeSession,
-            `await handoff('Navigate and resume ${marker}', { timeoutMs: 30000 }); return { resumed: true, url: page.url() }`,
+            `await handoff('Navigate and resume ${marker}', { timeoutMs: 30000 }); return { resumed: true, url: page.url(), view: await snapshot({ maxItems: 20 }) }`,
           ]).pipe(Effect.forkChild)
           yield* Effect.sleep("500 millis")
           const ownerPage = yield* scopedOwnerCdpPage({ sessionId: smokeSession, urlIncludes: marker })
@@ -1042,7 +1042,7 @@ return { result: await page.locator('#class-result').textContent() }
 
           yield* ownerPage.evaluate(`document.querySelector('#__browser_control_page_status__')?.shadowRoot?.querySelector('button')?.click()`)
           const output = yield* Fiber.join(executeFiber)
-          if (!output.includes("resumed: true") || !output.includes(fixture.afterUrl)) {
+          if (!output.includes("resumed: true") || !output.includes(fixture.afterUrl) || !output.includes('button "Unrelated page button"')) {
             return yield* Effect.fail(new Error(`handoff did not resume on the navigated page: ${output}`))
           }
           return output.trim()

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -158,6 +158,10 @@ await page.getByRole("heading", { name: /account|dashboard/i }).waitFor()
 return { authenticatedUrl: page.url(), title: await page.title() }
 ```
 
+After a resolved handoff, Browser Control waits through transient destination
+context replacement before returning, so this verification can remain in the
+same execute.
+
 Tell the user what action is waiting. Human acknowledgment is not verification:
 always assert the expected URL or stable element after `handoff`. If the action
 was already completed and only the human step remains, call `handoff(message)`

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -182,30 +182,6 @@ export function isSessionPageConnected(options: {
   return options.browserConnected && options.pageUrl !== null && !options.healthCheckRequired
 }
 
-export async function finishHandoff(options: {
-  readonly outcome: HandoffOutcome
-  readonly message: string
-  readonly timeoutMs: number
-  readonly evaluate: () => Promise<void>
-  readonly contextTimeoutMs?: number
-  readonly retryDelayMs?: number
-  readonly delay?: (milliseconds: number) => Promise<void>
-}): Promise<void> {
-  if (options.outcome === "timeout") {
-    throw new Error(`Handoff timed out after ${options.timeoutMs}ms waiting for the user: ${options.message}`)
-  }
-  if (options.outcome !== "resolved") {
-    const targetEvent = options.outcome.reason === "target-crashed" ? "crashed" : "detached"
-    throw new Error(`Handoff cancelled because its target ${targetEvent}: ${options.message}`)
-  }
-  await waitForPageContext({
-    evaluate: options.evaluate,
-    timeoutMs: options.contextTimeoutMs ?? sessionPageHealthCheckTimeoutMs,
-    ...(options.retryDelayMs === undefined ? {} : { retryDelayMs: options.retryDelayMs }),
-    ...(options.delay === undefined ? {} : { delay: options.delay }),
-  })
-}
-
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
@@ -815,11 +791,15 @@ export class ExecuteSandbox {
         ...(options?.start ? { start: options.start } : {}),
         ...(options?.start ? { cancelStart: () => Effect.runPromise(this.disconnectSettled()) } : {}),
       })
-      await finishHandoff({
-        outcome,
-        message: handoffMessage,
-        timeoutMs,
-        contextTimeoutMs: handoffPageContextTimeoutMs,
+      if (outcome === "timeout") {
+        throw new Error(`Handoff timed out after ${timeoutMs}ms waiting for the user: ${handoffMessage}`)
+      }
+      if (outcome !== "resolved") {
+        const targetEvent = outcome.reason === "target-crashed" ? "crashed" : "detached"
+        throw new Error(`Handoff cancelled because its target ${targetEvent}: ${handoffMessage}`)
+      }
+      await waitForPageContext({
+        timeoutMs: handoffPageContextTimeoutMs,
         evaluate: async () => {
           try {
             const currentPage = await this.getSessionPage({ context })

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -30,6 +30,7 @@ const playwrightCloseTimeoutMs = 2_000
 const playwrightConnectTimeoutMs = 15_000
 const sessionPageHealthCheckTimeoutMs = 3_000
 const sessionPageHealthRetryDelayMs = 100
+const handoffPageContextTimeoutMs = 15_000
 const timedOut = Symbol("timed-out")
 export const downloadCapabilityErrorMessage = "Downloads are unavailable in Browser Control extension-backed tabs: Chromium blocks Browser.setDownloadBehavior and Page.setDownloadBehavior through chrome.debugger, so Playwright cannot retain an artifact for download.saveAs(). Fetch the response in the page and write the returned bytes with fs when the site exposes them."
 const downloadGuardedPages = new WeakSet<Page>()
@@ -179,6 +180,30 @@ export function isSessionPageConnected(options: {
   readonly healthCheckRequired: boolean
 }): boolean {
   return options.browserConnected && options.pageUrl !== null && !options.healthCheckRequired
+}
+
+export async function finishHandoff(options: {
+  readonly outcome: HandoffOutcome
+  readonly message: string
+  readonly timeoutMs: number
+  readonly evaluate: () => Promise<void>
+  readonly contextTimeoutMs?: number
+  readonly retryDelayMs?: number
+  readonly delay?: (milliseconds: number) => Promise<void>
+}): Promise<void> {
+  if (options.outcome === "timeout") {
+    throw new Error(`Handoff timed out after ${options.timeoutMs}ms waiting for the user: ${options.message}`)
+  }
+  if (options.outcome !== "resolved") {
+    const targetEvent = options.outcome.reason === "target-crashed" ? "crashed" : "detached"
+    throw new Error(`Handoff cancelled because its target ${targetEvent}: ${options.message}`)
+  }
+  await waitForPageContext({
+    evaluate: options.evaluate,
+    timeoutMs: options.contextTimeoutMs ?? sessionPageHealthCheckTimeoutMs,
+    ...(options.retryDelayMs === undefined ? {} : { retryDelayMs: options.retryDelayMs }),
+    ...(options.delay === undefined ? {} : { delay: options.delay }),
+  })
 }
 
 function delay(milliseconds: number): Promise<void> {
@@ -790,13 +815,23 @@ export class ExecuteSandbox {
         ...(options?.start ? { start: options.start } : {}),
         ...(options?.start ? { cancelStart: () => Effect.runPromise(this.disconnectSettled()) } : {}),
       })
-      if (outcome === "timeout") {
-        throw new Error(`Handoff timed out after ${timeoutMs}ms waiting for the user: ${handoffMessage}`)
-      }
-      if (outcome !== "resolved") {
-        const targetEvent = outcome.reason === "target-crashed" ? "crashed" : "detached"
-        throw new Error(`Handoff cancelled because its target ${targetEvent}: ${handoffMessage}`)
-      }
+      await finishHandoff({
+        outcome,
+        message: handoffMessage,
+        timeoutMs,
+        contextTimeoutMs: handoffPageContextTimeoutMs,
+        evaluate: async () => {
+          try {
+            const currentPage = await this.getSessionPage({ context })
+            await currentPage.evaluate(() => true)
+          } catch (error) {
+            if (error instanceof SessionPageRecoveryError && error.reason === "target-unavailable") {
+              throw new Error("Execution context is not available while the handoff destination settles", { cause: error })
+            }
+            throw error
+          }
+        },
+      })
       handoffTracker.count += 1
     }
     return {

--- a/test/execute-lifecycle.test.ts
+++ b/test/execute-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { Effect } from "effect"
-import { finishHandoff, isSessionPageConnected, recoverSessionPage, runPlaywrightOperation, waitForPageContext } from "../src/execute.ts"
+import { isSessionPageConnected, recoverSessionPage, runPlaywrightOperation, waitForPageContext } from "../src/execute.ts"
 
 describe("execute lifecycle", () => {
   it("reports a session connected only when it has a live default page", () => {
@@ -107,22 +107,6 @@ describe("execute lifecycle", () => {
     await expect(waitForPageContext({
       timeoutMs: 1_000,
       retryDelayMs: 10,
-      delay: () => Promise.resolve(),
-      evaluate: () => ++attempts < 3
-        ? Promise.reject(new Error("Execution context was destroyed"))
-        : Promise.resolve(),
-    })).resolves.toBeUndefined()
-    expect(attempts).toBe(3)
-  })
-
-  it("does not return from a resolved handoff until the destination context is available", async () => {
-    let attempts = 0
-    await expect(finishHandoff({
-      outcome: "resolved",
-      message: "complete authentication",
-      timeoutMs: 30_000,
-      contextTimeoutMs: 1_000,
-      retryDelayMs: 0,
       delay: () => Promise.resolve(),
       evaluate: () => ++attempts < 3
         ? Promise.reject(new Error("Execution context was destroyed"))

--- a/test/execute-lifecycle.test.ts
+++ b/test/execute-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { Effect } from "effect"
-import { isSessionPageConnected, recoverSessionPage, runPlaywrightOperation, waitForPageContext } from "../src/execute.ts"
+import { finishHandoff, isSessionPageConnected, recoverSessionPage, runPlaywrightOperation, waitForPageContext } from "../src/execute.ts"
 
 describe("execute lifecycle", () => {
   it("reports a session connected only when it has a live default page", () => {
@@ -107,6 +107,22 @@ describe("execute lifecycle", () => {
     await expect(waitForPageContext({
       timeoutMs: 1_000,
       retryDelayMs: 10,
+      delay: () => Promise.resolve(),
+      evaluate: () => ++attempts < 3
+        ? Promise.reject(new Error("Execution context was destroyed"))
+        : Promise.resolve(),
+    })).resolves.toBeUndefined()
+    expect(attempts).toBe(3)
+  })
+
+  it("does not return from a resolved handoff until the destination context is available", async () => {
+    let attempts = 0
+    await expect(finishHandoff({
+      outcome: "resolved",
+      message: "complete authentication",
+      timeoutMs: 30_000,
+      contextTimeoutMs: 1_000,
+      retryDelayMs: 0,
       delay: () => Promise.resolve(),
       evaluate: () => ++attempts < 3
         ? Promise.reject(new Error("Execution context was destroyed"))


### PR DESCRIPTION
## What

Keep a resolved human handoff inside its execute until the destination page has a usable execution context. Code immediately after `await handoff(...)` can now inspect and verify a navigation-triggered authentication result without racing Playwright's context replacement.

## Before / After

**Before:** the in-page completion control resolved the handoff as soon as the human clicked it. If that click coincided with a redirect or cross-document navigation, `handoff` returned while the old execution context was being destroyed, so the next `snapshot()`, locator, or evaluation could fail even though the human action succeeded. Retrying the whole execute could require repeating the human step.

**After:** a resolved handoff probes the session page through the existing page-recovery path and waits up to 15 seconds through context-destroyed or context-missing transitions. Unrelated page failures still fail immediately. The same execute can inspect the settled destination and independently verify success.

## How

- `src/execute.ts` runs the existing `waitForPageContext` classifier after a resolved handoff and reacquires replacement session targets through `getSessionPage`.
- `scripts/smoke.ts` strengthens `handoff-navigation` by taking a compact snapshot immediately after handoff and requiring content from the navigated destination.
- `AGENTS.md`, `PLAN.md`, `skills/browser-control/SKILL.md`, and `.changeset/calm-handoffs-settle.md` document and release the invariant.

## Scope

This does not change WAIT presentation, completion-token matching, handoff cancellation, action settlement, or target rebinding. It adds readiness waiting only after the existing handoff outcome is resolved.

## Testing

- `pnpm run ci`: typecheck, 459 unit tests, CLI and extension builds, and extension package validation passed.
- `pnpm exec vitest run test/execute-lifecycle.test.ts test/handoff.test.ts`: 27 focused lifecycle and handoff tests passed.
- The enhanced `handoff-navigation` browser smoke was not run because the unpacked extension is fixed to port `19989` and the active shared packaged relay must not be replaced.

## Flow

```mermaid
sequenceDiagram
    participant Agent as Execute script
    participant Relay
    participant Human
    participant Page
    Agent->>Relay: await handoff(...)
    Relay->>Human: Present WAIT control
    Human->>Page: Complete action
    Page->>Relay: Resolve exact handoff token
    Page-->>Relay: Navigation replaces execution context
    loop Only context-missing/destroyed failures
        Relay->>Page: Reacquire page and probe context
    end
    Relay-->>Agent: handoff returns
    Agent->>Page: snapshot / verify destination
```