### PR TITLE
feat(sdk): expose redacted secret profile workers

### DIFF
--- a/.changeset/calm-profile-workers.md
+++ b/.changeset/calm-profile-workers.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Expose safe Secret Profile status and profile-worker execution through the TypeScript SDK.

--- a/PLAN.md
+++ b/PLAN.md
@@ -322,6 +322,9 @@ reconciles existing client announcements, browser grouping, and page status.
   reload-based refresh preserve references by observed request source.
 - `secrets run` injects profile values into a child process and redacts known
   values from bounded stdout and stderr before returning them.
+- The public `SecretProfile` SDK exposes metadata-only `status` and redacted
+  profile-worker `run`, so generated applications do not require a
+  user-authored `browser-control secrets run` wrapper or gain raw profile reads.
 - While capture is active, values observed in completed exchanges and
   secret-shaped returned data are removed from execute results, URLs, logs,
   and journal records before they leave the sandbox.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,30 @@ both available.
 Use `resetSession(id)` to replace a persisted session generation that is no
 longer connected before creating a new authenticated-origin capability.
 
+Applications with a generated direct client can also consume a Secret Profile
+without requiring users to wrap the application in `browser-control secrets
+run`:
+
+```ts
+import { SecretProfile } from "@opencode-ai/browser-control"
+import { Effect } from "effect"
+
+const result = await Effect.runPromise(SecretProfile.run({
+  name: "github",
+  command: process.execPath,
+  args: ["./github-cli.js", "repositories"],
+}))
+
+process.stdout.write(result.stdout)
+process.stderr.write(result.stderr)
+process.exitCode = result.exitCode
+```
+
+The child receives `BC_SECRET_N` variables. The parent never receives their raw
+values, and known values are redacted from bounded child output. `status()`
+returns metadata only; the public SDK intentionally does not expose raw profile
+reads.
+
 ## Work in Sessions
 
 A bare `execute` creates a fresh session. Pass its ID to continue with the same

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ process.stderr.write(result.stderr)
 process.exitCode = result.exitCode
 ```
 
-The child receives `BC_SECRET_N` variables. The parent never receives their raw
-values, and known values are redacted from bounded child output. `status()`
+The trusted child receives `BC_SECRET_N` variables. The parent never receives
+their raw values, and known values are redacted from bounded child output. `status()`
 returns metadata only; the public SDK intentionally does not expose raw profile
 reads.
 

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -319,8 +319,8 @@ const result = await Effect.runPromise(SecretProfile.run({
 }))
 ```
 
-The worker receives `BC_SECRET_N` variables and its bounded output is redacted.
-The public SDK exposes profile metadata but never raw profile values.
+The trusted worker receives `BC_SECRET_N` variables and its bounded output is
+redacted. The public SDK exposes profile metadata but never raw profile values.
 
 Refresh credentials normally renewed by a page reload with:
 

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -305,6 +305,23 @@ browser-control secrets status github
 browser-control secrets run github -- ./github-cli repositories
 ```
 
+Generated TypeScript applications can own that wrapper internally through the
+public SDK:
+
+```ts
+import { SecretProfile } from "@opencode-ai/browser-control"
+import { Effect } from "effect"
+
+const result = await Effect.runPromise(SecretProfile.run({
+  name: "github",
+  command: process.execPath,
+  args: ["./github-cli.js", "repositories"],
+}))
+```
+
+The worker receives `BC_SECRET_N` variables and its bounded output is redacted.
+The public SDK exposes profile metadata but never raw profile values.
+
 Refresh credentials normally renewed by a page reload with:
 
 ```bash

--- a/src/auth-profile.ts
+++ b/src/auth-profile.ts
@@ -78,6 +78,8 @@ export const defaultBaseDir = (): string => path.join(os.homedir(), ".browser-co
 const writeLock = Semaphore.makeUnsafe(1)
 const profileLockTimeoutMs = 30_000
 const staleProfileLockMs = 60_000
+const maximumRunOutputBytes = 10_000_000
+const maximumTimeoutMs = 2_147_483_647
 
 export const read = Effect.fn("AuthProfile.read")(function* (name: string, options: { readonly baseDir?: string } = {}) {
   const filePath = yield* profilePath(options.baseDir ?? defaultBaseDir(), name)
@@ -216,15 +218,22 @@ export const run = Effect.fn("AuthProfile.run")(function* (options: AuthRunOptio
   if (!options.command.trim()) {
     return yield* Effect.fail(new AuthProfileError({ message: "Auth command must not be empty", operation: "run", reason: "run-failed" }))
   }
+  const timeoutMs = options.timeoutMs ?? 120_000
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > maximumTimeoutMs) {
+    return yield* Effect.fail(new AuthProfileError({ message: `Auth command timeout must be an integer between 1 and ${maximumTimeoutMs} milliseconds`, operation: "run", reason: "run-failed" }))
+  }
+  const maxOutputBytes = options.maxOutputBytes ?? 1_000_000
+  if (!Number.isSafeInteger(maxOutputBytes) || maxOutputBytes < 0 || maxOutputBytes > maximumRunOutputBytes) {
+    return yield* Effect.fail(new AuthProfileError({ message: `Auth command output limit must be an integer between 0 and ${maximumRunOutputBytes} bytes`, operation: "run", reason: "run-failed" }))
+  }
   const profile = yield* read(options.name, { ...(options.baseDir ? { baseDir: options.baseDir } : {}) })
   const startedAt = Date.now()
-  const maxOutputBytes = options.maxOutputBytes ?? 1_000_000
   const maxSecretBytes = profile.slots.reduce((max, slot) => Math.max(max, Buffer.byteLength(slot.value)), 0)
   const result = yield* runChild({
       command: options.command,
       args: options.args ?? [],
       ...(options.cwd ? { cwd: options.cwd } : {}),
-      timeoutMs: options.timeoutMs ?? 120_000,
+      timeoutMs,
       maxOutputBytes: maxOutputBytes + maxSecretBytes,
       env: Object.fromEntries(profile.slots.map((slot) => [slot.ref, slot.value])),
     }).pipe(

--- a/src/auth-profile.ts
+++ b/src/auth-profile.ts
@@ -51,6 +51,19 @@ export type AuthRunResult = {
   readonly durationMs: number
 }
 
+export interface AuthProfileOptions {
+  readonly baseDir?: string
+}
+
+export interface AuthRunOptions extends AuthProfileOptions {
+  readonly name: string
+  readonly command: string
+  readonly args?: readonly string[]
+  readonly cwd?: string
+  readonly timeoutMs?: number
+  readonly maxOutputBytes?: number
+}
+
 export class AuthProfileError extends Schema.TaggedError<AuthProfileError>()(
   "AuthProfile.Error",
   {
@@ -195,19 +208,11 @@ export const write = Effect.fn("AuthProfile.write")(function* (options: {
   return yield* writeLock.withPermit(writeProfile(options))
 })
 
-export const status = Effect.fn("AuthProfile.status")(function* (name: string, options: { readonly baseDir?: string } = {}) {
+export const status = Effect.fn("AuthProfile.status")(function* (name: string, options: AuthProfileOptions = {}) {
   return summary(yield* read(name, options))
 })
 
-export const run = Effect.fn("AuthProfile.run")(function* (options: {
-  readonly name: string
-  readonly command: string
-  readonly args?: readonly string[]
-  readonly cwd?: string
-  readonly timeoutMs?: number
-  readonly maxOutputBytes?: number
-  readonly baseDir?: string
-}) {
+export const run = Effect.fn("AuthProfile.run")(function* (options: AuthRunOptions) {
   if (!options.command.trim()) {
     return yield* Effect.fail(new AuthProfileError({ message: "Auth command must not be empty", operation: "run", reason: "run-failed" }))
   }
@@ -237,7 +242,7 @@ export const run = Effect.fn("AuthProfile.run")(function* (options: {
   } satisfies AuthRunResult
 })
 
-export const remove = Effect.fn("AuthProfile.remove")(function* (name: string, options: { readonly baseDir?: string } = {}) {
+export const remove = Effect.fn("AuthProfile.remove")(function* (name: string, options: AuthProfileOptions = {}) {
   const filePath = yield* profilePath(options.baseDir ?? defaultBaseDir(), name)
   return yield* Effect.tryPromise({
     try: async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { AuthenticatedOrigin, BrowserControlClient } from "./browser-control-client.ts"
+export * as SecretProfile from "./secret-profile.ts"

--- a/src/secret-profile.ts
+++ b/src/secret-profile.ts
@@ -1,0 +1,21 @@
+import { Effect } from "effect"
+import * as AuthProfile from "./auth-profile.ts"
+
+export type Summary = AuthProfile.AuthProfileSummary
+export type RunResult = AuthProfile.AuthRunResult
+export type RunOptions = AuthProfile.AuthRunOptions
+export type StatusOptions = AuthProfile.AuthProfileOptions
+export type Error = AuthProfile.AuthProfileError
+
+/** Return profile metadata without revealing credential values. */
+export const status = Effect.fn("SecretProfile.status")(function* (name: string, options: StatusOptions = {}) {
+  return yield* AuthProfile.status(name, options)
+})
+
+/**
+ * Run a credential-bearing worker with profile slots injected as BC_SECRET_N.
+ * Known values are redacted from bounded stdout and stderr before they return.
+ */
+export const run = Effect.fn("SecretProfile.run")(function* (options: RunOptions) {
+  return yield* AuthProfile.run(options)
+})

--- a/src/secret-profile.ts
+++ b/src/secret-profile.ts
@@ -6,6 +6,7 @@ export type RunResult = AuthProfile.AuthRunResult
 export type RunOptions = AuthProfile.AuthRunOptions
 export type StatusOptions = AuthProfile.AuthProfileOptions
 export type Error = AuthProfile.AuthProfileError
+export const Error = AuthProfile.AuthProfileError
 
 /** Return profile metadata without revealing credential values. */
 export const status = Effect.fn("SecretProfile.status")(function* (name: string, options: StatusOptions = {}) {
@@ -13,7 +14,7 @@ export const status = Effect.fn("SecretProfile.status")(function* (name: string,
 })
 
 /**
- * Run a credential-bearing worker with profile slots injected as BC_SECRET_N.
+ * Run a trusted credential-bearing worker with profile slots injected as BC_SECRET_N.
  * Known values are redacted from bounded stdout and stderr before they return.
  */
 export const run = Effect.fn("SecretProfile.run")(function* (options: RunOptions) {

--- a/test/auth-profile.test.ts
+++ b/test/auth-profile.test.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 import { Effect } from "effect"
 import * as AuthProfile from "../src/auth-profile.ts"
+import { SecretProfile } from "../src/index.ts"
 
 const temporaryDirectories: string[] = []
 
@@ -22,6 +23,8 @@ describe("AuthProfile", () => {
 
     expect(result).toMatchObject({ name: "uber", slotCount: 1, slots: [{ ref: "BC_SECRET_1", expired: false }] })
     expect(JSON.stringify(result)).not.toContain("token-value")
+    const publicStatus = await Effect.runPromise(SecretProfile.status("uber", { baseDir }))
+    expect(publicStatus).toEqual(result)
     const stat = await fs.stat(path.join(baseDir, "uber.json"))
     expect(stat.mode & 0o777).toBe(0o600)
   })
@@ -34,7 +37,7 @@ describe("AuthProfile", () => {
       slots: [{ ref: "BC_SECRET_1", value: "token-value", sources: ["request.header.authorization"] }],
     }))
 
-    const result = await Effect.runPromise(AuthProfile.run({
+    const result = await Effect.runPromise(SecretProfile.run({
       name: "uber",
       baseDir,
       command: process.execPath,

--- a/test/auth-profile.test.ts
+++ b/test/auth-profile.test.ts
@@ -46,6 +46,23 @@ describe("AuthProfile", () => {
     expect(result).toMatchObject({ exitCode: 0, stdout: "${BC_SECRET_1}", stderr: "" })
   })
 
+  it("exposes a runtime error class and rejects unsafe worker bounds", async () => {
+    const baseDir = await temporaryDirectory()
+
+    await expect(Effect.runPromise(SecretProfile.run({
+      name: "uber",
+      baseDir,
+      command: process.execPath,
+      timeoutMs: 0,
+    }))).rejects.toBeInstanceOf(SecretProfile.Error)
+    await expect(Effect.runPromise(SecretProfile.run({
+      name: "uber",
+      baseDir,
+      command: process.execPath,
+      maxOutputBytes: -1,
+    }))).rejects.toMatchObject({ _tag: "AuthProfile.Error", reason: "run-failed" })
+  })
+
   it("does not leak a credential cut by the output budget", async () => {
     const baseDir = await temporaryDirectory()
     await Effect.runPromise(AuthProfile.write({


### PR DESCRIPTION
## What

Add a public `SecretProfile` SDK namespace for generated Node applications that need to consume Browser Control credential profiles without requiring the user to wrap every invocation in `browser-control secrets run`. The SDK exposes metadata-only `status`, trusted subprocess `run`, and a runtime `SecretProfile.Error` class.

Raw profile values remain inside the restrictive local store and the spawned worker environment. The parent receives only metadata and bounded stdout/stderr with known values replaced by stable `${BC_SECRET_N}` references.

## Before / After

**Before:** generated direct clients could only instruct users to launch them through the CLI wrapper. The package root had no supported profile-worker API, so applications either needed an external shell wrapper or risked inventing their own raw profile reader.

**After:** applications can call `SecretProfile.status(name)` and `SecretProfile.run(options)` directly. Worker timeout and output bounds are validated before profile access, inherited `BC_SECRET_N` variables remain stripped, and callers can identify failures with `instanceof SecretProfile.Error`.

## How

- `src/secret-profile.ts` defines the narrow public namespace over the existing profile implementation.
- `src/index.ts` exports that namespace from the package root.
- `src/auth-profile.ts` names reusable option/result types, keeps `signal` portable as `string | null`, and validates worker timeout/output limits.
- `test/auth-profile.test.ts` exercises public metadata, redacted output, runtime errors, unsafe bounds, timeout termination, inherited-secret removal, and profile locking.
- `README.md`, `PLAN.md`, `skills/browser-control/SKILL.md`, and `.changeset/calm-profile-workers.md` document and release the API.

## Scope

The public SDK intentionally does not expose raw profile reads, writes, capture, or refresh. It does not change relay/browser behavior and should only run commands trusted to receive the selected profile credentials.

## Testing

- `pnpm run ci`: typecheck, 460 unit tests, CLI and extension builds, and extension package validation passed.
- `pnpm pack`: inspected the `0.4.1` candidate tarball and verified it contains `dist/index.js`, `dist/types/index.d.ts`, `dist/types/secret-profile.d.ts`, and its declaration dependencies.
- Clean tarball consumer: installed with Bun, passed strict `bunx tsc --noEmit` with `types: []` and no `@types/node`, then used an isolated home/profile to verify metadata redaction, `${BC_SECRET_1}` output replacement, and `instanceof SecretProfile.Error`.
- Browser smoke was not run because this API reads the local profile store and spawns a local worker; it does not use the relay or extension.

## Flow

```mermaid
sequenceDiagram
    participant App as Generated application
    participant SDK as SecretProfile SDK
    participant Store as Mode-0600 profile
    participant Worker as Trusted child process
    App->>SDK: run({ name, command, args })
    SDK->>SDK: Validate timeout and output bounds
    SDK->>Store: Read selected profile
    SDK->>Worker: Spawn with BC_SECRET_N environment
    Worker-->>SDK: Bounded stdout / stderr
    SDK->>SDK: Replace known values with stable references
    SDK-->>App: Exit metadata and redacted output
```