### PR TITLE
fix(session): make deletion idempotent

### DIFF
--- a/.changeset/kind-sessions-clean.md
+++ b/.changeset/kind-sessions-clean.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Make session deletion idempotent when the requested session is already absent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,8 @@ local Node relay.
   navigation timestamps.
 - Session delete/reset must acquire the session's execute permit before closing
   the sandbox, so running scripts are never yanked mid-flight.
+- Session deletion is idempotent for a resolved session id: return whether a
+  live session was deleted instead of failing when it is already absent.
 - Reset/delete of an absent persisted relay-owned target waits for protocol-v1
   inventory reconciliation or a bounded grace, then forgets the dead identity
   without guessing a physical tab to close. Never apply this dead-target path

--- a/PLAN.md
+++ b/PLAN.md
@@ -71,6 +71,12 @@ Verification:
 
 ## Recently Shipped
 
+### Session cleanup is safely repeatable
+
+Deleting a resolved session id is idempotent across HTTP, CLI, and MCP. The
+structured result reports whether a live session was deleted, while CLI cleanup
+retries no longer turn an already-absent session into a failure.
+
 ### Handoffs return on a live destination context
 
 After a human completes a navigation-triggering handoff, Browser Control waits

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ result envelope. Delete the session when you finish:
 browser-control session delete docs
 ```
 
+Deletion is idempotent for an explicit session id, so cleanup can be safely
+retried when that session is already absent.
+
 ## Control an Existing Tab
 
 Relay-created pages are isolated from other Browser Control sessions. To use a

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -119,6 +119,9 @@ browser-control session reset github
 browser-control session delete github
 ```
 
+Deletion is idempotent for an explicit session id, so cleanup can be safely
+retried when that session is already absent.
+
 Every execute is journaled under
 `~/.browser-control/sessions/<id>/journal.jsonl`. The journal records code,
 status, duration, URL movement, warnings, handoffs, and bounded diagnostics.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -438,11 +438,16 @@ const sessionDelete = Command.make(
   Effect.fn("Cli.sessionDelete")(function* ({ id, session }) {
     const relay = yield* RelayClient.Service
     const store = yield* SessionStore.Service
-    const sessionId = yield* resolveExistingSessionId(resolveExplicitSessionSelector({
+    const selectedSessionId = resolveExplicitSessionSelector({
       positional: optionString(id),
       flag: optionString(session),
       environment: Option.getOrUndefined(yield* sessionIdConfig),
-    }))
+    })
+    const sessionId = selectedSessionId ?? (yield* store.read)
+    if (!sessionId) {
+      return yield* Effect.fail(new Error("No session provided and no current Browser Control session exists"))
+    }
+    yield* ensureCliRelay()
     yield* relay.sessionDelete(sessionId)
     const current = yield* store.read
     if (current === sessionId) {

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -374,11 +374,7 @@ function handleCliRequest(options: {
       const request = yield* decodeRequest(SessionIdRequest, body, "session delete")
       const id = requiredSessionId(request.id)
       const deleted = yield* options.sessions.delete(id)
-      if (!deleted) {
-        sendJson(options.response, { error: `Session not found: ${id}`, code: "session-not-found" }, 404)
-        return
-      }
-      sendJson(options.response, { deleted: true, id })
+      sendJson(options.response, { deleted, id })
       return
     }
     if (options.pathname === "/cli/session/reset" && options.request.method === "POST") {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -37,6 +37,7 @@ type AdoptArguments = {
 }
 
 const emptyInputSchema = objectSchema({})
+export const sessionDeleteIsIdempotent = true
 
 function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSession): readonly ToolSpec[] {
   return [
@@ -152,7 +153,7 @@ function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSess
       }),
       readOnly: false,
       destructive: true,
-      idempotent: true,
+      idempotent: false,
       handle: (input) => Effect.gen(function* () {
         const id = optionalStringField(input, "id") ?? currentSession.id
         const session = yield* relay.sessionReset(id)
@@ -169,7 +170,7 @@ function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSess
       }),
       readOnly: false,
       destructive: true,
-      idempotent: false,
+      idempotent: sessionDeleteIsIdempotent,
       handle: (input) => Effect.gen(function* () {
         const id = optionalStringField(input, "id") ?? currentSession.id
         const result = yield* relay.sessionDelete(id)

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -152,7 +152,7 @@ function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSess
       }),
       readOnly: false,
       destructive: true,
-      idempotent: false,
+      idempotent: true,
       handle: (input) => Effect.gen(function* () {
         const id = optionalStringField(input, "id") ?? currentSession.id
         const session = yield* relay.sessionReset(id)

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -126,6 +126,10 @@ describe("HTTP request schemas", () => {
         status: 404,
         body: { error: "Session not found: ghost", code: "session-not-found" },
       })
+      await expect(postJson(port, "/cli/session/delete", { id: "ghost" })).resolves.toMatchObject({
+        status: 200,
+        body: { deleted: false, id: "ghost" },
+      })
       await expect(postJson(port, "/cli/session/adopt", {
         sessionId: "beta",
         createIfMissing: false,

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { mcpErrorMessage, mcpToolRequiresRelayCompatibility, toolResultForValue } from "../src/mcp.ts"
+import { mcpErrorMessage, mcpToolRequiresRelayCompatibility, sessionDeleteIsIdempotent, toolResultForValue } from "../src/mcp.ts"
 
 describe("MCP tool results", () => {
   it("rechecks relay compatibility for operational tools", () => {
@@ -9,6 +9,10 @@ describe("MCP tool results", () => {
     expect(mcpToolRequiresRelayCompatibility("status")).toBe(false)
     expect(mcpToolRequiresRelayCompatibility("session_current")).toBe(false)
     expect(mcpToolRequiresRelayCompatibility("skill")).toBe(false)
+  })
+
+  it("advertises session deletion as idempotent", () => {
+    expect(sessionDeleteIsIdempotent).toBe(true)
   })
 
   it("marks execute script failures as failed MCP tool calls", () => {

--- a/test/relay-client.test.ts
+++ b/test/relay-client.test.ts
@@ -80,11 +80,16 @@ describe("RelayClient", () => {
   })
 
   it("keeps the relay's error message as the top-level failure message", async () => {
-    routes.set("POST /cli/session/delete", { status: 404, body: { error: "Session not found: ghost", code: "session-not-found" } })
-    const error = await withClient((client) => client.sessionDelete("ghost").pipe(Effect.flip))
+    routes.set("POST /cli/session/reset", { status: 404, body: { error: "Session not found: ghost", code: "session-not-found" } })
+    const error = await withClient((client) => client.sessionReset("ghost").pipe(Effect.flip))
     expect(error._tag).toBe("RelayClient.RelayRejected")
     expect(error.message).toBe("Session not found: ghost")
     expect(error._tag === "RelayClient.RelayRejected" ? error.code : undefined).toBe("session-not-found")
+  })
+
+  it("decodes an idempotent delete for an absent session", async () => {
+    routes.set("POST /cli/session/delete", { status: 200, body: { deleted: false, id: "ghost" } })
+    await expect(withClient((client) => client.sessionDelete("ghost"))).resolves.toEqual({ deleted: false, id: "ghost" })
   })
 
   it("fails with RelayRejected including HTTP status when no error envelope exists", async () => {


### PR DESCRIPTION
## What

Make deletion of an explicitly resolved Browser Control session id safely repeatable across HTTP, CLI, and MCP. Cleanup callers now receive a successful result when the session is already absent instead of turning an interrupted or repeated cleanup into a failure.

## Before / After

**Before:** `BrowserControlSessions.delete(id)` already returned `false` for an absent session, but the HTTP adapter converted that result to `404 session-not-found`. The CLI also listed sessions first and failed before issuing delete. Repeating `browser-control session delete ghost-session` therefore failed even though the desired end state had already been reached. MCP advertised the operation as non-idempotent.

**After:** the HTTP endpoint returns `{ deleted: false, id }` with status 200, the CLI sends delete directly once it has resolved an explicit or persisted id, and MCP advertises `session_delete` with `idempotentHint: true`. A missing selector still fails rather than inventing a session id. Reset remains non-idempotent.

## How

- `src/http-api.ts` preserves the session manager's boolean deletion result.
- `src/cli.ts` resolves a concrete id without preflighting session existence, ensures the relay, then deletes it.
- `src/mcp.ts` marks only `session_delete` as idempotent.
- HTTP, relay-client, and MCP tests lock the response and annotation contracts.
- README, agent workflow, architecture guidance, plan, and Changesets metadata document the behavior.

## Scope

This does not make session reset idempotent, delete an inferred arbitrary session, remove journals, or change how live session sandboxes and targets are closed. The existing execute-permit and persistence behavior remains unchanged.

## Testing

- `pnpm run ci`: typecheck, 462 unit tests, CLI/extension builds, and extension package validation passed.
- Isolated CLI E2E: started a foreground relay on port `21993` with a temporary `HOME`; two consecutive `node dist/cli.js session delete ghost-session` calls both exited 0 and printed the resolved id.
- Isolated MCP protocol check: negotiated protocol `2025-11-25` with built `dist/mcp.js`, requested `tools/list`, and verified `session_delete.annotations.idempotentHint === true`.
- No browser smoke was run because deletion of an absent session does not touch an extension target or page.

## Flow

```mermaid
sequenceDiagram
    participant Caller as CLI or MCP caller
    participant Relay as Relay HTTP adapter
    participant Sessions as Session manager
    Caller->>Relay: delete(resolved session id)
    Relay->>Sessions: delete(id)
    alt live session exists
        Sessions-->>Relay: true
        Relay-->>Caller: success, deleted=true
    else session already absent
        Sessions-->>Relay: false
        Relay-->>Caller: success, deleted=false
    end
```