### PR TITLE
chore(release): mark Node floor as minor

### DIFF
--- a/.changeset/fresh-tools-build.md
+++ b/.changeset/fresh-tools-build.md
@@ -1,5 +1,5 @@
 ---
-"@opencode-ai/browser-control": patch
+"@opencode-ai/browser-control": minor
 ---
 
 Update Playwright, WebSocket, parser, package-manager, build, test, and TypeScript dependencies to their current compatible releases. Align the documented Node.js requirement with the Node 22.19 minimum required by the current Effect Platform runtime.


### PR DESCRIPTION
## What

Classify the pending Node.js minimum-version change as a minor release instead of a patch. This promotes the accumulated release candidate from `0.4.2` to `0.5.0`.

## Before / After

**Before:** the toolchain changeset requested a patch even though npm `0.4.1` supports Node 20 and the pending release requires Node 22.19. Consumers could receive a breaking runtime compatibility change through an apparently safe patch update.

**After:** Changesets reports a minor bump, making the Node support boundary visible in the release version.

## Scope

This changes only release metadata. It does not alter source, dependencies, artifacts, or the Node 22.19 requirement established in #62.

## Testing

- `pnpm install --frozen-lockfile` passed with supply-chain policy verification.
- `pnpm changeset status` reports a minor bump for `@opencode-ai/browser-control`.
- `git diff --check` passed.