### PR TITLE
fix(release): use Changesets action v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,10 @@ jobs:
       - run: npm install --global npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm run ci
-      - uses: changesets/action@v1
+      - uses: changesets/action@v2
         with:
-          publish: pnpm release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          publish-script: pnpm release
+          pr-draft: always
+          create-github-releases: true
+          push-git-tags: true


### PR DESCRIPTION
## What

Migrate the release workflow to `changesets/action@v2`, the action line compatible with `@changesets/cli` 3.x. Preserve draft version PRs and explicitly enable remote tags and GitHub Releases after trusted npm publishing.

## Before / After

**Before:** the `0.5.0` OIDC publish succeeded under Changesets CLI 3, but `changesets/action@v1` left the generated tag only in the ephemeral runner. The workflow exited successfully without a remote `v0.5.0` tag or GitHub Release.

**After:** action v2 consumes CLI 3 output and owns version PRs, npm publish, remote tag creation, and GitHub Release creation. Its GitHub token is passed through the v2 input rather than the obsolete environment contract.

The missing `v0.5.0` tag and GitHub Release were backfilled at release commit `acd81d0` with the generated changelog.

## Scope

Workflow infrastructure only. No npm package or runtime files change, so there is no changeset.

## Testing

- Confirmed action v2.1.1 input names from its published `action.yml`.
- `git diff --check` passed.
- Verified npm `latest` is `0.5.0`, remote tag `v0.5.0` exists, and the GitHub Release is published with the generated notes.
- The release workflow itself still runs `pnpm run ci` before invoking Changesets.