### PR TITLE
refactor(core): simplify lifecycle paths

### DIFF
--- a/.changeset/tidy-runtime-paths.md
+++ b/.changeset/tidy-runtime-paths.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Simplify session, target, recording, and extension lifecycles while avoiding duplicate network-capture settlement and stale finalizer waiters.

--- a/extension/src/content-script.ts
+++ b/extension/src/content-script.ts
@@ -1,5 +1,5 @@
 import type { PageStatus } from "../../src/protocol.ts"
-import { pageStatusView } from "./page-status.ts"
+import { pageStatusFromJson, pageStatusView } from "./page-status.ts"
 
 const hostId = "__browser_control_page_status__"
 let currentStatus: PageStatus | undefined
@@ -19,8 +19,9 @@ chrome.runtime.onMessage.addListener((message: unknown) => {
     clearStatus()
     return
   }
-  if (incoming.action === "page-status.set" && isPageStatus(incoming.status)) {
-    currentStatus = incoming.status
+  const status = pageStatusFromJson(incoming.status)
+  if (incoming.action === "page-status.set" && status) {
+    currentStatus = status
     completingHandoffId = undefined
     renderStatus()
   }
@@ -188,7 +189,7 @@ function renderStatus(): void {
     const vignette = document.createElement("div")
     vignette.id = "vignette"
     host.shadowRoot?.insertBefore(vignette, statusElement)
-    positionWaitingStatus(host, statusElement)
+    positionWaitingStatus(host)
   }
   if (!host.isConnected) {
     document.documentElement.append(host)
@@ -196,7 +197,7 @@ function renderStatus(): void {
   observeHost()
 }
 
-function positionWaitingStatus(host: HTMLElement, statusElement: HTMLElement): void {
+function positionWaitingStatus(host: HTMLElement): void {
   const cursor = document.getElementById("__browser_control_ghost_cursor__")
   const x = Number(cursor?.dataset.targetX)
   const y = Number(cursor?.dataset.targetY)
@@ -275,15 +276,4 @@ function observeHost(): void {
     }
   })
   observer.observe(document.documentElement, { childList: true })
-}
-
-function isPageStatus(value: unknown): value is PageStatus {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false
-  }
-  const candidate = value as { readonly state?: unknown; readonly owner?: unknown; readonly message?: unknown; readonly handoffId?: unknown }
-  const validState = candidate.state === "attached" || candidate.state === "running" || candidate.state === "waiting"
-  const validOwner = candidate.owner === "session" || candidate.owner === "user"
-  const validHandoff = candidate.state !== "waiting" || (typeof candidate.message === "string" && typeof candidate.handoffId === "string")
-  return validState && validOwner && validHandoff
 }

--- a/extension/src/page-status.ts
+++ b/extension/src/page-status.ts
@@ -1,4 +1,4 @@
-import type { JsonObject, PageStatus } from "../../src/protocol.ts"
+import { isJsonObject, type PageStatus } from "../../src/protocol.ts"
 
 export type PageStatusView = {
   readonly label: string
@@ -51,22 +51,23 @@ export function pageStatusView(status: PageStatus): PageStatusView {
   }
 }
 
-export function pageStatusFromJson(value: JsonObject | undefined): PageStatus | undefined {
-  const state = value?.state
-  const owner = value?.owner
+export function pageStatusFromJson(value: unknown): PageStatus | undefined {
+  if (!isJsonObject(value)) return undefined
+  const state = value.state
+  const owner = value.owner
   if ((state !== "attached" && state !== "running" && state !== "waiting") || (owner !== "session" && owner !== "user")) {
     return undefined
   }
-  const message = value?.message
-  const handoffId = value?.handoffId
+  const message = value.message
+  const handoffId = value.handoffId
   if (state === "waiting" && (typeof message !== "string" || typeof handoffId !== "string")) {
     return undefined
   }
   return {
     state,
     owner,
-    ...(typeof value?.sessionId === "string" ? { sessionId: value.sessionId } : {}),
-    ...(value?.readOnly === true ? { readOnly: true } : {}),
+    ...(typeof value.sessionId === "string" ? { sessionId: value.sessionId } : {}),
+    ...(value.readOnly === true ? { readOnly: true } : {}),
     ...(typeof message === "string" ? { message } : {}),
     ...(typeof handoffId === "string" ? { handoffId } : {}),
   }

--- a/scripts/build-cli.ts
+++ b/scripts/build-cli.ts
@@ -14,23 +14,25 @@ const execFileAsync = promisify(execFile)
 
 await fs.rm(dist, { recursive: true, force: true })
 await fs.mkdir(dist, { recursive: true })
-await build({
-  entryPoints: {
-    cli: path.join(root, "src", "cli.ts"),
-    index: path.join(root, "src", "index.ts"),
-    mcp: path.join(root, "src", "mcp-main.ts"),
-  },
-  bundle: true,
-  format: "esm",
-  platform: "node",
-  target: "node22",
-  packages: "external",
-  define: {
-    "globalThis.__BROWSER_CONTROL_VERSION__": JSON.stringify(packageJson.version),
-    "globalThis.__BROWSER_CONTROL_BUILD_ID__": JSON.stringify(buildId),
-  },
-  outdir: dist,
-})
-await execFileAsync(path.join(root, "node_modules", ".bin", "tsc"), ["-p", path.join(root, "tsconfig.build.json")])
+await Promise.all([
+  build({
+    entryPoints: {
+      cli: path.join(root, "src", "cli.ts"),
+      index: path.join(root, "src", "index.ts"),
+      mcp: path.join(root, "src", "mcp-main.ts"),
+    },
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    target: "node22",
+    packages: "external",
+    define: {
+      "globalThis.__BROWSER_CONTROL_VERSION__": JSON.stringify(packageJson.version),
+      "globalThis.__BROWSER_CONTROL_BUILD_ID__": JSON.stringify(buildId),
+    },
+    outdir: dist,
+  }),
+  execFileAsync(path.join(root, "node_modules", ".bin", "tsc"), ["-p", path.join(root, "tsconfig.build.json")]),
+])
 await fs.chmod(path.join(dist, "cli.js"), 0o755)
 await fs.chmod(path.join(dist, "mcp.js"), 0o755)

--- a/scripts/build-extension.ts
+++ b/scripts/build-extension.ts
@@ -8,25 +8,27 @@ const dist = path.join(root, "extension", "dist")
 
 await fs.rm(dist, { recursive: true, force: true })
 await fs.mkdir(dist, { recursive: true })
-await build({
-  entryPoints: [
-    path.join(root, "extension", "src", "background.ts"),
-    path.join(root, "extension", "src", "offscreen.ts"),
-  ],
-  bundle: true,
-  format: "esm",
-  platform: "browser",
-  target: "chrome120",
-  outdir: dist,
-})
-await build({
-  entryPoints: [path.join(root, "extension", "src", "content-script.ts")],
-  bundle: true,
-  format: "iife",
-  platform: "browser",
-  target: "chrome120",
-  outdir: dist,
-})
+await Promise.all([
+  build({
+    entryPoints: [
+      path.join(root, "extension", "src", "background.ts"),
+      path.join(root, "extension", "src", "offscreen.ts"),
+    ],
+    bundle: true,
+    format: "esm",
+    platform: "browser",
+    target: "chrome120",
+    outdir: dist,
+  }),
+  build({
+    entryPoints: [path.join(root, "extension", "src", "content-script.ts")],
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "chrome120",
+    outdir: dist,
+  }),
+])
 await fs.copyFile(path.join(root, "extension", "manifest.json"), path.join(dist, "manifest.json"))
 await fs.copyFile(path.join(root, "extension", "src", "offscreen.html"), path.join(dist, "offscreen.html"))
 await fs.mkdir(path.join(dist, "icons"), { recursive: true })

--- a/src/cdp-shims.ts
+++ b/src/cdp-shims.ts
@@ -1,5 +1,5 @@
 import { WebSocket } from "ws"
-import type { CdpEvent, JsonObject, TargetInfo } from "./protocol.ts"
+import type { JsonObject, TargetInfo } from "./protocol.ts"
 import { getObject, sendCdpEvent } from "./relay-helpers.ts"
 import type { ChildTarget, ConnectedTarget } from "./relay-types.ts"
 import { shouldExposeChildTarget, type TargetRegistry } from "./target-registry.ts"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,8 +94,8 @@ const recordingTarget = Effect.fnUntraced(function* (options: {
   readonly session: Option.Option<string>
   readonly tabId: Option.Option<number>
 }) {
-  const sessionId = optionString(options.session)
-  const tabId = optionNumber(options.tabId)
+  const sessionId = Option.getOrUndefined(options.session)
+  const tabId = Option.getOrUndefined(options.tabId)
   if (sessionId && tabId !== undefined) {
     return yield* Effect.fail(new Error("Use only one recording target selector: --session or --tab-id"))
   }
@@ -184,14 +184,6 @@ function errorJsonEnvelope(error: unknown): ExecuteJsonEnvelope {
   return { ok: false, isError: true, text: message, value: null, valueUnavailable: true, error: { _tag: tag, message }, logs: [], warnings: [] }
 }
 
-function optionString(value: Option.Option<string>): string | undefined {
-  return Option.isSome(value) ? value.value : undefined
-}
-
-function optionNumber(value: Option.Option<number>): number | undefined {
-  return Option.isSome(value) ? value.value : undefined
-}
-
 const serve = Command.make(
   "serve",
   {},
@@ -227,7 +219,7 @@ const execute = Command.make(
   Effect.fn("Cli.execute")(function* ({ code, file, session, targetUrl, targetIndex, json }) {
     const run = Effect.gen(function* () {
       const relay = yield* RelayClient.Service
-      const filePath = optionString(file)
+      const filePath = Option.getOrUndefined(file)
       if (code.length > 0 && filePath) {
         return yield* Effect.fail(new Error("Use either positional code or --file, not both"))
       }
@@ -236,9 +228,9 @@ const execute = Command.make(
       }
       const executeCode = filePath ? yield* readExecuteFile(filePath) : code.join(" ")
       yield* ensureCliRelayAndExtension()
-      const explicitSessionId = optionString(session) ?? Option.getOrUndefined(yield* sessionIdConfig)
-      const targetUrlValue = optionString(targetUrl) ?? Option.getOrUndefined(yield* targetUrlConfig)
-      const targetIndexValue = optionNumber(targetIndex) ?? Option.getOrUndefined(yield* targetIndexConfig)
+      const explicitSessionId = Option.getOrUndefined(session) ?? Option.getOrUndefined(yield* sessionIdConfig)
+      const targetUrlValue = Option.getOrUndefined(targetUrl) ?? Option.getOrUndefined(yield* targetUrlConfig)
+      const targetIndexValue = Option.getOrUndefined(targetIndex) ?? Option.getOrUndefined(yield* targetIndexConfig)
       if (targetIndexValue !== undefined && targetIndexValue < 0) {
         return yield* Effect.fail(new Error("Target index must be a non-negative integer"))
       }
@@ -316,7 +308,7 @@ const sessionNew = Command.make(
     const relay = yield* RelayClient.Service
     yield* ensureCliRelay()
     const store = yield* SessionStore.Service
-    const result = yield* relay.sessionNew(optionString(name), readOnly ? { readOnly: true } : {})
+    const result = yield* relay.sessionNew(Option.getOrUndefined(name), readOnly ? { readOnly: true } : {})
     yield* store.write(result.id)
     yield* Console.log(result.id)
   }),
@@ -383,8 +375,8 @@ const sessionReset = Command.make(
   Effect.fn("Cli.sessionReset")(function* ({ id, session }) {
     const relay = yield* RelayClient.Service
     const sessionId = yield* resolveExistingSessionId(resolveExplicitSessionSelector({
-      positional: optionString(id),
-      flag: optionString(session),
+      positional: Option.getOrUndefined(id),
+      flag: Option.getOrUndefined(session),
       environment: Option.getOrUndefined(yield* sessionIdConfig),
     }))
     const resetSession = yield* relay.sessionReset(sessionId)
@@ -402,9 +394,9 @@ const sessionAdopt = Command.make(
   Effect.fn("Cli.sessionAdopt")(function* ({ session, targetUrl, targetIndex }) {
     const relay = yield* RelayClient.Service
     yield* ensureCliRelayAndExtension()
-    const explicitSessionId = optionString(session) ?? Option.getOrUndefined(yield* sessionIdConfig)
-    const targetUrlValue = optionString(targetUrl)
-    const targetIndexValue = optionNumber(targetIndex)
+    const explicitSessionId = Option.getOrUndefined(session) ?? Option.getOrUndefined(yield* sessionIdConfig)
+    const targetUrlValue = Option.getOrUndefined(targetUrl)
+    const targetIndexValue = Option.getOrUndefined(targetIndex)
     if (!targetUrlValue && targetIndexValue === undefined) {
       return yield* Effect.fail(new Error("session adopt requires --target-url or --target-index"))
     }
@@ -439,8 +431,8 @@ const sessionDelete = Command.make(
     const relay = yield* RelayClient.Service
     const store = yield* SessionStore.Service
     const selectedSessionId = resolveExplicitSessionSelector({
-      positional: optionString(id),
-      flag: optionString(session),
+      positional: Option.getOrUndefined(id),
+      flag: Option.getOrUndefined(session),
       environment: Option.getOrUndefined(yield* sessionIdConfig),
     })
     const sessionId = selectedSessionId ?? (yield* store.read)
@@ -586,9 +578,9 @@ const recordingStart = Command.make(
     const relay = yield* RelayClient.Service
     yield* ensureCliRelayAndExtension()
     const target = yield* recordingTarget({ session, tabId })
-    const modeValue = yield* parseRecordingModeOption(optionString(mode))
-    const frameRateValue = optionNumber(frameRate)
-    const maxDurationMsValue = optionNumber(maxDurationMs)
+    const modeValue = yield* parseRecordingModeOption(Option.getOrUndefined(mode))
+    const frameRateValue = Option.getOrUndefined(frameRate)
+    const maxDurationMsValue = Option.getOrUndefined(maxDurationMs)
     const resolvedOutputPath = path.resolve(outputPath)
     const result = yield* relay.recordingStart({
       ...target,
@@ -673,11 +665,11 @@ const recording = Command.make("recording").pipe(
 )
 
 const networkSession = Effect.fnUntraced(function* (session: Option.Option<string>) {
-  return yield* resolveExistingSessionId(optionString(session) ?? Option.getOrUndefined(yield* sessionIdConfig))
+  return yield* resolveExistingSessionId(Option.getOrUndefined(session) ?? Option.getOrUndefined(yield* sessionIdConfig))
 })
 
 const parseNetworkContent = Effect.fnUntraced(function* (content: Option.Option<string>) {
-  const value = optionString(content)
+  const value = Option.getOrUndefined(content)
   if (value === undefined || value === "embed" || value === "omit") return value
   return yield* Effect.fail(new Error("Network content must be embed or omit"))
 })
@@ -710,10 +702,10 @@ const networkStart = Command.make(
     yield* ensureCliRelayAndExtension()
     const sessionId = yield* networkSession(session)
     const contentValue = yield* parseNetworkContent(content)
-    const urlFilterValue = optionString(urlFilter)
-    const maxBodyBytesValue = optionNumber(maxBodyBytes)
-    const maxTotalBodyBytesValue = optionNumber(maxTotalBodyBytes)
-    const maxEntriesValue = optionNumber(maxEntries)
+    const urlFilterValue = Option.getOrUndefined(urlFilter)
+    const maxBodyBytesValue = Option.getOrUndefined(maxBodyBytes)
+    const maxTotalBodyBytesValue = Option.getOrUndefined(maxTotalBodyBytes)
+    const maxEntriesValue = Option.getOrUndefined(maxEntries)
     const result = yield* relay.networkStart({
       sessionId,
       ...(urlFilterValue === undefined ? {} : { urlFilter: urlFilterValue }),
@@ -752,8 +744,8 @@ const networkStop = Command.make(
   Effect.fn("Cli.networkStop")(function* ({ session, output, secrets, json }) {
     const relay = yield* RelayClient.Service
     const sessionId = yield* networkSession(session)
-    const outputValue = optionString(output)
-    const secretsValue = optionString(secrets)
+    const outputValue = Option.getOrUndefined(output)
+    const secretsValue = Option.getOrUndefined(secrets)
     if (!outputValue && !secretsValue) {
       return yield* Effect.fail(new Error("network stop requires --output, --secrets, or both"))
     }
@@ -814,8 +806,8 @@ const secretsRefresh = Command.make(
     const relay = yield* RelayClient.Service
     yield* ensureCliRelayAndExtension()
     const sessionId = yield* networkSession(session)
-    const urlFilterValue = optionString(urlFilter)
-    const timeoutMsValue = optionNumber(timeoutMs)
+    const urlFilterValue = Option.getOrUndefined(urlFilter)
+    const timeoutMsValue = Option.getOrUndefined(timeoutMs)
     const result = yield* relay.authRefresh({
       sessionId,
       name,
@@ -839,8 +831,8 @@ const secretsRun = Command.make(
     yield* ensureCliRelay()
     const [executable, ...args] = decodeCliOperands(command)
     if (!executable) return yield* Effect.fail(new Error("secrets run requires a command after --"))
-    const cwdValue = optionString(cwd)
-    const timeoutMsValue = optionNumber(timeoutMs)
+    const cwdValue = Option.getOrUndefined(cwd)
+    const timeoutMsValue = Option.getOrUndefined(timeoutMs)
     const result = yield* relay.authRun({
       name,
       command: executable,
@@ -871,12 +863,12 @@ const journal = Command.make(
   },
   Effect.fn("Cli.journal")(function* ({ session, limit, json }) {
     const store = yield* SessionStore.Service
-    const sessionId = optionString(session) ?? Option.getOrUndefined(yield* sessionIdConfig) ?? (yield* store.read)
+    const sessionId = Option.getOrUndefined(session) ?? Option.getOrUndefined(yield* sessionIdConfig) ?? (yield* store.read)
     if (!sessionId) {
       return yield* Effect.fail(new Error("No session provided and no current Browser Control session exists"))
     }
     const entries = yield* Effect.tryPromise({
-      try: () => readJournalEntries({ baseDir: defaultJournalBaseDir(), sessionId, limit: optionNumber(limit) ?? 20 }),
+      try: () => readJournalEntries({ baseDir: defaultJournalBaseDir(), sessionId, limit: Option.getOrUndefined(limit) ?? 20 }),
       catch: (cause) => new Error(`read session journal for ${sessionId}`, { cause }),
     })
     if (json) {

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -480,7 +480,7 @@ export class ExecuteSandbox {
       },
     }).pipe(
       Effect.uninterruptible,
-      Effect.ensuring(Effect.promise(() => this.networkCapture.settleForOutput())),
+      Effect.tapError(() => Effect.promise(() => this.networkCapture.settleForOutput())),
       Effect.match({
         onFailure: (error): ExecuteResult => {
           const logSummary = error instanceof ExecuteCodeError ? error.logSummary : emptyExecuteLogSummary()
@@ -558,82 +558,44 @@ export class ExecuteSandbox {
   }
 
   close(): Effect.Effect<void, Error> {
-    const sandbox = this
-    return Effect.gen(function* () {
-      const page = sandbox.page
-      const browser = sandbox.browser
-      const ownsOpenPage = page !== undefined && sandbox.ownsPage && !page.isClosed()
-      sandbox.browser = undefined
-      sandbox.page = undefined
-      sandbox.clearPageListeners()
-      sandbox.defaultPageTargetId = undefined
-      sandbox.ownsPage = false
-      sandbox.pageHealthCheckRequired = false
-      sandbox.pendingPageTarget = undefined
-      sandbox.notifyDefaultTargetChange()
-      yield* sandbox.networkCapture.cancel()
-
-      if (ownsOpenPage) {
-        yield* runPlaywrightOperation({
-          label: "Close sandbox page",
-          timeoutMs: playwrightCloseTimeoutMs,
-          run: () => page.close(),
-        }).pipe(Effect.ignore)
-      }
-      if (browser) {
-        yield* runPlaywrightOperation({
-          label: "Close sandbox browser connection",
-          timeoutMs: playwrightCloseTimeoutMs,
-          run: () => browser.close(),
-        }).pipe(Effect.ignore)
-      }
+    return this.teardown({
+      mode: "close",
+      pageLabel: "Close sandbox page",
+      browserLabel: "Close sandbox browser connection",
     })
   }
 
   disconnect(): Effect.Effect<void, Error> {
-    const sandbox = this
-    return Effect.gen(function* () {
-      const browser = sandbox.browser
-      sandbox.browser = undefined
-      sandbox.page = undefined
-      sandbox.clearPageListeners()
-      sandbox.pageHealthCheckRequired = false
-      if (sandbox.defaultPageTargetId) {
-        sandbox.pendingPageTarget = { targetId: sandbox.defaultPageTargetId, warnReplaced: false }
-      }
-      yield* sandbox.networkCapture.cancel()
-      if (browser) {
-        yield* runPlaywrightOperation({
-          label: "Disconnect sandbox browser during relay shutdown",
-          timeoutMs: playwrightCloseTimeoutMs,
-          run: () => browser.close(),
-        }).pipe(Effect.ignore)
-      }
+    return this.teardown({
+      mode: "disconnect",
+      browserLabel: "Disconnect sandbox browser during relay shutdown",
     })
   }
 
   disconnectSettled(): Effect.Effect<void, Error> {
-    const sandbox = this
-    return Effect.gen(function* () {
-      const browser = sandbox.browser
-      sandbox.browser = undefined
-      sandbox.page = undefined
-      sandbox.clearPageListeners()
-      sandbox.pageHealthCheckRequired = false
-      if (sandbox.defaultPageTargetId) {
-        sandbox.pendingPageTarget = { targetId: sandbox.defaultPageTargetId, warnReplaced: false }
-      }
-      yield* sandbox.networkCapture.cancel()
-      if (browser) {
-        yield* runSettledPlaywrightOperation({
-          label: "Disconnect sandbox browser after handoff cancellation",
-          run: () => browser.close(),
-        }).pipe(Effect.ignore)
-      }
+    return this.teardown({
+      mode: "disconnect",
+      settled: true,
+      browserLabel: "Disconnect sandbox browser after handoff cancellation",
     })
   }
 
   closeSettled(): Effect.Effect<void, Error> {
+    return this.teardown({
+      mode: "close",
+      settled: true,
+      pageLabel: "Close sandbox page after adoption",
+      browserLabel: "Close sandbox browser connection after adoption",
+    })
+  }
+
+  private teardown(options: {
+    readonly settled?: boolean
+    readonly browserLabel: string
+  } & (
+    | { readonly mode: "close"; readonly pageLabel: string }
+    | { readonly mode: "disconnect" }
+  )): Effect.Effect<void, Error> {
     const sandbox = this
     return Effect.gen(function* () {
       const page = sandbox.page
@@ -642,24 +604,26 @@ export class ExecuteSandbox {
       sandbox.browser = undefined
       sandbox.page = undefined
       sandbox.clearPageListeners()
-      sandbox.defaultPageTargetId = undefined
-      sandbox.ownsPage = false
       sandbox.pageHealthCheckRequired = false
-      sandbox.pendingPageTarget = undefined
-      sandbox.notifyDefaultTargetChange()
+      if (options.mode === "close") {
+        sandbox.defaultPageTargetId = undefined
+        sandbox.ownsPage = false
+        sandbox.pendingPageTarget = undefined
+        sandbox.notifyDefaultTargetChange()
+      } else if (sandbox.defaultPageTargetId) {
+        sandbox.pendingPageTarget = { targetId: sandbox.defaultPageTargetId, warnReplaced: false }
+      }
       yield* sandbox.networkCapture.cancel()
 
-      if (ownsOpenPage) {
-        yield* runSettledPlaywrightOperation({
-          label: "Close sandbox page after adoption",
-          run: () => page.close(),
-        }).pipe(Effect.ignore)
+      const run = <A>(label: string, operation: () => Promise<A>): Effect.Effect<A, Error> => options.settled
+        ? runSettledPlaywrightOperation({ label, run: operation })
+        : runPlaywrightOperation({ label, timeoutMs: playwrightCloseTimeoutMs, run: operation })
+
+      if (options.mode === "close" && ownsOpenPage) {
+        yield* run(options.pageLabel, () => page.close()).pipe(Effect.ignore)
       }
       if (browser) {
-        yield* runSettledPlaywrightOperation({
-          label: "Close sandbox browser connection after adoption",
-          run: () => browser.close(),
-        }).pipe(Effect.ignore)
+        yield* run(options.browserLabel, () => browser.close()).pipe(Effect.ignore)
       }
     })
   }

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -8,7 +8,6 @@ import {
   formatHostForUrl,
   headerValue,
   optionalSessionId,
-  parseTargetSelection,
   readJsonBody,
   requiredSessionId,
   sendJson,
@@ -393,10 +392,7 @@ function handleCliRequest(options: {
       const body = yield* readJsonBody(options.request)
       const request = yield* decodeRequest(SessionAdoptRequest, body, "session adopt")
       const requestedSessionId = optionalSessionId(request.sessionId)
-      const targetSelection = parseTargetSelection(request.targetSelection)
-      if (!targetSelection) {
-        throw new Error("targetSelection is required")
-      }
+      const targetSelection = request.targetSelection
       const selectedTarget = selectTarget({
         targets: options.registry.listRootTargets(),
         selection: targetSelection,
@@ -419,7 +415,7 @@ function handleCliRequest(options: {
       const body = yield* readJsonBody(options.request)
       const request = yield* decodeRequest(ExecuteRequest, body, "execute")
       const requestedSessionId = optionalSessionId(request.sessionId)
-      const targetSelection = parseTargetSelection(request.targetSelection)
+      const targetSelection = request.targetSelection
       const { result, session } = yield* options.sessions.execute({
         ...(requestedSessionId ? { sessionId: requestedSessionId } : {}),
         code: request.code,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -230,10 +230,7 @@ function makeToolSpecs(relay: RelayClient.Interface, currentSession: CurrentSess
         if (explicitSession) {
           yield* ensureSessionExists(relay, sessionId)
         } else {
-          const sessions = yield* relay.sessions
-          if (!sessions.some((session) => session.id === sessionId)) {
-            yield* relay.sessionNew(sessionId)
-          }
+          yield* relay.sessionEnsure(sessionId)
           currentSession.established = true
         }
         yield* RelayLifecycle.ensureExtensionConnected({ relay, waitForReconnect: true })

--- a/src/network-capture.ts
+++ b/src/network-capture.ts
@@ -106,7 +106,7 @@ type ActiveCapture = {
   readonly pending: Map<Request, PendingEntry>
   readonly entries: CapturedEntry[]
   readonly finalizeQueue: FinalizeWork[]
-  readonly finalizeWaiters: Array<() => void>
+  readonly finalizeWaiters: Set<() => void>
   readonly liveCollector: SecretCollector
   finalizeWorkers: number
   finalizeGeneration: number
@@ -155,7 +155,7 @@ export class Recorder {
           pending: new Map(),
           entries: [],
           finalizeQueue: [],
-          finalizeWaiters: [],
+          finalizeWaiters: new Set(),
           liveCollector: new SecretCollector(),
           finalizeWorkers: 0,
           finalizeGeneration: 0,
@@ -778,10 +778,12 @@ async function bodyWithTimeout(response: Response, timeoutMs: number): Promise<B
 async function settleFinalizers(active: ActiveCapture, timeoutMs: number): Promise<boolean> {
   if (active.pending.size === 0 && active.finalizeQueue.length === 0 && active.finalizeWorkers === 0) return true
   let timeout: NodeJS.Timeout | undefined
+  let waiter: (() => void) | undefined
   try {
     return await Promise.race([
       new Promise<true>((resolve) => {
-        active.finalizeWaiters.push(() => resolve(true))
+        waiter = () => resolve(true)
+        active.finalizeWaiters.add(waiter)
       }),
       new Promise<false>((resolve) => {
         timeout = setTimeout(() => resolve(false), timeoutMs)
@@ -789,12 +791,14 @@ async function settleFinalizers(active: ActiveCapture, timeoutMs: number): Promi
     ])
   } finally {
     if (timeout) clearTimeout(timeout)
+    if (waiter) active.finalizeWaiters.delete(waiter)
   }
 }
 
 function notifyFinalizersSettled(active: ActiveCapture): void {
   if (active.pending.size > 0 || active.finalizeQueue.length > 0 || active.finalizeWorkers > 0) return
-  for (const resolve of active.finalizeWaiters.splice(0)) resolve()
+  for (const resolve of active.finalizeWaiters) resolve()
+  active.finalizeWaiters.clear()
 }
 
 function safeValue<A>(read: () => A, fallback: A): A {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -63,61 +63,7 @@ export type PageStatus = {
   readonly handoffId?: string
 }
 
-export type ExtensionCommand = {
-  readonly id: number
-  readonly method:
-    | "ping"
-    | "debugger.attach"
-    | "debugger.detach"
-    | "debugger.sendCommand"
-    | "tabs.create"
-    | "tabs.remove"
-    | "tabs.group"
-    | "tabs.ungroup"
-    | "action.setAttached"
-    | "action.setBadge"
-    | "pageStatus.set"
-    | "pageStatus.clear"
-    | "runtime.reload"
-    | "recording.start"
-    | "recording.stop"
-    | "recording.status"
-    | "recording.cancel"
-  readonly params?: JsonObject
-}
-
-export type ExtensionResponse = {
-  readonly id: number
-  readonly result?: JsonObject
-  readonly error?: string
-}
-
-export type ExtensionEvent = {
-  readonly method:
-    | "hello"
-    | "ready"
-    | "toolbar.clicked"
-    | "handoff.completed"
-    | "debugger.event"
-    | "debugger.attached"
-    | "debugger.detached"
-    | "tabs.removed"
-    | "pong"
-    | "log"
-    | "recording.cancelled"
-    | "pageStatus.requested"
-  readonly params?: JsonObject
-}
-
-export function parseJsonObject(input: string): JsonObject {
-  const parsed: unknown = JSON.parse(input)
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("Expected JSON object")
-  }
-  return parsed as JsonObject
-}
-
-const extensionCommandMethods = new Set<ExtensionCommand["method"]>([
+const extensionCommandMethodValues = [
   "ping",
   "debugger.attach",
   "debugger.detach",
@@ -135,9 +81,9 @@ const extensionCommandMethods = new Set<ExtensionCommand["method"]>([
   "recording.stop",
   "recording.status",
   "recording.cancel",
-])
+] as const
 
-const extensionEventMethods = new Set<ExtensionEvent["method"]>([
+const extensionEventMethodValues = [
   "hello",
   "ready",
   "toolbar.clicked",
@@ -150,14 +96,46 @@ const extensionEventMethods = new Set<ExtensionEvent["method"]>([
   "log",
   "recording.cancelled",
   "pageStatus.requested",
-])
+] as const
+
+type ExtensionCommandMethod = typeof extensionCommandMethodValues[number]
+type ExtensionEventMethod = typeof extensionEventMethodValues[number]
+
+export type ExtensionCommand = {
+  readonly id: number
+  readonly method: ExtensionCommandMethod
+  readonly params?: JsonObject
+}
+
+export type ExtensionResponse = {
+  readonly id: number
+  readonly result?: JsonObject
+  readonly error?: string
+}
+
+export type ExtensionEvent = {
+  readonly method: ExtensionEventMethod
+  readonly params?: JsonObject
+}
+
+export function parseJsonObject(input: string): JsonObject {
+  const parsed: unknown = JSON.parse(input)
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Expected JSON object")
+  }
+  return parsed as JsonObject
+}
+
+const extensionCommandMethods = new Set<string>(extensionCommandMethodValues)
+
+const extensionEventMethods = new Set<string>(extensionEventMethodValues)
 
 export function parseExtensionCommand(input: string): ExtensionCommand {
   const parsed = parseJsonObject(input)
   if (
     typeof parsed.id !== "number" ||
     typeof parsed.method !== "string" ||
-    !extensionCommandMethods.has(parsed.method as ExtensionCommand["method"]) ||
+    !extensionCommandMethods.has(parsed.method) ||
     (parsed.params !== undefined && !isJsonObject(parsed.params))
   ) {
     throw new Error("Invalid extension command")
@@ -181,10 +159,10 @@ export function isExtensionResponse(input: JsonObject): input is ExtensionRespon
 
 export function isExtensionEvent(input: JsonObject): input is ExtensionEvent {
   return typeof input.method === "string" &&
-    extensionEventMethods.has(input.method as ExtensionEvent["method"]) &&
+    extensionEventMethods.has(input.method) &&
     (input.params === undefined || isJsonObject(input.params))
 }
 
-function isJsonObject(value: JsonValue): value is JsonObject {
+export function isJsonObject(value: unknown): value is JsonObject {
   return value !== null && typeof value === "object" && !Array.isArray(value)
 }

--- a/src/recording-relay.ts
+++ b/src/recording-relay.ts
@@ -395,22 +395,7 @@ export class RecordingRelay {
       await recording.promise?.catch(() => {})
     }))
     await Promise.all(active.map(async (recording) => {
-      if (recording.mode === "tab-capture" && recording.finalizePromise) {
-        await recording.finalizePromise
-        return
-      }
-      if (recording.resolveStop) {
-        recording.resolveStop({ success: false, error: reason })
-      }
-      if (recording.mode === "cdp") {
-        if (recording.stopPromise) {
-          await recording.stopPromise.catch(() => {})
-          return
-        }
-        await this.cancelCdpRecording(recording)
-        return
-      }
-      await this.cleanupRecording(recording.tabId)
+      await this.abortActiveRecording(recording, reason)
     }))
   }
 
@@ -425,11 +410,15 @@ export class RecordingRelay {
     if (!recording) {
       return
     }
+    await this.abortActiveRecording(recording, options.reason)
+  }
+
+  private async abortActiveRecording(recording: ActiveRecording, reason: string): Promise<void> {
     if (recording.mode === "tab-capture" && recording.finalizePromise) {
       await recording.finalizePromise
       return
     }
-    recording.resolveStop?.({ success: false, error: options.reason })
+    recording.resolveStop?.({ success: false, error: reason })
     if (recording.mode === "cdp") {
       if (recording.stopPromise) {
         await recording.stopPromise.catch(() => {})

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -88,11 +88,9 @@ export const SessionEnsureRequest = Schema.Struct({
 
 export interface SessionEnsureRequest extends Schema.Schema.Type<typeof SessionEnsureRequest> {}
 
-export const SessionEnsureResponse = Schema.Struct({
-  session: SessionSummary,
-})
+export const SessionEnsureResponse = SessionContainer
 
-export interface SessionEnsureResponse extends Schema.Schema.Type<typeof SessionEnsureResponse> {}
+export type SessionEnsureResponse = SessionContainer
 
 export const SessionIdRequest = Schema.Struct({
   id: Schema.String,

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -336,15 +336,7 @@ export class BrowserControlSessions {
   }
 
   networkStart(id: string, options: NetworkCaptureOptions = {}): Effect.Effect<NetworkCaptureStatus, Error> {
-    const manager = this
-    const session = this.sessions.get(id)
-    if (!session) return Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
-    return this.withLifecyclePermit(session, "network start", Effect.gen(function* () {
-      if (manager.sessions.get(id) !== session) {
-        return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
-      }
-      return yield* session.sandbox.networkStart(options)
-    }))
+    return this.withActiveSession(id, "network start", (session) => session.sandbox.networkStart(options))
   }
 
   networkStatus(id: string): Effect.Effect<NetworkCaptureStatus, Error> {
@@ -355,38 +347,30 @@ export class BrowserControlSessions {
   }
 
   networkStop(id: string, options: NetworkCaptureStopOptions = {}): Effect.Effect<NetworkCaptureResult, Error> {
-    const manager = this
-    const session = this.sessions.get(id)
-    if (!session) return Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
-    return this.withLifecyclePermit(session, "network stop", Effect.gen(function* () {
-      if (manager.sessions.get(id) !== session) {
-        return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
-      }
-      return yield* session.sandbox.networkStop(options)
-    }))
+    return this.withActiveSession(id, "network stop", (session) => session.sandbox.networkStop(options))
   }
 
   networkCancel(id: string): Effect.Effect<{ readonly cancelled: boolean }, Error> {
-    const manager = this
-    const session = this.sessions.get(id)
-    if (!session) return Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
-    return this.withLifecyclePermit(session, "network cancel", Effect.gen(function* () {
-      if (manager.sessions.get(id) !== session) {
-        return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
-      }
-      return yield* session.sandbox.networkCancel()
-    }))
+    return this.withActiveSession(id, "network cancel", (session) => session.sandbox.networkCancel())
   }
 
   authRefresh(id: string, options: { readonly name: string; readonly urlFilter?: string; readonly timeoutMs?: number }): Effect.Effect<NetworkCaptureResult, Error> {
+    return this.withActiveSession(id, "auth refresh", (session) => session.sandbox.authRefresh(options))
+  }
+
+  private withActiveSession<A>(
+    id: string,
+    operation: string,
+    run: (session: BrowserControlSession) => Effect.Effect<A, Error>,
+  ): Effect.Effect<A, Error> {
     const manager = this
     const session = this.sessions.get(id)
     if (!session) return Effect.fail(sessionError("not-found", `Session not found: ${id}`, id))
-    return this.withLifecyclePermit(session, "auth refresh", Effect.gen(function* () {
+    return this.withLifecyclePermit(session, operation, Effect.gen(function* () {
       if (manager.sessions.get(id) !== session) {
         return yield* Effect.fail(sessionError("inactive", `Session is no longer active: ${id}`, id))
       }
-      return yield* session.sandbox.authRefresh(options)
+      return yield* run(session)
     }))
   }
 

--- a/src/target-registry.ts
+++ b/src/target-registry.ts
@@ -108,7 +108,6 @@ export class TargetRegistry {
   readonly targets = new Map<string, ConnectedTarget>()
   readonly tabTargets = new Map<number, ConnectedTarget>()
   readonly targetsByTargetId = new Map<string, ConnectedTarget>()
-  readonly childSessionTabs = new Map<string, number>()
   readonly childTargets = new Map<string, ChildTarget>()
   readonly childTargetsByTargetId = new Map<string, ChildTarget>()
   readonly tabFrameEvents = new Map<number, Map<string, StoredFrameEvents>>()
@@ -119,7 +118,6 @@ export class TargetRegistry {
     this.targets.clear()
     this.tabTargets.clear()
     this.targetsByTargetId.clear()
-    this.childSessionTabs.clear()
     this.childTargets.clear()
     this.childTargetsByTargetId.clear()
     this.tabFrameEvents.clear()
@@ -219,10 +217,8 @@ export class TargetRegistry {
     }
     const existingForTargetId = this.childTargetsByTargetId.get(target.targetInfo.targetId)
     if (existingForTargetId) {
-      this.childSessionTabs.delete(existingForTargetId.sessionId)
       this.childTargets.delete(existingForTargetId.sessionId)
     }
-    this.childSessionTabs.set(target.sessionId, target.tabId)
     this.childTargets.set(target.sessionId, target)
     this.childTargetsByTargetId.set(target.targetInfo.targetId, target)
   }
@@ -325,9 +321,9 @@ export class TargetRegistry {
     this.targetsByTargetId.delete(target.targetInfo.targetId)
     this.pendingOwnershipReservations.delete(target.targetInfo.targetId)
     if (!options.preserveFrameEvents) this.tabFrameEvents.delete(tabId)
-    const childSessionIds = Array.from(this.childSessionTabs.entries())
-      .filter(([, childTabId]) => {
-        return childTabId === tabId
+    const childSessionIds = Array.from(this.childTargets.entries())
+      .filter(([, child]) => {
+        return child.tabId === tabId
       })
       .filter(([sessionId]) => {
         return this.childTargets.get(sessionId)?.parentSessionId !== options.preserveChildParentSessionId
@@ -341,7 +337,6 @@ export class TargetRegistry {
 
   detachChildTargetState(sessionId: string): ChildTarget | undefined {
     const target = this.childTargets.get(sessionId)
-    this.childSessionTabs.delete(sessionId)
     this.childTargets.delete(sessionId)
     if (target) {
       this.childTargetsByTargetId.delete(target.targetInfo.targetId)
@@ -448,7 +443,7 @@ export class TargetRegistry {
     if (target) {
       return target.tabId
     }
-    return this.childSessionTabs.get(sessionId)
+    return this.childTargets.get(sessionId)?.tabId
   }
 
   allTargetInfos(options: {

--- a/test/cdp-shims.test.ts
+++ b/test/cdp-shims.test.ts
@@ -101,7 +101,6 @@ describe("sendAttachedToChildTarget", () => {
   it("replays dedicated workers without synthesizing iframe navigation events", () => {
     const events: CdpEvent[] = []
     const client = socket(events)
-    const announcements = new Map([[client, createClientTargetAnnouncements()]])
     const registry = new TargetRegistry()
     registry.addChildTarget({
       ...child("worker-session", "worker-target"),

--- a/test/target-registry.test.ts
+++ b/test/target-registry.test.ts
@@ -42,6 +42,7 @@ describe("TargetRegistry root generations", () => {
         canAccessOpener: false,
       },
     })
+    expect(registry.tabIdForSession("child-1")).toBe(7)
 
     const change = registry.addRootTarget(root({ sessionId: "bc-tab-2", targetId: "target-2" }))
 


### PR DESCRIPTION
## What

Simplify Browser Control's internal lifecycle and boundary code without changing its public API or agent workflow. The tree removes 103 net lines while preserving session, recording, extension, and target behavior.

The only operational improvements are avoiding a duplicate network-capture settlement wait, releasing timed-out settlement waiters immediately, and running independent build steps concurrently.

## How

- `src/execute.ts` routes close/disconnect variants through one Effect-owned teardown path and settles capture output once per normal execute outcome.
- `src/session-manager.ts` centralizes active-session lookup, permit acquisition, and generation validation for network/auth operations.
- `src/recording-relay.ts` shares one active-recording abort implementation.
- `src/target-registry.ts` derives child tab ownership from `childTargets` instead of maintaining a second synchronized map.
- `src/network-capture.ts` uses a removable waiter set so timed-out output settlement does not retain closures.
- Protocol, page-status, HTTP schema, MCP session, CLI Option, and response-schema paths reuse their existing canonical decoders and primitives.
- CLI declaration/bundle builds and the two independent extension bundles now run concurrently.
- A patch changeset records the runtime cleanup.

## Scope

This is deliberately not the larger correctness work identified by the separate audit: capture redaction coverage, logical-session reset/delete serialization, multi-page cleanup, target-context routing, and release permission hardening remain follow-up work. It also avoids broad MCP schema generation, sandbox API redesign, and shared test-harness extraction because those changes increase review surface without a comparable immediate simplification.

## Testing

- `pnpm run ci`: TypeScript typecheck, all 462 unit tests, CLI/extension builds, and extension package validation passed.
- `pnpm exec tsc --noEmit --noUnusedLocals --noUnusedParameters`: passed.
- Focused lifecycle, target-registry, recording, capture, session-manager, MCP, protocol, extension-status, CDP shim, and HTTP tests: 132 passed.
- `pnpm changeset status`: reports the expected package patch.
- Browser smoke and unpacked-extension reload were not run to avoid disrupting the active browser; the extension change only consolidates the already unit-tested page-status decoder.

## Flow

```mermaid
flowchart LR
    Execute[Execute result] --> Settle[Settle capture once]
    Settle --> Redact[Redact output]
    Session[Session operation] --> Permit[Shared active-session permit]
    Permit --> Sandbox[Sandbox operation]
    Shutdown[Close or disconnect] --> Teardown[Shared scoped teardown]
    Recording[Relay or tab abort] --> Abort[Shared recording abort]
```