### PR TITLE
fix(relay): enforce root health and reconciliation readiness

### DIFF
--- a/.changeset/healthy-roots-verify.md
+++ b/.changeset/healthy-roots-verify.md
@@ -1,0 +1,9 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Skip crashed session-owned roots when routing named browser-context commands,
+without changing raw-client ambiguity or explicit target visibility and routing.
+Preserve exhausted root-probe errors and reject malformed target information for
+committed roots as well as staged roots. Failed inventory readiness closes the
+extension connection and clears live target state rather than reporting success.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,10 @@ local Node relay.
 - CDP guardrails are pure logic in `src/cdp-guardrails.ts`, enforced at the top
   of `routeCdpCommand`. Destructive browser-state methods are always blocked;
   read-only sessions additionally reject `Input.*`.
-- Browser-context CDP methods route through a session-owned root for named
-  clients or exactly one visible root for raw clients. A named client never
-  falls back to an unrelated unowned tab.
+- Browser-context CDP methods route through a non-crashed session-owned root for
+  named clients or exactly one visible root for raw clients. A named client never
+  falls back to an unrelated unowned tab. Crashed roots remain visible and count
+  toward raw-client ambiguity; explicit target routes remain available.
 - Human handoff waiters live in `src/handoff.ts`; derive their stable CDP target
   id from the actual Playwright `Page`, then bind the exact registry
   target/tab/session. The relay resolves only a matching handoff id from that
@@ -125,7 +126,9 @@ local Node relay.
 - `RootTargetLifecycle` owns per-tab setup, staging, verification, commit, retry,
   and generation invalidation. Stale workers must never detach a successor tab.
   Drain its scoped workers before closing extension RPCs; keep presentation
-  best-effort and outside authoritative ownership.
+  best-effort and outside authoritative ownership. Exhausted committed or staged
+  root probes fail readiness; preserve original RPC errors. Readiness rejection
+  closes the extension socket with 1011 and disconnect cleanup clears live targets.
 - `BrowserControlSessions` installs the sandbox's default-target callback and
   binds it to the exact session instance. Retired sandbox callbacks must never
   update a reset or recreated session with the same id.

--- a/PLAN.md
+++ b/PLAN.md
@@ -65,6 +65,9 @@ its interface, tested through an event sink without browser or websocket mocks.
 `CdpRouter` owns
 client-relative visibility, target inventory, target and alias resolution, and
 exact root-versus-child Chrome session routing.
+Named browser-context commands skip crashed owned roots without falling back to
+unrelated tabs. Raw-client ambiguity includes crashed roots; visibility and
+explicit target routing do not filter them out.
 
 `CdpRuntime` owns register-before-send context observation, bounded reset fallback,
 and idle reset targeting. Runtime recovery is tied to captured root/child and
@@ -93,6 +96,10 @@ with exact-target reacquisition retained for default-page replacement.
 scoped reconciliation workers, and generation checks across asynchronous steps.
 Committed ownership and handoff/default-target rebinding precede retiring old
 client views; stale workers cannot tear down a successor generation.
+Committed and staged root probes retain exhausted RPC errors or reject malformed
+target info. A failed inventory readiness check closes the extension socket with
+1011 and clears live registry state through disconnect cleanup; this is not
+automatic debugger reattachment or full SPA recovery.
 
 Verification:
 

--- a/src/cdp-router.ts
+++ b/src/cdp-router.ts
@@ -54,7 +54,7 @@ export class CdpRouter<Client extends object> {
     let preferred: ConnectedTarget | undefined
     for (const target of this.registry.listRootTargets()) {
       if (clientSessionId !== undefined) {
-        if (target.browserControlSessionId === clientSessionId) return target
+        if (target.browserControlSessionId === clientSessionId && target.crashed !== true) return target
         continue
       }
       const matches = this.canSeeTarget(client, target)

--- a/src/root-target-lifecycle.ts
+++ b/src/root-target-lifecycle.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Latch, Option, Schedule, Schema, Scope, Semaphore } from "effect"
+import { Effect, Exit, Latch, Schedule, Schema, Scope, Semaphore } from "effect"
 import type { CdpClientPool } from "./cdp-client-pool.ts"
 import { ghostCursorClientSource } from "./ghost-cursor.ts"
 import type { HandoffRegistry } from "./handoff.ts"
@@ -283,13 +283,11 @@ export class RootTargetLifecycle {
     if (!expected && !staged) return
     const result = yield* this.command(transition, "Target.getTargetInfo").pipe(
       Effect.retry({ times: 1, schedule: Schedule.spaced(50), while: (error) => !(error instanceof GenerationChanged) }),
-      Effect.option,
     )
     yield* this.check(transition)
-    const targetInfo = getTargetInfo(Option.isSome(result) ? result.value.targetInfo : undefined)
+    const targetInfo = getTargetInfo(result.targetInfo)
     if (!targetInfo) {
-      if (staged) return yield* Effect.fail(new Error("Unable to verify staged root target"))
-      return
+      return yield* Effect.fail(new Error(staged ? "Unable to verify staged root target" : "Unable to verify committed root target"))
     }
     if (staged?.targetInfo.targetId === targetInfo.targetId) {
       yield* this.finish(transition, staged)

--- a/test/cdp-router.test.ts
+++ b/test/cdp-router.test.ts
@@ -99,6 +99,34 @@ describe("CdpRouter", () => {
     expect(router.isBrowserAlias(client, "unknown-session")).toBe(false)
   })
 
+  it("skips a crashed owned root that precedes a healthy sibling", () => {
+    const { clients, registry, router } = setup()
+    const client = {}
+    clients.register(client, "session-a")
+    registry.addRootTarget(root({ tabId: 1, sessionId: "crashed-root", targetId: "crashed-target", browserControlSessionId: "session-a" }))
+    registry.markRootTargetCrashed(1)
+    const healthy = root({ tabId: 2, sessionId: "healthy-root", targetId: "healthy-target", browserControlSessionId: "session-a" })
+    registry.addRootTarget(healthy)
+
+    expect(registry.listRootTargets().map((target) => target.tabId)).toEqual([1, 2])
+    expect(router.preferredRoot(client)).toBe(healthy)
+    expect(router.visibleRoots(client)).toHaveLength(2)
+    expect(router.session(client, "crashed-root")).toEqual({ tabId: 1, rootSessionId: "crashed-root" })
+  })
+
+  it("does not replace crashed owned roots with an unrelated healthy root", () => {
+    const { clients, registry, router } = setup()
+    const client = {}
+    clients.register(client, "session-a")
+    for (const tabId of [1, 2]) {
+      registry.addRootTarget(root({ tabId, sessionId: `root-${tabId}`, targetId: `target-${tabId}`, browserControlSessionId: "session-a" }))
+      registry.markRootTargetCrashed(tabId)
+    }
+    registry.addRootTarget(root({ tabId: 3, sessionId: "unrelated-root", targetId: "unrelated-target", owner: "user" }))
+
+    expect(router.preferredRoot(client)).toBeUndefined()
+  })
+
   it("does not fall through from an empty named session to an unrelated root", () => {
     const { clients, registry, router } = setup()
     const client = {}
@@ -121,6 +149,18 @@ describe("CdpRouter", () => {
     registry.addRootTarget(visible)
 
     expect(router.preferredRoot(client)).toBe(visible)
+
+    registry.addRootTarget(root({ tabId: 2, sessionId: "root-2", targetId: "target-2" }))
+    expect(router.preferredRoot(client)).toBeUndefined()
+  })
+
+  it("keeps crashed roots in raw-client selection and ambiguity checks", () => {
+    const { clients, registry, router } = setup()
+    const client = {}
+    clients.register(client)
+    registry.addRootTarget(root({ tabId: 1, sessionId: "root-1", targetId: "target-1" }))
+    const crashed = registry.markRootTargetCrashed(1)
+    expect(router.preferredRoot(client)).toBe(crashed)
 
     registry.addRootTarget(root({ tabId: 2, sessionId: "root-2", targetId: "target-2" }))
     expect(router.preferredRoot(client)).toBeUndefined()

--- a/test/relay-extension-handshake.test.ts
+++ b/test/relay-extension-handshake.test.ts
@@ -269,6 +269,39 @@ describe("relay extension handshake", () => {
       expect(status).toMatchObject({ connected: false, activeTargets: 0 })
     })))
   })
+
+  it.each(["rpc", "malformed"] as const)("rejects ready and clears live roots after a committed root %s probe failure", async (failure) => {
+    const port = 24_000 + Math.floor(Math.random() * 10_000)
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const relay = yield* startRelay({ port, sessionCatalogPath: null })
+      const options: { targetId?: string; error?: string } = { targetId: "committed-target" }
+      const extension = yield* Effect.promise(() => connectRespondingExtension(relay.url, options))
+      const closed = waitForClose(extension)
+      try {
+        extension.send(JSON.stringify({ method: "hello", params: { version: "0.0.24", protocolVersion: 2 } }))
+        extension.send(JSON.stringify({ method: "debugger.attached", params: { tabId: 7 } }))
+        const committed = yield* Effect.promise(() => waitForStatus(relay.url, (candidate) => candidate.activeTargets === 1))
+        expect(committed.connected).toBe(false)
+
+        if (failure === "rpc") options.error = "Debugger is not attached to the tab with id: 7"
+        else delete options.targetId
+        extension.send(JSON.stringify({ method: "debugger.detached", params: { tabId: 7, reason: "target_closed" } }))
+        extension.send(JSON.stringify({ method: "ready" }))
+
+        const status = yield* Effect.promise(() => waitForStatus(relay.url, (candidate) => candidate.connected || candidate.activeTargets === 0))
+        expect(status).toMatchObject({ connected: false, activeTargets: 0 })
+        expect(yield* Effect.promise(() => closed)).toBe(1011)
+        expect(error).toHaveBeenCalled()
+        if (failure === "rpc") {
+          expect(error.mock.calls.some((call) => call[1] instanceof Error && call[1].message === options.error)).toBe(true)
+        }
+        expect(extension.commands.some((command) => command.method === "tabs.remove" || command.method === "debugger.detach")).toBe(false)
+      } finally {
+        extension.close()
+      }
+    })))
+  })
 })
 
 type ExtensionStatus = { readonly connected: boolean; readonly activeTargets: number; readonly protocolCompatible?: boolean }

--- a/test/relay-visibility-prune.test.ts
+++ b/test/relay-visibility-prune.test.ts
@@ -7,7 +7,7 @@ import { parseExtensionCommand, type CdpEvent, type CdpRequest, type ExtensionCo
 type CdpMessage = CdpEvent | { readonly id: number; readonly result?: JsonObject; readonly error?: { readonly message: string } }
 
 describe("relay target visibility pruning", () => {
-  it("routes browser-context commands only through the client's preferred root", async () => {
+  it.each([false, true])("routes browser-context commands through an owned healthy root (first root crashed: %s)", async (crashFirst) => {
     const port = 24_000 + Math.floor(Math.random() * 10_000)
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
       const relay = yield* startRelay({ port, sessionCatalogPath: null })
@@ -65,6 +65,21 @@ describe("relay target visibility pruning", () => {
         expect(browserAlias).toBeDefined()
         if (!browserAlias) throw new Error("Expected browser session alias")
 
+        if (crashFirst) {
+          yield* Effect.promise(() => new Promise<void>((resolve) => {
+            const onMessage = () => {
+              if (!sessionClient.events.some((event) => event.method === "Inspector.targetCrashed")) return
+              sessionClient.off("message", onMessage)
+              resolve()
+            }
+            sessionClient.on("message", onMessage)
+            extension.send(JSON.stringify({
+              method: "debugger.event",
+              params: { tabId: 2, method: "Inspector.targetCrashed", params: {} },
+            }))
+          }))
+        }
+
         const secondOwnedCreate = yield* Effect.promise(() => sendCdp(sessionClient, {
           id: 6,
           method: "Target.createTarget",
@@ -111,7 +126,7 @@ describe("relay target visibility pruning", () => {
         expect(forwarded).toHaveLength(routedCommands.length)
         for (const [index, command] of routedCommands.entries()) {
           expect(forwarded[index]?.params).toEqual({
-            tabId: 2,
+            tabId: crashFirst ? 3 : 2,
             method: command.method,
             params: command.params,
           })

--- a/test/root-target-lifecycle.test.ts
+++ b/test/root-target-lifecycle.test.ts
@@ -298,6 +298,65 @@ describe("root target lifecycle", () => {
     })).pipe(Effect.provide(TestClock.layer())))
   })
 
+  it.each([
+    ["committed", "rpc"],
+    ["committed", "malformed"],
+    ["staged", "malformed"],
+  ] as const)("retains exhausted %s root %s probe failure until a successful queue", async (state, failure) => {
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const f = yield* fixture()
+      const target = root("root-new")
+      if (state === "committed") f.registry.addRootTarget(target)
+      else f.registry.stageRootTarget(target)
+      const failed = yield* Latch.make()
+      const error = new Error("Debugger is not attached to the tab with id: 1")
+      f.state.intercept = (command) => command.params?.method === "Target.getTargetInfo"
+        ? failed.open.pipe(Effect.andThen(failure === "rpc"
+          ? Effect.fail(error)
+          : Effect.succeed({ targetInfo: { targetId: 123 } })))
+        : undefined
+      f.lifecycle.queue({ tabId: 1, attachIfMissing: false, verificationRetries: 3, errorMessage: "Reconcile failed" })
+      yield* failed.await
+      yield* TestClock.adjust(1_000)
+      expect(yield* f.lifecycle.settle(1)).toBe(false)
+      expect(f.commands).toEqual(Array(failure === "rpc" ? 6 : 3).fill("Target.getTargetInfo"))
+      expect(f.errors).toHaveLength(3)
+      for (const reported of f.errors) {
+        if (failure === "rpc") expect(reported).toBe(error)
+        else expect(reported).toMatchObject({ message: `Unable to verify ${state} root target` })
+      }
+      expect(f.events).toEqual([])
+      expect(f.registry.routingRootTarget(1)?.targetInfo.targetId).toBe("root-new")
+
+      f.state.intercept = () => undefined
+      f.queue()
+      expect(yield* f.lifecycle.settle(1)).toBe(true)
+      expect(f.registry.tabTargets.get(1)?.targetInfo.targetId).toBe("root-new")
+    })).pipe(Effect.provide(TestClock.layer())))
+  })
+
+  it("retries a committed root probe after the inner retry is exhausted", async () => {
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const f = yield* fixture()
+      const target = root("root-new")
+      f.registry.addRootTarget(target)
+      const failed = yield* Latch.make()
+      const error = new Error("Transient target probe failure")
+      let probes = 0
+      f.state.intercept = (command) => command.params?.method === "Target.getTargetInfo" && ++probes <= 2
+        ? failed.open.pipe(Effect.andThen(Effect.fail(error)))
+        : undefined
+      f.queue()
+      yield* failed.await
+      yield* TestClock.adjust(300)
+      expect(yield* f.lifecycle.settle(1)).toBe(true)
+      expect(probes).toBe(3)
+      expect(f.errors).toEqual([error])
+      expect(f.registry.tabTargets.get(1)).toBe(target)
+      expect(f.events).toEqual([])
+    })).pipe(Effect.provide(TestClock.layer())))
+  })
+
   it.each(["attach", "queue"] as const)("drains accepted %s work before close, even after an interrupted settle", async (operation) => {
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
       const f = yield* fixture()


### PR DESCRIPTION
## Why

Named browser-context commands can select a crashed owned root even when a healthy sibling exists. Committed-root verification also swallows exhausted probe errors, allowing inventory readiness to succeed without verified debugger access.

## What Changes

| Case | Behavior |
| --- | --- |
| Crashed owned root before a healthy sibling | Named context commands use the non-crashed sibling |
| All owned roots crashed | No route and no unrelated-root fallback |
| Multiple raw-client roots, including crashed roots | Remain ambiguous |
| Exhausted RPC or malformed root probe | Preserve failure through existing bounded retries and readiness bookkeeping |
| Later successful reconciliation | Clear the retained failure for that tab/generation |
| Inventory readiness rejected | Existing behavior closes the extension socket with 1011; disconnect cleanup clears live roots |

Explicit target routes and diagnostic target visibility remain unchanged.

## Scope

Related to #50 and #67, not closing either. This is a bounded root-health and verification fix, not automatic debugger reattachment or full SPA recovery. Context-identity routing and real-browser continuity still need separate verification.

## Verification

```bash
bun run test test/cdp-router.test.ts test/relay-visibility-prune.test.ts test/root-target-lifecycle.test.ts test/relay-extension-handshake.test.ts test/relay-child-dedupe.test.ts
bun run typecheck
bun run ci
pnpm exec changeset status
pnpm runtime:prepare
git diff --cached --check
```

Eight expected pre-fix assertion failures became green. All 62 focused tests and 735 full-suite tests pass, including transient retry, generation/invalidation, routing isolation, and readiness-rejection coverage. Full CI validation passed twice, including unused checks, CLI/extension builds, and extension packaging. Standalone runtime preparation passed clean-install CLI/MCP and SDK-consumer validation; packed contents were inspected. A patch changeset is included.

No live browser, authenticated SPA recovery, or active installation was changed or tested.
