### PR TITLE
fix(runtime): pin the Effect dependency cohort

### DIFF
--- a/.changeset/aligned-runtime-cohort.md
+++ b/.changeset/aligned-runtime-cohort.md
@@ -1,0 +1,8 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Pin the shared Node platform to the same Effect prerelease as the CLI runtime,
+preventing incompatible scope layouts in fresh standalone installations. Validate
+the packed dependency cohort, CLI, and SDK in an isolated pnpm consumer before
+accepting a runtime candidate or publishing through the release workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,10 @@ local Node relay.
 - Each Browser Control session owns one default page and persistent JavaScript
   `state`; do not default to arbitrary shared tabs for normal execute calls.
 - Use stock `playwright-core` for v1.
-- Use Effect v4 for Node-side code, keeping `effect` and `@effect/platform-node`
-  on the same release. The local `/Users/kit/code/open-source/effect` checkout
-  is the source of truth for APIs and patterns; `effect-smol` is archived.
+- Use Effect v4 for Node-side code, keeping `effect`, `@effect/platform-node`,
+  and `@effect/platform-node-shared` exactly pinned to the same release. The local
+  `/Users/kit/code/open-source/effect` checkout is the source of truth for APIs and
+  patterns; `effect-smol` is archived.
 - Prefer `Effect.fn` / `Effect.fnUntraced` for functions that return Effects,
   and use scoped resources (`Effect.acquireRelease`, `Effect.scoped`) for
   Playwright and relay lifecycles.

--- a/PLAN.md
+++ b/PLAN.md
@@ -34,6 +34,10 @@ checkout. Installation selection changes one shared pointer for future CLI/MCP
 processes, not an existing daemon. Keep old complete installations until their
 processes retire. The loaded extension directory is separate from this workflow.
 
+Preparation also checks the packed Effect dependency cohort in a fresh isolated
+pnpm consumer, without checkout locks or user overrides. Keep all three Effect
+runtime packages exactly aligned; this is not a universal host-graph lock.
+
 Ordinary clients may start an absent daemon but never replace a running one.
 `browser-control relay restart` is the sole CLI replacement operation. It requires
 an exact managed instance with safe shutdown protocol 2, records bounded private

--- a/knip.ts
+++ b/knip.ts
@@ -19,6 +19,8 @@ export default {
   project: ["src/**/*.ts!", "extension/src/**/*.ts!", "scripts/*.{ts,js}", "test/**/*.ts"],
   // Package scripts discover the TS command entrypoints; Vitest discovers tests.
   vitest: { entry: ["test/**/*.test.ts"] },
+  // Align the transitive Node runtime with Effect's prerelease scope layout.
+  ignoreDependencies: ["@effect/platform-node-shared"],
   // ffmpeg is installed separately; the benchmark invokes this package's own bin.
   ignoreBinaries: ["ffmpeg", "browser-control"],
 } satisfies KnipConfig

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@effect/platform-node": "4.0.0-rc.112",
+    "@effect/platform-node-shared": "4.0.0-rc.112",
     "acorn": "^8.18.0",
     "effect": "4.0.0-rc.112",
     "playwright-core": "^1.62.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@effect/platform-node':
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+      '@effect/platform-node-shared':
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
       acorn:
         specifier: ^8.18.0
         version: 8.18.0

--- a/scripts/runtime-install.ts
+++ b/scripts/runtime-install.ts
@@ -25,13 +25,13 @@ const attempt = <A>(run: (signal: AbortSignal) => Promise<A>) => Effect.tryPromi
   catch: (cause) => cause instanceof Error ? cause : new Error(String(cause)),
 })
 
-type RunCommand = (command: string, args: string[], cwd: string) => Effect.Effect<string, Error>
+type RunCommand = (command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv) => Effect.Effect<string, Error>
 
-const runCommand: RunCommand = Effect.fn("RuntimeInstall.command")(function* (command, args, cwd) {
+const runCommand: RunCommand = Effect.fn("RuntimeInstall.command")(function* (command, args, cwd, env) {
   const result = yield* Effect.tryPromise({
     try: (signal) => exec(command, args, {
       cwd, signal, timeout: 300_000, maxBuffer: 8 * 1024 * 1024,
-      env: { ...process.env, NODE_OPTIONS: undefined, NODE_PATH: undefined },
+      env: env ?? { ...process.env, NODE_OPTIONS: undefined, NODE_PATH: undefined },
     }),
     catch: (cause) => new Error(`${command} ${args.join(" ")} failed in ${cwd}`, { cause }),
   })
@@ -176,6 +176,52 @@ const validateMcp = Effect.fn("RuntimeInstall.validateMcp")(function* (install: 
   })
 })
 
+const validatePnpmConsumer = Effect.fn("RuntimeInstall.validatePnpmConsumer")(function* (
+  staging: string, archive: string, version: string, packageManager: string, run: RunCommand,
+) {
+  const consumer = yield* Effect.acquireRelease(
+    attempt(() => fs.mkdtemp(path.join(path.dirname(staging), ".browser-control-pnpm-"))),
+    (directory) => attempt(() => fs.rm(directory, { recursive: true, force: true })).pipe(Effect.orDie),
+  )
+  // No checkout lockfile, user config or overrides: resolve the packed runtime as a standalone consumer.
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH, SystemRoot: process.env.SystemRoot, HOME: consumer,
+    XDG_CONFIG_HOME: path.join(consumer, "config"), XDG_DATA_HOME: path.join(consumer, "data"),
+    XDG_CACHE_HOME: path.join(consumer, "cache"), XDG_STATE_HOME: path.join(consumer, "state"),
+  }
+  yield* attempt(async () => {
+    await fs.writeFile(path.join(consumer, "package.json"), JSON.stringify({ private: true, type: "module", packageManager }), { flag: "wx" })
+    await fs.writeFile(path.join(consumer, "pnpm-workspace.yaml"), "packages:\n  - .\n", { flag: "wx" })
+  })
+  yield* run("pnpm", ["add", "--workspace-root", "--prod", "--ignore-scripts", "--config.node-linker=isolated", archive], consumer, env)
+  yield* run("node", ["--input-type=module", "--eval", String.raw`
+import assert from 'node:assert/strict'
+import { realpathSync } from 'node:fs'
+import { createRequire } from 'node:module'
+const require = createRequire(realpathSync('./node_modules/${packageName}/package.json'))
+const packed = require('./package.json')
+assert.equal(packed.name, '${packageName}')
+assert.equal(packed.version, ${JSON.stringify(version)})
+const pins = packed.dependencies
+assert.match(pins.effect, /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/, 'Effect must be exactly pinned')
+for (const name of ['@effect/platform-node', '@effect/platform-node-shared']) {
+  assert.equal(pins[name], pins.effect, name + ' must share the exact Effect pin')
+  assert.equal(require(name + '/package.json').version, pins.effect, name + ' resolved version mismatch')
+}
+const node = createRequire(require.resolve('@effect/platform-node/NodeServices'))
+const shared = createRequire(node.resolve('@effect/platform-node-shared/NodeFileSystem'))
+assert.equal(node('@effect/platform-node-shared/package.json').version, pins.effect)
+const runtimes = [require, node, shared]
+for (const runtime of runtimes) assert.equal(runtime('effect/package.json').version, pins.effect)
+assert.equal(new Set(runtimes.map(runtime => runtime.resolve('effect'))).size, 1, 'Multiple Effect runtimes')
+const { BrowserControlClient, AuthenticatedOrigin, SecretProfile } = await import('${packageName}')
+assert.ok(BrowserControlClient.Service && AuthenticatedOrigin.reveal && SecretProfile.run && SecretProfile.Error, 'SDK exports missing')
+`], consumer, env)
+  const cli = path.join(consumer, "node_modules", ".bin", "browser-control")
+  if (!(yield* run(cli, ["--help"], consumer, env)).includes("browser-control")) return yield* Effect.fail(new Error("pnpm CLI help is missing"))
+  if ((yield* run(cli, ["--version"], consumer, env)).trim() !== `browser-control v${version}`) return yield* Effect.fail(new Error("pnpm CLI version mismatch"))
+}, Effect.scoped)
+
 export const prepareRuntime = Effect.fn("RuntimeInstall.prepare")(function* (
   options: { readonly source: string; readonly staging: string; readonly install: string },
   run: RunCommand = runCommand,
@@ -199,7 +245,9 @@ export const prepareRuntime = Effect.fn("RuntimeInstall.prepare")(function* (
       })
     }
   })
-  const manifest = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(manifestSchema))(
+  const manifest = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Struct({
+    ...manifestSchema.fields, packageManager: Schema.String,
+  })))(
     yield* attempt(() => fs.readFile(path.join(staging, "package.json"), "utf8")),
   )
   yield* run("pnpm", ["install", "--frozen-lockfile"], staging)
@@ -209,6 +257,7 @@ export const prepareRuntime = Effect.fn("RuntimeInstall.prepare")(function* (
   const archives = yield* attempt(() => fs.readdir(path.join(staging, "artifacts")))
   if (archives.length !== 1 || !archives[0]?.endsWith(".tgz")) return yield* Effect.fail(new Error("Expected one packed tarball"))
   const archive = path.join(staging, "artifacts", archives[0])
+  yield* validatePnpmConsumer(staging, archive, manifest.version, manifest.packageManager, run)
   yield* attempt(() => fs.writeFile(path.join(install, "package.json"), '{"private":true,"type":"module"}\n', { flag: "wx" }))
   yield* run("npm", ["install", "--prefix", install, "--ignore-scripts", "--no-audit", "--no-fund", "--omit=dev", archive], install)
   yield* attempt(() => fs.symlink("node_modules/.bin", path.join(install, "bin")))

--- a/test/runtime-install.test.ts
+++ b/test/runtime-install.test.ts
@@ -26,7 +26,7 @@ async function fixture() {
   for (const relative of ["src", "scripts", "extension/src", "extension/icons", "extension/dist", "dist", "node_modules", "skills/browser-control"]) {
     await fs.mkdir(path.join(source, relative), { recursive: true })
   }
-  await fs.writeFile(path.join(source, "package.json"), JSON.stringify({ name: packageName, version: "1.2.3", type: "module", exports: "./dist/index.js" }))
+  await fs.writeFile(path.join(source, "package.json"), JSON.stringify({ name: packageName, version: "1.2.3", packageManager: "pnpm@11.20.0", type: "module", exports: "./dist/index.js" }))
   for (const relative of ["pnpm-lock.yaml", "pnpm-workspace.yaml", "tsconfig.json", "tsconfig.build.json", "extension/manifest.json", "README.md", "LICENSE"]) {
     await fs.writeFile(path.join(source, relative), "fixture")
   }
@@ -36,7 +36,22 @@ async function fixture() {
 
   // Fake only expensive build/package-manager/compiler steps. Installed binaries,
   // SDK resolution, MCP protocol, filesystem isolation and selection run for real.
-  const run = (command: string, args: string[], cwd: string) => Effect.tryPromise(async () => {
+  // The strict pnpm consumer runs against a real tarball in CI's runtime:prepare.
+  const run = (command: string, args: string[], cwd: string, env?: NodeJS.ProcessEnv) => Effect.tryPromise(async () => {
+    if (path.basename(cwd).startsWith(".browser-control-pnpm-")) {
+      expect(path.dirname(cwd)).toBe(directory)
+      expect(env).toEqual({
+        PATH: process.env.PATH, SystemRoot: process.env.SystemRoot, HOME: cwd,
+        XDG_CONFIG_HOME: path.join(cwd, "config"), XDG_DATA_HOME: path.join(cwd, "data"),
+        XDG_CACHE_HOME: path.join(cwd, "cache"), XDG_STATE_HOME: path.join(cwd, "state"),
+      })
+      expect(await fs.readFile(path.join(cwd, "package.json"), "utf8")).toBe(JSON.stringify({ private: true, type: "module", packageManager: "pnpm@11.20.0" }))
+      if (command === "pnpm") {
+        expect(args).toEqual(["add", "--workspace-root", "--prod", "--ignore-scripts", "--config.node-linker=isolated", path.join(staging, "artifacts/package.tgz")])
+        await expect(fs.lstat(path.join(cwd, "pnpm-lock.yaml"))).rejects.toMatchObject({ code: "ENOENT" })
+      }
+      return args[0] === "--version" ? "browser-control v1.2.3" : args[0] === "--help" ? "browser-control help" : ""
+    }
     if (command === "pnpm") {
       expect(cwd).toBe(staging)
       if (args[0] === "install") {
@@ -159,12 +174,21 @@ describe("isolated runtime installation", () => {
 
   it("does not stamp a candidate whose final installed validation fails", async () => {
     const f = await fixture()
-    await expect(Effect.runPromise(prepareRuntime(f, (command, args, cwd) => args[0] === "--version"
+    await expect(Effect.runPromise(prepareRuntime(f, (command, args, cwd, env) => args[0] === "--version" && !env
       ? Effect.succeed("wrong-version")
-      : f.run(command, args, cwd)))).rejects.toThrow("CLI version mismatch")
+      : f.run(command, args, cwd, env)))).rejects.toThrow("CLI version mismatch")
     await expect(fs.lstat(path.join(f.install, marker))).rejects.toMatchObject({ code: "ENOENT" })
     await fs.symlink(f.source, f.active)
     await expect(Effect.runPromise(selectRuntime(f))).rejects.toThrow()
     expect(await fs.realpath(f.active)).toBe(f.source)
+  })
+
+  it("cleans the strict packed consumer and leaves the candidate unvalidated when its check fails", async () => {
+    const f = await fixture()
+    await expect(Effect.runPromise(prepareRuntime(f, (command, args, cwd, env) => command === "node" && env
+      ? Effect.fail(new Error("packed Effect cohort mismatch"))
+      : f.run(command, args, cwd, env)))).rejects.toThrow("packed Effect cohort mismatch")
+    expect((await fs.readdir(f.directory)).some((name) => name.startsWith(".browser-control-pnpm-"))).toBe(false)
+    await expect(fs.lstat(path.join(f.install, marker))).rejects.toMatchObject({ code: "ENOENT" })
   })
 })


### PR DESCRIPTION
## Why

A clean mise installation of published Browser Control 0.5.1 crashes on `--version` when the shared Node platform resolves rc.112 alongside Effect rc.111. The prereleases have incompatible single-finalizer Scope layouts; main already upgrades the two direct packages to rc.112, but the shared platform can still float separately.

## What Changes

Pin `@effect/platform-node-shared` to rc.112 alongside Effect and the Node platform, with an intentional Knip exemption for runtime-cohort alignment.

Extend existing runtime preparation with a fresh standalone pnpm consumer of the packed tarball. It has an isolated home/config/store, no checkout lockfile or dependency overrides, and disabled dependency build scripts. Validate all three exact packed pins, their resolved versions, one shared Effect runtime path, CLI help/version, and SDK import before stamping a candidate. Retain the existing npm consumer and MCP/type validation.

| Packed consumer | Resolution | CLI result |
| --- | --- | --- |
| Historical two-pin rc.111 fixture | Effect rc.111 plus shared platform/Effect rc.112 | Exact Scope finalizer crash |
| Historical three-pin rc.111 fixture | All three remain rc.111 despite available rc.112 | Version succeeds |
| Current candidate | All three rc.112, identical Effect module path | `browser-control v0.5.1` |

Add a patch changeset and document the exact runtime-cohort invariant.

## Scope

This covers fresh standalone aube/pnpm consumers, not a universal lock across arbitrary host dependency graphs. Related #39: its original trust-policy failure is distinct from this runtime crash; published-version retry is still required before treating that report as fully resolved.

## Verification

```bash
pnpm install --frozen-lockfile
bun run test test/runtime-install.test.ts
pnpm typecheck
pnpm run ci
pnpm exec changeset status
VALIDATION_DIR="$(mktemp -d "${TMPDIR%/}/opencode/runtime-cohort-final.XXXXXX")"
pnpm runtime:prepare --staging "$VALIDATION_DIR/stage" --install "$VALIDATION_DIR/install"
```

- Red before the third pin: packed validation rejected the missing exact shared-platform pin.
- Focused tests: 7 passed, including strict-consumer cleanup and refusal to stamp a failed candidate.
- Full repository gates: 736 tests across 55 files, unused checks, CLI/extension builds, and extension packaging passed.
- Runtime preparation passed strict pnpm validation and existing npm CLI, SDK/type, and fake-endpoint MCP validation.
- Normal `pnpm pack` tarball inspected and independently installed with pnpm 11.20.0 in a fresh isolated consumer. All runtime edges resolved the identical rc.112 Effect file; CLI and SDK smoke passed.
- Historical packed differential verified with aube 2.2.4, the version embedded in mise 2026.9.0; the three-pin result also verified with pnpm. No aube binary or historical fixture added to CI.
- No trust-policy exclusions, provenance relaxation, live browser operations, or publication performed.
