### PR TITLE
feat(recording): improve capture quality and visual evidence

### DIFF
--- a/.changeset/clear-visual-evidence.md
+++ b/.changeset/clear-visual-evidence.md
@@ -1,0 +1,8 @@
+---
+"@opencode-ai/browser-control": minor
+---
+
+Add the code-first screenshotDiff helper for PNG visual comparisons, changed-pixel
+metrics, and highlighted diff images. Expose CDP recording quality in stop/status
+receipts and JSON output, including screenshot fallback. Reject frame rates outside
+the supported integer range of 1 through 60 instead of silently clamping them.

--- a/.changeset/sharp-native-recordings.md
+++ b/.changeset/sharp-native-recordings.md
@@ -1,0 +1,8 @@
+---
+"@opencode-ai/browser-control": patch
+---
+
+Fix undersized, padded CDP recordings with emulated viewports and Retina backing
+surfaces. Preserve the starting viewport instead of downscaling to 720p, improve
+source image quality, and default to 60 fps with a 60 fps ceiling. Frame delivery
+still depends on the browser; use a lower frame rate for smaller recordings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,10 +199,19 @@ local Node relay.
   best-effort and must never fail the execute call.
 - Relay-owned recording uses `Page.startScreencast`, immediately acknowledges
   compositor frames, activates the target to avoid background-tab throttling,
-  and fits its viewport within 1280×720. Stream each distinct JPEG once in a
-  timestamped Matroska envelope and let ffmpeg produce constant 25 fps output;
+  and preserves its starting CSS viewport. Request uncapped JPEG100 frames:
+  screencast caps shrink an emulated viewport against the full backing surface.
+  Normalize device pixels using the first frame's surface width, then crop to
+  the viewport without upscaling. Stream each distinct JPEG once in a
+  timestamped Matroska envelope and let ffmpeg produce constant 60 fps output;
   never push duplicated JPEGs through Node or derive duration from discontinuous
   navigation timestamps.
+- Recording receipts and sidecars share the same CDP quality counters; report
+  screenshot fallback explicitly and never call compositor-event counts distinct
+  motion. Reject unsupported frame rates instead of silently clamping them.
+- `screenshotDiff` remains a session-page execute helper. Preserve original pixel
+  geometry, reject unequal image dimensions, bound PNG decoding, and never
+  overwrite baseline or existing output artifacts to make a comparison pass.
 - Session delete/reset must acquire the session's execute permit before closing
   the sandbox, so running scripts are never yanked mid-flight.
 - Session deletion is idempotent for a resolved session id: return whether a

--- a/PLAN.md
+++ b/PLAN.md
@@ -425,6 +425,11 @@ reconciles existing client announcements, browser grouping, and page status.
   operations while the mask is active.
 - `screenshotWithLabels({ page, path? })` annotates likely interactive elements
   and returns label metadata.
+- `screenshotDiff({ baseline, path?, threshold?, fullPage? })` compares PNGs at
+  the same CSS-pixel scale and returns changed-pixel counts/ratio plus a
+  red-highlighted image. It rejects dimension mismatches instead of resizing,
+  counts antialiasing changes, bounds input size, and never overwrites an existing
+  output. It is an execute helper, not a new action-tool family.
 - `fillInput` and `fillInputs` provide a DOM-evaluation fallback when browser
   extensions make native Playwright filling hang.
 - Allowed Playwright mouse actions can reveal a spring-animated cursor.
@@ -597,8 +602,19 @@ commands never replace a running relay.
   extension-backed tabs because Chromium blocks download behavior commands from
   `chrome.debugger`; download waits return a direct capability error.
 - CDP recording activates its tab to avoid background compositor throttling,
-  fits the viewport within 1280x720, requires `ffmpeg` on `PATH`, and does not
-  capture audio.
+   preserves the starting CSS viewport rather than downscaling to 720p, requires
+   `ffmpeg` on `PATH`, and does not capture audio. It captures uncapped JPEG100
+   compositor frames, normalizes device pixels using the first frame's surface
+   width, then crops at native CSS size (rounding odd output dimensions down to
+   even). Output defaults to 60 fps; actual motion depends on source frames.
+   The encoder starts on the first frame; a start-time ffmpeg probe preserves
+   missing-dependency errors. Keep viewport/emulation fixed during recording.
+- Recording start/stop/status expose JSON receipts. CDP quality metrics come from
+  the same counters as the sidecar: dimensions, configured rate, received/retained
+  source frames and rates, coalescing/drops, and stop-time screenshot fallback.
+  Compositor events are not distinct-motion measurements. Tab capture and older
+  relays omit unavailable quality data. All explicit frame rates must be integers
+  in 1..60; never silently clamp unsupported requests.
 - The trusted sandbox exposes selected Node built-ins, not unrestricted local
   command execution.
 - Exact parity across third-party authentication remains a manual diagnostic.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Other inspection helpers include:
   values, custom ARIA range values, and editable content omitted; await it
   separately from other operations on the same page
 - `screenshotWithLabels()` for an annotated screenshot and element metadata
+- `screenshotDiff({ baseline })` for changed-pixel metrics and a red-highlighted
+  PNG against a saved baseline; capture both at the same CSS viewport scale
 - `fillInput()` and `fillInputs()` when browser extensions interfere with
   Playwright's normal `locator.fill()`
 
@@ -334,6 +336,26 @@ browser-control recording start ./demo.webm --session github
 browser-control recording status --session github
 browser-control recording stop --session github
 ```
+
+Recording start/stop/status support `--json`. CDP quality receipts distinguish
+output fps from received/retained source frames and report coalescing, drops,
+dimensions, and screenshot fallback. These counters do not prove distinct motion.
+Explicit frame rates must be integers from 1 to 60; unsupported values are rejected.
+
+Visual comparison stays code-first:
+
+```ts
+await page.screenshot({ path: "/absolute/before.png", scale: "css" })
+// Make the intended UI change, keeping the viewport unchanged.
+return await screenshotDiff({ baseline: "/absolute/before.png" })
+```
+
+The result includes a diff image, `matches`, `changedPixels`, and `changedRatio`.
+Use `path` for a new absolute PNG output instead of inline media. `threshold`
+(default 0.1) controls pixel color tolerance, not allowed changed area. Different
+dimensions fail without resizing. Images are bounded to 32 MiB / 16 megapixels;
+existing output files are never overwritten. Review visible private content
+before sharing either screenshots or diffs.
 
 Automatic mode uses browser tab capture for user-owned tabs and CDP screencast
 for relay-created tabs. Tab capture writes WebM and can include audio. CDP mode

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "audit:duplicates": "jscpd src extension/src --format typescript --min-lines 10 --min-tokens 100 --mode weak --reporters console --absolute --no-tips",
     "bench:recording": "tsx scripts/bench-recording.ts",
+    "bench:recording-quality": "tsx scripts/bench-recording-quality.ts",
     "build:cli": "tsx scripts/build-cli.ts",
     "build": "pnpm build:cli && pnpm build:extension",
     "build:extension": "tsx scripts/build-extension.ts",
@@ -59,13 +60,16 @@
     "@effect/platform-node-shared": "4.0.0-rc.112",
     "acorn": "^8.18.0",
     "effect": "4.0.0-rc.112",
+    "pixelmatch": "^7.2.0",
     "playwright-core": "^1.62.1",
+    "pngjs": "^7.0.0",
     "ws": "^8.21.3"
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.1",
     "@types/chrome": "^0.2.7",
     "@types/node": "^26.2.0",
+    "@types/pngjs": "^6.0.5",
     "@types/ws": "^8.18.1",
     "esbuild": "^0.28.2",
     "fflate": "^0.8.3",

--- a/perf/recording-quality.md
+++ b/perf/recording-quality.md
@@ -1,0 +1,164 @@
+# Recording quality
+
+Goal: preserve readable UI pixels and smooth actual motion, not merely label a
+small or repeated image 720p/30fps. Do not restart the shared relay for experiments.
+
+## Benchmark
+
+```sh
+pnpm bench:recording-quality --browser <Chromium-executable> --out <fresh-directory>
+pnpm bench:recording-quality --browser <Chromium-executable> --backing-surface --verify --out <fresh-directory>
+pnpm bench:recording-quality --browser <Chromium-executable> --width 1920 --height 1080 --dpr 1 --verify --out <fresh-directory>
+```
+
+Requires ffmpeg and ffprobe. `--verify` requires text SSIM ≥ 0.98, at least 45
+actual motion changes/sec, native output dimensions, and no dropped frames in
+every measured run. `--format webm` checks the alternate encoder.
+
+For extension evidence, create a **disposable** Browser Control session with one
+blank owned page, then pass `--session <id>` instead of `--browser`. This replaces
+that page's content and emulation. The source recorder runs in the benchmark
+process; only CDP commands/events cross the installed relay. It does not replace
+the installed recorder, restart the relay, or touch other sessions. Delete the
+disposable session afterward. This harness uses the default local relay port.
+
+Runs the production `RecordingRelay` against an isolated Chromium CDP session and
+real ffmpeg. One warmup, seven measured 2.2-second recordings. Primary metric:
+median text-region SSIM versus the same browser's native PNG. Guardrails: actual
+moving-bar position changes per decoded second, output dimensions, dropped source
+frames, duration and file size. Normalization for scoring is not a delivery fix.
+
+Repeat with 1280×720 and 1920×1080 CSS viewports and DPR 1/2. A direct-CDP browser
+run does not certify the extension transport; verify the winner through a dedicated
+Browser Control session before calling the original failure fixed.
+
+## Reference
+
+Vercel `vercel-labs/agent-browser` cloned read-only at
+`4a98df79bd232fcde5ca3a4a48e1337b8108b160`. Its Rust recorder requests JPEG80,
+does not cap screencast dimensions, derives ffmpeg dimensions from image input,
+and defaults to30fps with a60fps ceiling. It uses a separate capture session.
+Its five-second gap truncation is NOT a behavior to copy: Browser Control must
+retain the actual recording timeline. Source comparison is not an executed
+agent-browser quality score.
+
+## Baseline / experiments
+
+Production source starts at3019ad9; installed0.6.0 is
+a separate artifact. Known user repro: 1280×720 output contains640×360 page plus
+padding; a later screenshot-loop workaround retains pixels but only about10fps.
+Organizer bug: ba8d0274. Keep raw artifacts outside the repository.
+
+- Initial broad-region SSIM was diluted by whitespace; narrowed the primary score
+  to a fixed800×220 text/button region and reran the baseline before source edits.
+- 1080p baseline (1warmup+7): textSSIM **0.960825**, distinct motion25fps,
+  output1280×720, median24530bytes/2.2s. The cap destroys requested detail.
+- **Keep native viewport dimensions:** SSIM **0.984925**, motion25fps, zero drops,
+  output1920×1080, median35436bytes. Existing frame-ack/timeline test red then green
+  with native-size expectations. This is not yet the original padding defect fix.
+- Live-extension benchmark initially used a second Playwright CDPSession and
+  received no compositor events (only stop-time screenshot fallback). Those runs
+  are invalid motion evidence. A dedicated raw CDP client with one target alias
+  receives real events: roughly60sourcefps/25encodedfps at1280×720. It uses only
+  the benchmark-owned session, never restarts the shared relay.
+- Next hypothesis: JPEG95 improves small-text fidelity beyond JPEG80 without
+  reducing distinct motion rate. Only the quality constant changes in this round.
+- **Keep JPEG95 candidate:**1080p SSIM0.992925 (vs0.984925),25distinctfps,
+  zero drops, median32512bytes (vs35436). Cleaner source JPEGs also compressed
+  better in this synthetic MP4. Next test JPEG100 for remaining headroom.
+- Executed released Agent Browser0.36.0 on the same1280fixture: seven runs,
+  median textSSIM about0.9845 and10distinctfps. Its stop result has no captured
+  frame counter. This differs from cloned main's30/60fps screencast implementation;
+  do not misrepresent the release binary as execution of the cloned source.
+- **Keep JPEG100:** SSIM0.993832,25distinctfps, median31982bytes/1080p clip.
+- **Keep uncapped screencast + crop at native scale:** reproduced original bug
+  with a2560×1273 backing surface and1280×720 emulated viewport using
+  `dontSetVisibleSize:true`. Before SSIM0.861510 and visibly half-sized content;
+  after seven measured runs SSIM0.993832,25distinctfps, full-size content.
+  The pad must round UP to even dimensions before crop: odd1273height otherwise
+  makes ffmpeg fail `Padded dimensions cannot be smaller than input dimensions`.
+  Preserved encoder stderr on pipe failure so this is not hidden as stream-destroyed.
+- Next hypothesis:60fps retains the source compositor's real motion without
+  reducing text quality. Test at1080p and through the existing extension on an
+  owned synthetic tab; no shared-runtime replacement.
+
+## Retina correction and final validation
+
+Uncapped capture alone is insufficient. The live Retina path returned two image
+pixels per CSS surface pixel; cropping directly cut off half the content
+(SSIM 0.830768). **Discard that intermediate implementation.** Normalize the
+JPEG down to the first frame's `metadata.deviceWidth`, preserving aspect ratio,
+then pad/crop to the starting CSS viewport. Never upscale a smaller source.
+
+This requires the production encoder to receive the first frame's surface width.
+Its acquisition is lazy and cancellation waits for an in-progress acquisition;
+a bounded start-time `ffmpeg -version` probe preserves missing-dependency errors.
+Normalize aspect ratio with `-1`, not `-2`: even-rounding at the scale stage
+stretches an odd-height surface. Round up only when padding, before final crop.
+Viewport/emulation must remain fixed during a recording.
+
+**Keep 60 fps:** controlled motion rises from 25 to roughly 59 distinct frames/sec.
+Text SSIM changes from 0.993832 at 25 fps to approximately 0.99332 at 60 fps;
+the small compression difference buys substantially smoother motion. MP4 median
+size rises from about 32 KB to 38 KB for this 2.2-second 1080p fixture. Real sites
+will cost more; high-DPI source transport remains a throughput limit.
+
+Final seven-run medians (one warmup each, after excluding the initial static
+position from the motion-change count):
+
+| Case | Text SSIM | Distinct motion/sec | Output | Drops |
+| --- | ---: | ---: | --- | ---: |
+| Isolated, odd backing surface, emulated viewport | 0.993319 | 59.55 | 1280×720 | 0 |
+| Live extension, Retina + odd backing surface | 0.988932 | 51.36 | 1280×720 | 0 |
+| Isolated 1080p, DPR 1 | 0.993321 | 58.65 | 1920×1080 | 0 |
+| Isolated 1080p, WebM | 0.995020 | 58.64 | 1920×1080 | 0 |
+
+The live stress case ranged from 47.82–54.55 actual motion changes/sec, not a
+guaranteed 60 distinct frames. All four cases passed `--verify`; encoded native
+MP4 frames were visually inspected. Isolated Chromium was 151.0.7922.34, Playwright
+1.62.1. The shared extension/relay remained on their existing installation.
+
+Artifacts are retained under the session temp directory, prefixes
+`bc-final-odd-surface`, `bc-final-live-retina`, and `bc-final-1080-dpr1`.
+The original bad artifacts and rejected intermediate runs remain for diagnosis.
+Unit suite: 705 tests / 54 files, including frame acknowledgements, monotonic
+timeline, cancellation, first-frame surface metadata, native dimensions, and
+default/explicit/capped frame rates. No full browser smoke-set claim.
+
+Final gates: `pnpm typecheck`, `pnpm check:locals`, `pnpm check:unused`,
+`bun run test`, and `pnpm build:cli --outdir <external-directory>` passed.
+The benchmark-owned browser session was deleted; the unrelated local UI fixture
+was retained. The recording guidance was synced into the canonical dotfiles
+skill without overwriting its unrelated, newer workflow sections.
+
+No package has been published or selected, and no shared relay was restarted.
+The source correction is verified; installed-runtime rollout remains separate.
+
+## Follow-up: visual diffs, receipts, and strict frame rates
+
+Implemented the three approved follow-ups without replacing the installed tool:
+
+- `screenshotDiff` is a session-page execute helper using PNGJS and Pixelmatch.
+  Same CSS scale, no implicit resizing, bounded PNG decoding, exclusive private
+  output files. A real Chromium/DPR-2 fixture compared equal with zero changes;
+  changing one button's colors highlighted 9,394 pixels (1.529% of 960×640).
+  The generated diff was visually inspected. Sandbox tests also verify that the
+  global is bound correctly and the PNG is extracted as execute media.
+- CDP stop/status `quality` receipts and the existing sidecar share one source
+  of counters. A real 30 fps capture returned 112 compositor events, 36 retained
+  images, 76 coalesced events, and zero drops. The schema-decoded receipt matched
+  every sidecar quality field. These are not distinct-motion measurements.
+  The stop-time screenshot fallback has a separate flag and visible warning.
+- Frame rates must be integers in 1..60 at CLI, HTTP schema, and recorder
+  boundaries. A standalone installed CLI rejected 120 fps before allocating a
+  recording; no output file was created. Explicit rates are never clamped.
+
+Final validation: 740 tests / 56 files; typecheck, locals, Knip, frozen install,
+and standalone `runtime:prepare` passed. Packed contents were inspected; the only
+new lockfile packages are Pixelmatch, PNGJS, and PNGJS types. An incidental Vite
+transitive-resolution change was removed before final validation.
+
+Private proof: `bc-three-proof/{before.png,after.png,diff.png,evidence.json}`.
+Final candidate: `bc-visual-final-runtime`; archive in
+`bc-visual-final-stage/artifacts`. Candidate prepared, **not selected or published**.
+No shared relay restart, extension reload, or full browser smoke-set claim.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,15 @@ importers:
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
+      pixelmatch:
+        specifier: ^7.2.0
+        version: 7.2.0
       playwright-core:
         specifier: ^1.62.1
         version: 1.62.1
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       ws:
         specifier: ^8.21.3
         version: 8.21.3
@@ -36,6 +42,9 @@ importers:
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -762,6 +771,9 @@ packages:
   '@types/node@26.4.0':
     resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
 
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1191,10 +1203,18 @@ packages:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
+  pixelmatch@7.2.0:
+    resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
   playwright-core@1.62.1:
     resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
     engines: {node: '>=20'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -1900,6 +1920,10 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 26.2.0
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.4.0
@@ -2293,7 +2317,13 @@ snapshots:
 
   picomatch@4.0.7: {}
 
+  pixelmatch@7.2.0:
+    dependencies:
+      pngjs: 7.0.0
+
   playwright-core@1.62.1: {}
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.26:
     dependencies:

--- a/scripts/bench-recording-quality.ts
+++ b/scripts/bench-recording-quality.ts
@@ -1,0 +1,161 @@
+import { spawnSync } from "node:child_process"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { parseArgs } from "node:util"
+import { once } from "node:events"
+import { WebSocket } from "ws"
+import { chromium, type CDPSession } from "playwright-core"
+import { RecordingRelay } from "../src/recording-relay.ts"
+import { getObject } from "../src/relay-helpers.ts"
+import type { JsonObject } from "../src/protocol.ts"
+
+// Real Chromium -> production RecordingRelay -> ffmpeg. --session is destructive
+// to its one fixture page: use only a new, disposable Browser Control session.
+const { values } = parseArgs({ options: {
+  browser: { type: "string" }, out: { type: "string" }, runs: { type: "string", default: "7" },
+  width: { type: "string", default: "1280" }, height: { type: "string", default: "720" },
+  dpr: { type: "string", default: "2" }, headed: { type: "boolean", default: false }, session: { type: "string" },
+  "backing-surface": { type: "boolean", default: false },
+  verify: { type: "boolean", default: false },
+  format: { type: "string", default: "mp4" },
+} })
+if (!values.out) throw new Error("Pass --out <fresh artifact directory>")
+const directory = path.resolve(values.out)
+await fs.mkdir(directory)
+const width = Number(values.width)
+const height = Number(values.height)
+const runs = Number(values.runs)
+if (![width, height, runs].every((value) => Number.isInteger(value) && value > 0)) throw new Error("Invalid dimensions/runs")
+if (values.format !== "mp4" && values.format !== "webm") throw new Error("Format must be mp4 or webm")
+const browser = values.session
+  ? await chromium.connectOverCDP("http://127.0.0.1:19989", { headers: { "Browser-Control-Session-Id": values.session } })
+  : await chromium.launch({ headless: !values.headed, ...(values.browser ? { executablePath: values.browser } : {}) })
+const results = []
+let recordingRelay: RecordingRelay | undefined
+let socket: WebSocket | undefined
+try {
+  const context = values.session ? browser.contexts()[0]! : await browser.newContext({ viewport: values["backing-surface"] ? { width: 2560, height: 1273 } : { width, height }, deviceScaleFactor: Number(values.dpr) })
+  if (values.session && context.pages().length !== 1) throw new Error("Expected exactly one owned benchmark page")
+  const page = values.session ? context.pages()[0]! : await context.newPage()
+  await page.setViewportSize(values["backing-surface"] ? { width: 2560, height: 1273 } : { width, height })
+  await page.setContent(`<!doctype html><style>
+    *{box-sizing:border-box}body{margin:0;background:#fff;color:#151515;font:16px Arial,sans-serif}
+    main{margin:48px;border:1px solid #ccc;border-radius:8px;padding:24px;height:${height - 260}px}
+    h1{font-size:28px;margin:0 0 24px}p{margin:12px 0}.small{font-size:12px}
+    button{font:inherit;padding:8px 16px;border:1px solid #ccc;border-radius:6px;background:white}
+    .color{color:#185adb}.motion{position:absolute;left:48px;right:48px;bottom:40px;height:100px;background:#000;overflow:hidden}
+    .bar{width:8px;height:100%;background:white;animation:move 2s linear infinite alternate}
+    @keyframes move{to{transform:translateX(${width - 112}px)}}
+    .corner{position:absolute;width:16px;height:16px;background:#eb00eb;right:0;bottom:0}
+  </style><main><h1>Workspace settings — recording quality</h1>
+    <p>Reply model: Example model (Example custom provider)</p>
+    <p>The workspace pays for replies and background response checks.</p>
+    <p class="small">Small UI text: 0123456789 Il1 O0 Settings / Usage / API keys</p>
+    <p class="color">Colored text and thin borders must remain readable without upscaling.</p>
+    <button>Reconnect Slack</button> <button>Disconnect Slack</button>
+  </main><div class="motion"><div class="bar"></div></div><div class="corner"></div>`)
+  const cdp = await context.newCDPSession(page)
+  await cdp.send("Page.enable")
+  // One raw target alias receives root events through the extension transport.
+  // A second Playwright CDPSession currently receives no screencast events here.
+  const pending = new Map<number, { resolve: (value: JsonObject) => void; reject: (error: Error) => void }>()
+  let requestID = 0
+  let sessionID: string | undefined
+  const send = (method: string, params: JsonObject): Promise<JsonObject> => {
+    if (!socket) return cdp.send(method as Parameters<CDPSession["send"]>[0], params).then((value) => getObject(value) ?? {})
+    return new Promise((resolve, reject) => {
+      const id = ++requestID
+      pending.set(id, { resolve, reject })
+      socket!.send(JSON.stringify({ id, method, params, ...(sessionID ? { sessionId: sessionID } : {}) }))
+    })
+  }
+  if (values.session) {
+    socket = new WebSocket(`ws://127.0.0.1:19989/devtools/browser/recording-benchmark?browserControlSessionId=${encodeURIComponent(values.session)}`)
+    socket.on("message", (raw) => {
+      const event = getObject(JSON.parse(raw.toString()))!
+      if (typeof event.id === "number") {
+        const request = pending.get(event.id)
+        pending.delete(event.id)
+        if (event.error) request?.reject(new Error(JSON.stringify(event.error)))
+        else request?.resolve(getObject(event.result) ?? {})
+      }
+      if (event.method === "Page.screencastFrame") recordingRelay?.handleDebuggerEvent({ tabId: 1, method: event.method, params: getObject(event.params) })
+    })
+    socket.on("close", () => { for (const request of pending.values()) request.reject(new Error("CDP benchmark disconnected")); pending.clear() })
+    await once(socket, "open")
+    const targets = await send("Target.getTargets", {})
+    if (!Array.isArray(targets.targetInfos) || targets.targetInfos.length !== 1) throw new Error("Expected one raw target")
+    const attached = await send("Target.attachToTarget", { targetId: getObject(targets.targetInfos[0])!.targetId!, flatten: true })
+    if (typeof attached.sessionId !== "string") throw new Error("Missing raw session id")
+    sessionID = attached.sessionId
+    await send("Page.enable", {})
+  }
+  await page.evaluate(() => document.fonts.ready)
+  if (values["backing-surface"]) {
+    await send("Emulation.setDeviceMetricsOverride", { width, height, deviceScaleFactor: 1, mobile: false, dontSetVisibleSize: true })
+    const screenshot = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: false })
+    if (typeof screenshot.data !== "string") throw new Error("Missing reference screenshot")
+    await fs.writeFile(path.join(directory, "reference.png"), Buffer.from(screenshot.data, "base64"))
+  } else {
+    await page.screenshot({ path: path.join(directory, "reference.png"), scale: "css" })
+  }
+  const relay = new RecordingRelay({
+    isExtensionConnected: () => true,
+    sendToExtension: async () => { throw new Error("Unexpected extension call") },
+    sendDebuggerCommand: ({ method, params }) => send(method, params),
+  })
+  recordingRelay = relay
+  if (!values.session) cdp.on("Page.screencastFrame", (params) => relay.handleDebuggerEvent({ tabId: 1, method: "Page.screencastFrame", params: getObject(params) }))
+  for (let index = 0; index <= runs; index++) {
+    const output = path.join(directory, `${index}.${values.format}`)
+    const started = await relay.startRecording({ tabId: 1, owner: "relay", outputPath: output, mode: "cdp" })
+    if (!started.success) throw new Error(started.error)
+    await page.waitForTimeout(2200)
+    const stopped = await relay.stopRecording({ tabId: 1 })
+    if (!stopped.success) throw new Error(stopped.error)
+    const metadata = JSON.parse(await fs.readFile(`${output}.json`, "utf8"))
+    if (metadata.sourceFrameCount < 2) throw new Error("Moving fixture received no compositor stream; screenshot fallback is not motion proof")
+    const probe = JSON.parse(run("ffprobe", ["-v", "error", "-show_entries", "stream=width,height,r_frame_rate:format=duration,size", "-of", "json", output]).stdout.toString())
+    const frame = path.join(directory, `${index}.png`)
+    run("ffmpeg", ["-v", "error", "-ss", "0.5", "-i", output, "-frames:v", "1", frame])
+    // Normalize to the intended CSS viewport for comparison, not for the delivered recording.
+    const comparison = run("ffmpeg", ["-i", path.join(directory, "reference.png"), "-i", frame, "-lavfi",
+      `[0:v]crop=800:220:64:64,format=yuv444p[a];[1:v]scale=${width}:${height}:flags=lanczos,crop=800:220:64:64,format=yuv444p[b];[a][b]ssim`, "-f", "null", "-"])
+    const ssim = Number(comparison.stderr.toString().match(/All:([\d.]+)/)?.[1])
+    if (!Number.isFinite(ssim)) throw new Error("No SSIM result")
+    const motion = run("ffmpeg", ["-v", "error", "-i", output, "-vf", `scale=${width}:${height},crop=${width - 96}:1:48:${height - 90},format=gray`, "-f", "rawvideo", "-"]).stdout
+    const stride = width - 96
+    const positions = Array.from({ length: Math.floor(motion.length / stride) }, (_, i) => motion.subarray(i * stride, (i + 1) * stride).findIndex((pixel) => pixel > 220))
+    const changes = positions.filter((position, i) => i > 0 && position >= 0 && position !== positions[i - 1]).length
+    const result = {
+      run: index, warmup: index === 0, textSSIM: ssim,
+      distinctMotionFps: changes / Number(probe.format.duration),
+      encodedSourceFps: metadata.encodedSourceFrameCount / (metadata.durationMs / 1000),
+      droppedFrames: metadata.droppedFrameCount,
+      outputWidth: probe.streams[0].width, outputHeight: probe.streams[0].height,
+      bytes: Number(probe.format.size), duration: Number(probe.format.duration),
+    }
+    console.log(JSON.stringify(result))
+    if (index > 0) results.push(result)
+  }
+  await fs.writeFile(path.join(directory, "results.json"), JSON.stringify({ width, height, dpr: Number(values.dpr), results }, null, 2))
+  for (const key of ["textSSIM", "distinctMotionFps", "encodedSourceFps", "bytes"] as const) {
+    const samples = results.map((row) => row[key]).sort((a, b) => a - b)
+    const median = samples[Math.floor(samples.length / 2)]!
+    console.log(`METRIC recording_${key}=${median.toFixed(6)} min=${samples[0]} max=${samples.at(-1)}`)
+  }
+  if (values.verify && results.some((row) => row.textSSIM < 0.98 || row.distinctMotionFps < 45 || row.droppedFrames !== 0 || row.outputWidth !== width || row.outputHeight !== height)) {
+    throw new Error("Recording quality regression: require SSIM>=0.98, >=45 actual motion changes/s, native dimensions, and no dropped frames")
+  }
+} finally {
+  if (recordingRelay?.hasActiveRecordings()) await recordingRelay.cancelRecording({ tabId: 1 })
+  socket?.close()
+  // connectOverCDP.close disconnects this client; it does not close the attached browser.
+  await browser.close()
+}
+
+function run(command: string, args: string[]) {
+  const result = spawnSync(command, args, { maxBuffer: 64 * 1024 * 1024 })
+  if (result.status !== 0) throw new Error(`${command}: ${result.stderr.toString()}`)
+  return result
+}

--- a/skills/browser-control/SKILL.md
+++ b/skills/browser-control/SKILL.md
@@ -225,6 +225,11 @@ Use the least expensive view that answers the question:
   the same page concurrently.
 - `screenshotWithLabels({ page, path? })` adds visual labels and metadata when
   layout matters.
+- `screenshotDiff({ baseline, path?, threshold?, fullPage? })` compares a saved
+  PNG (absolute path or Buffer) with the current session page at CSS-pixel scale.
+  It returns `matches`, `changedPixels`, `changedRatio` (0..1), dimensions, and a
+  red-highlighted PNG. Omit `path` to return the image as execute media; otherwise
+  supply a fresh absolute `.png` path. Existing output files are never overwritten.
 
 ```js
 return await snapshot({ within: "main", maxItems: 200 })
@@ -234,6 +239,21 @@ return await screenshotWithLabels({ page })
 
 Saving an image and returning only `"ok"` proves file creation, not visual
 correctness. Return screenshot buffers through MCP when visual evidence matters.
+
+For visual regression checks, save a baseline before changing the UI:
+
+```ts
+await page.screenshot({ path: "/absolute/before.png", scale: "css" })
+// After the intended UI change, in the same viewport:
+return await screenshotDiff({ baseline: "/absolute/before.png" })
+```
+
+The threshold defaults to 0.1 and controls per-pixel color tolerance, not the
+allowed changed area. Set it to 0 for exact pixels. Antialiasing changes count.
+Settle animations yourself and use the same viewport and `fullPage` setting for
+both captures. Dimension mismatches fail explicitly; images are never resized.
+Comparisons are limited to PNGs of 32 MiB / 16 megapixels each. Screenshots and
+diffs include visible page content: inspect for private information before sharing.
 
 ## Execute Interface
 
@@ -382,9 +402,34 @@ browser-control recording status --session github
 browser-control recording stop --session github
 ```
 
+Start, stop, and status accept `--json`. CDP stop/status results include a
+`quality` receipt: output dimensions/rate, source and retained-image counts/rates,
+coalesced/dropped frames, and `screenshotFallback`. The fallback means no
+compositor frames arrived and the video holds one stop-time screenshot; do not
+present that as recorded motion. Source counters count compositor events, not
+visually distinct frames. Low rates can be normal on a static page. Tab capture
+and older relays omit quality telemetry rather than inventing measurements.
+
+Explicit frame rates must be integers from 1 through 60 in either mode; invalid
+values fail instead of silently clamping. The start result reports the chosen rate.
+
 `--mode auto` uses tab capture for user-owned tabs and CDP for relay-owned tabs.
 Tab capture can include audio; CDP requires `ffmpeg` and has no audio. Use the
 command's `--help` for format and cursor options.
+
+CDP recordings preserve the starting CSS viewport (not a fixed 720p canvas),
+use high-quality source frames, and default to 60 fps. Use `--frame-rate 30`
+for smaller files. Actual motion still depends on Chrome delivering new frames;
+60 fps output does not guarantee 60 distinct frames. Larger viewports cost more
+CPU, transport bandwidth, and storage. Set the viewport before recording and do
+not change viewport/emulation mid-recording. Odd dimensions round down to even.
+
+Inspect an encoded frame at native size before sharing: the whole viewport must
+fill the frame, small text must be readable, and motion must not be a repeated
+still image. Do not crop and upscale a low-resolution capture to call it HD.
+On an older installed relay that shrinks the page into a padded corner, record
+the defect and coordinate a recorder update; changing the file's resolution is
+not a repair.
 
 Completion: stop the recorder, inspect the resulting media rather than only its
 existence, and report the viewport, state, and interaction path actually tested.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { NodeRuntime, NodeServices } from "@effect/platform-node"
 import { Config, Console, Effect, FileSystem, Layer, Option } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import path from "node:path"
+import { formatRecordingQuality } from "./recording-presentation.ts"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
 import { createDoctorReport, formatDoctorReport } from "./doctor.ts"
@@ -585,15 +586,19 @@ const recordingStart = Command.make(
     tabId: Flag.integer("tab-id").pipe(Flag.optional, Flag.withDescription("Record this attached Chrome tab id")),
     mode: Flag.string("mode").pipe(Flag.optional, Flag.withDescription("Recording mode: auto, tab-capture, or cdp. auto uses CDP for relay-owned tabs and tabCapture for user-owned tabs")),
     audio: Flag.boolean("audio").pipe(Flag.withDefault(false), Flag.withDescription("Include tab audio")),
-    frameRate: Flag.integer("frame-rate").pipe(Flag.optional, Flag.withDescription("Output frame rate, defaults to 30 for tab-capture and 25 for CDP")),
+    frameRate: Flag.integer("frame-rate").pipe(Flag.optional, Flag.withDescription("Output frame rate, integer 1..60; defaults to 30 for tab-capture and 60 for CDP")),
     maxDurationMs: Flag.integer("max-duration-ms").pipe(Flag.optional, Flag.withDescription("Auto-stop guard in milliseconds, defaults to 900000")),
+    json: Flag.boolean("json").pipe(Flag.withDefault(false), Flag.withDescription("Print machine-readable JSON")),
   },
-  Effect.fn("Cli.recordingStart")(function* ({ outputPath, session, tabId, mode, audio, frameRate, maxDurationMs }) {
+  Effect.fn("Cli.recordingStart")(function* ({ outputPath, session, tabId, mode, audio, frameRate, maxDurationMs, json }) {
+    const frameRateValue = Option.getOrUndefined(frameRate)
+    if (frameRateValue !== undefined && (frameRateValue < 1 || frameRateValue > 60)) {
+      return yield* Effect.fail(new Error("Recording frameRate must be an integer from 1 to 60"))
+    }
     const relay = yield* RelayClient.Service
     yield* ensureCliRelayAndExtension()
     const target = yield* recordingTarget({ session, tabId })
     const modeValue = yield* parseRecordingModeOption(Option.getOrUndefined(mode))
-    const frameRateValue = Option.getOrUndefined(frameRate)
     const maxDurationMsValue = Option.getOrUndefined(maxDurationMs)
     const resolvedOutputPath = path.resolve(outputPath)
     const result = yield* relay.recordingStart({
@@ -607,7 +612,7 @@ const recordingStart = Command.make(
     if (!result.success) {
       return yield* Effect.fail(new Error(result.error ?? "Failed to start recording"))
     }
-    yield* Console.log(`Recording started: ${result.path ?? resolvedOutputPath} tab=${result.tabId ?? "unknown"} mode=${result.mode ?? "tab-capture"} artifact=${result.artifactType ?? "webm"} mime=${result.mimeType ?? "video/webm"}`)
+    yield* Console.log(json ? JSON.stringify(result, null, 2) : `Recording started: ${result.path ?? resolvedOutputPath} tab=${result.tabId ?? "unknown"} mode=${result.mode ?? "tab-capture"} artifact=${result.artifactType ?? "webm"} mime=${result.mimeType ?? "video/webm"} fps=${result.frameRate ?? "unknown"}`)
   }),
 ).pipe(Command.withDescription("Start recording an attached tab"))
 
@@ -616,8 +621,9 @@ const recordingStop = Command.make(
   {
     session: Flag.string("session").pipe(Flag.optional, Flag.withAlias("s"), Flag.withDescription("Stop recording for this CDP session id")),
     tabId: Flag.integer("tab-id").pipe(Flag.optional, Flag.withDescription("Stop recording for this Chrome tab id")),
+    json: Flag.boolean("json").pipe(Flag.withDefault(false), Flag.withDescription("Print machine-readable JSON")),
   },
-  Effect.fn("Cli.recordingStop")(function* ({ session, tabId }) {
+  Effect.fn("Cli.recordingStop")(function* ({ session, tabId, json }) {
     const relay = yield* RelayClient.Service
     yield* ensureCliRelay()
     const target = yield* recordingTarget({ session, tabId })
@@ -625,8 +631,10 @@ const recordingStop = Command.make(
     if (!result.success) {
       return yield* Effect.fail(new Error(result.error ?? "Failed to stop recording"))
     }
+    if (json) return yield* Console.log(JSON.stringify(result, null, 2))
     const frames = result.frameCount === undefined ? "" : `, frames=${result.frameCount}`
     yield* Console.log(`Recording saved: ${result.path ?? "unknown"} (${result.size ?? 0} bytes, ${result.duration ?? 0}ms, mode=${result.mode ?? "tab-capture"}, artifact=${result.artifactType ?? "webm"}${frames})`)
+    yield* Console.log(formatRecordingQuality(result.quality))
   }),
 ).pipe(Command.withDescription("Stop recording and write the artifact"))
 
@@ -652,6 +660,7 @@ const recordingStatus = Command.make(
     }
     const frames = result.frameCount === undefined ? "" : ` frameCount=${result.frameCount}`
     yield* Console.log(`Recording: active tab=${result.tabId ?? "unknown"} mode=${result.mode ?? "tab-capture"} artifact=${result.artifactType ?? "webm"} path=${result.path ?? "unknown"} size=${result.size ?? 0}${frames} startedAt=${result.startedAt ?? "unknown"}`)
+    yield* Console.log(formatRecordingQuality(result.quality))
   }),
 ).pipe(Command.withDescription("Check current recording status"))
 

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -22,6 +22,7 @@ import type { AuthenticatedJsonOutcome, AuthenticatedJsonRequest, ExecuteAfterma
 import type { SessionTarget } from "./relay-types.ts"
 import { executionContextFailureDiagnostic, runtimeFailureKind } from "./runtime-diagnostics.ts"
 import { ariaSnapshotWithoutTextControlValues, registerAriaSnapshotSelector } from "./aria-snapshot.ts"
+import { createScreenshotDiff, type ScreenshotDiffOptions, type ScreenshotDiffResult } from "./screenshot-diff.ts"
 
 const nodeModules = { fs, path, os, crypto, url, util, events, stream, buffer, http, https, zlib }
 const nodeModuleAliases = Object.keys(nodeModules).join(", ")
@@ -235,6 +236,7 @@ type SandboxGlobals = {
   readonly fillInput: (target: InputTarget, value: string) => Promise<void>
   readonly fillInputs: (page: Page, fields: ReadonlyArray<InputField>) => Promise<void>
   readonly screenshotWithLabels: (options: ScreenshotWithLabelsOptions) => Promise<ScreenshotWithLabelsResult>
+  readonly screenshotDiff: (options: ScreenshotDiffOptions) => Promise<ScreenshotDiffResult>
   readonly ariaSnapshot: AriaSnapshotHelper
   readonly snapshot: SnapshotHelper
   readonly ref: SnapshotRefHelper
@@ -785,6 +787,7 @@ export class ExecuteSandbox {
       fillInput: (target, value) => fillInput({ page, target, value }),
       fillInputs,
       screenshotWithLabels,
+      screenshotDiff: createScreenshotDiff(page),
       ariaSnapshot,
       snapshot,
       ref,
@@ -2415,6 +2418,7 @@ export async function runUserCode({ code, globals }: { readonly code: string; re
       "fillInput",
       "fillInputs",
       "screenshotWithLabels",
+      "screenshotDiff",
       "ariaSnapshot",
       "snapshot",
       "ref",
@@ -2435,6 +2439,7 @@ export async function runUserCode({ code, globals }: { readonly code: string; re
       globals.fillInput,
       globals.fillInputs,
       globals.screenshotWithLabels,
+      globals.screenshotDiff,
       globals.ariaSnapshot,
       globals.snapshot,
       globals.ref,

--- a/src/recording-presentation.ts
+++ b/src/recording-presentation.ts
@@ -1,0 +1,12 @@
+import type { RecordingQuality } from "./relay-schema.ts"
+
+export function formatRecordingQuality(quality: RecordingQuality | undefined): string {
+  if (!quality) return "Capture quality: unavailable (tab capture or older relay)."
+  return [
+    `Capture: ${quality.width}×${quality.height}, output ${quality.frameRate} fps; source surface ${quality.sourceWidth ?? "?"}×${quality.sourceHeight ?? "?"} CSS px`,
+    `Source frames: ${quality.sourceFrameCount} received (${quality.achievedSourceFrameRate.toFixed(1)}/s), ${quality.encodedSourceFrameCount} retained (${quality.achievedEncodedSourceFrameRate.toFixed(1)}/s), ${quality.coalescedFrameCount} coalesced, ${quality.droppedFrameCount} dropped`,
+    quality.screenshotFallback
+      ? "WARNING: no compositor frames arrived; this video holds a single stop-time screenshot."
+      : "Source counts are compositor events, not a measurement of distinct motion. Inspect the video before sharing.",
+  ].join("\n")
+}

--- a/src/recording-relay.ts
+++ b/src/recording-relay.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process"
+import { execFile, spawn } from "node:child_process"
 import crypto from "node:crypto"
 import { once } from "node:events"
 import fs from "node:fs/promises"
@@ -10,14 +10,15 @@ import type { ExtensionCommand, JsonObject } from "./protocol.ts"
 import { getObject } from "./relay-helpers.ts"
 import type { ConnectedTarget } from "./relay-types.ts"
 import { decodeRecordingFrame } from "./recording-protocol.ts"
+import type { RecordingQuality } from "./relay-schema.ts"
 
 const defaultMaxDurationMs = 15 * 60 * 1_000
-const defaultCdpFrameRate = 25
-const maxCdpFrameRate = 30
+const defaultCdpFrameRate = 60
+const maxRecordingFrameRate = 60
 const maxPendingCdpFrames = 30
-const maxCdpWidth = 1_280
-const maxCdpHeight = 720
-const cdpJpegQuality = 80
+const fallbackCdpWidth = 1_280
+const fallbackCdpHeight = 720
+const cdpJpegQuality = 100
 const maxPendingTabCaptureBytes = 16 * 1024 * 1024
 const maxTabCaptureOutputBytes = 1024 * 1024 * 1024
 
@@ -59,6 +60,7 @@ export type RecordingStartResult =
     readonly mimeType: string
     readonly mode: ActiveRecordingMode
     readonly artifactType: RecordingArtifactType
+    readonly frameRate?: number
   }
   | {
     readonly success: false
@@ -75,6 +77,7 @@ export type RecordingStopResult =
     readonly mode: ActiveRecordingMode
     readonly artifactType: RecordingArtifactType
     readonly frameCount?: number
+    readonly quality?: RecordingQuality
   }
   | {
     readonly success: false
@@ -90,6 +93,7 @@ export type RecordingStatusResult = {
   readonly mode?: ActiveRecordingMode
   readonly artifactType?: RecordingArtifactType
   readonly frameCount?: number
+  readonly quality?: RecordingQuality
 }
 
 export type RecordingCancelResult = {
@@ -152,10 +156,11 @@ type CdpRecording = ActiveRecordingBase & {
 type CdpVideoFrame = {
   readonly buffer: Buffer
   readonly frameNumber: number
+  readonly surfaceWidth?: number
 }
 
 export type VideoEncoder = {
-  readonly write: (frame: Buffer, timestampMs: number, durationMs: number) => Promise<void>
+  readonly write: (frame: Buffer, timestampMs: number, durationMs: number, surfaceWidth?: number) => Promise<void>
   readonly finish: () => Promise<void>
   readonly cancel: () => Promise<void>
 }
@@ -224,6 +229,9 @@ export class RecordingRelay {
   }
 
   async startRecording(options: RecordingStartOptions): Promise<RecordingStartResult> {
+    if (options.frameRate !== undefined && (!Number.isInteger(options.frameRate) || options.frameRate < 1 || options.frameRate > maxRecordingFrameRate)) {
+      return { success: false, error: "Recording frameRate must be an integer from 1 to 60" }
+    }
     if (!this.options.isExtensionConnected()) {
       return { success: false, error: "Browser Control extension is not connected" }
     }
@@ -321,6 +329,7 @@ export class RecordingRelay {
         path: recording.outputPath,
         mode: "cdp",
         artifactType: recording.artifactType,
+        quality: recordingQuality(recording, this.monotonicNow() - recording.startedMonotonicAt),
         frameCount: recording.stopping
           ? recording.frameCount
           : Math.max(0, Math.round(((this.monotonicNow() - recording.startedMonotonicAt) / 1_000) * recording.frameRate)),
@@ -483,7 +492,11 @@ export class RecordingRelay {
       } else if (recording.lastFrame) {
         recording.coalescedFrameCount += 1
       }
-      recording.lastFrame = { buffer, frameNumber }
+      recording.lastFrame = {
+        buffer,
+        frameNumber,
+        ...(typeof metadata?.deviceWidth === "number" ? { surfaceWidth: metadata.deviceWidth } : {}),
+      }
     }).catch((error: unknown) => {
       recording.writeError = error instanceof Error ? error : new Error(String(error))
     }).finally(() => {
@@ -687,6 +700,7 @@ export class RecordingRelay {
       success: true,
       tabId: result.tabId,
       startedAt: result.startedAt,
+      frameRate: options.frameRate ?? 30,
       path: options.outputPath,
       mimeType: result.mimeType ?? "video/webm",
       mode: "tab-capture",
@@ -704,11 +718,7 @@ export class RecordingRelay {
     }
     await fs.mkdir(path.dirname(options.outputPath), { recursive: true })
     if (starting.cancelled) return { success: false, error: "Recording was cancelled while starting" }
-    const requestedFrameRate = options.frameRate ?? defaultCdpFrameRate
-    if (requestedFrameRate <= 0 || !Number.isFinite(requestedFrameRate)) {
-      return { success: false, error: "Recording frameRate must be a positive finite number" }
-    }
-    const frameRate = Math.min(requestedFrameRate, maxCdpFrameRate)
+    const frameRate = options.frameRate ?? defaultCdpFrameRate
     let size: { readonly width: number; readonly height: number }
     try {
       await this.options.sendDebuggerCommand({
@@ -774,8 +784,6 @@ export class RecordingRelay {
         params: {
           format: "jpeg",
           quality: cdpJpegQuality,
-          maxWidth: size.width,
-          maxHeight: size.height,
           everyNthFrame: 1,
         },
       })
@@ -796,6 +804,7 @@ export class RecordingRelay {
       mimeType: artifactType === "mp4" ? "video/mp4" : "video/webm",
       mode: "cdp",
       artifactType,
+      frameRate,
     }
   }
 
@@ -863,6 +872,7 @@ export class RecordingRelay {
       await recording.encoder.finish()
 
       const stat = await fs.stat(recording.outputPath)
+      const quality = recordingQuality(recording, durationMs)
       const metadata = {
         mode: "cdp",
         artifactType: recording.artifactType,
@@ -871,17 +881,8 @@ export class RecordingRelay {
         startedAt: new Date(recording.startedAt).toISOString(),
         stoppedAt: new Date(stoppedAt).toISOString(),
         durationMs,
-        frameRate: recording.frameRate,
         frameCount: recording.frameCount,
-        sourceFrameCount: recording.sourceFrameCount,
-        encodedSourceFrameCount: recording.encodedSourceFrameCount,
-        coalescedFrameCount: recording.coalescedFrameCount,
-        droppedFrameCount: recording.droppedFrameCount,
-        achievedSourceFrameRate: recording.sourceFrameCount / Math.max(0.001, durationMs / 1_000),
-        width: recording.width,
-        height: recording.height,
-        ...(recording.sourceWidth === undefined ? {} : { sourceWidth: recording.sourceWidth }),
-        ...(recording.sourceHeight === undefined ? {} : { sourceHeight: recording.sourceHeight }),
+        ...quality,
         mimeType: recording.artifactType === "mp4" ? "video/mp4" : "video/webm",
       }
       await fs.writeFile(`${recording.outputPath}.json`, `${JSON.stringify(metadata, null, 2)}\n`, "utf8")
@@ -894,6 +895,7 @@ export class RecordingRelay {
         mode: "cdp",
         artifactType: recording.artifactType,
         frameCount: recording.frameCount,
+        quality,
       }
     } catch (error) {
       await recording.encoder.cancel().catch(() => {})
@@ -921,7 +923,7 @@ export class RecordingRelay {
   private async writeSourceFrame(recording: CdpRecording, frame: CdpVideoFrame, endFrameNumber: number): Promise<void> {
     const timestampMs = Math.round((frame.frameNumber * 1_000) / recording.frameRate)
     const durationMs = Math.max(1, Math.round(((endFrameNumber - frame.frameNumber) * 1_000) / recording.frameRate))
-    await recording.encoder.write(frame.buffer, timestampMs, durationMs)
+    await recording.encoder.write(frame.buffer, timestampMs, durationMs, frame.surfaceWidth)
     recording.encodedSourceFrameCount += 1
   }
 }
@@ -993,23 +995,69 @@ function cdpArtifactType(outputPath: string): "webm" | "mp4" | undefined {
   return undefined
 }
 
-function cdpRecordingSize(metrics: JsonObject): { readonly width: number; readonly height: number } {
-  const viewport = getObject(metrics.cssVisualViewport) ?? getObject(metrics.visualViewport)
-  const viewportWidth = typeof viewport?.clientWidth === "number" ? viewport.clientWidth : maxCdpWidth
-  const viewportHeight = typeof viewport?.clientHeight === "number" ? viewport.clientHeight : maxCdpHeight
-  const scale = Math.min(1, maxCdpWidth / viewportWidth, maxCdpHeight / viewportHeight)
+function recordingQuality(recording: CdpRecording, durationMs: number): RecordingQuality {
+  const seconds = Math.max(0.001, durationMs / 1_000)
   return {
-    width: Math.max(2, Math.floor(viewportWidth * scale) & ~1),
-    height: Math.max(2, Math.floor(viewportHeight * scale) & ~1),
+    width: recording.width,
+    height: recording.height,
+    frameRate: recording.frameRate,
+    sourceFrameCount: recording.sourceFrameCount,
+    encodedSourceFrameCount: recording.encodedSourceFrameCount,
+    coalescedFrameCount: recording.coalescedFrameCount,
+    droppedFrameCount: recording.droppedFrameCount,
+    achievedSourceFrameRate: recording.sourceFrameCount / seconds,
+    achievedEncodedSourceFrameRate: recording.encodedSourceFrameCount / seconds,
+    screenshotFallback: recording.sourceFrameCount === 0 && recording.encodedSourceFrameCount > 0,
+    ...(recording.sourceWidth === undefined ? {} : { sourceWidth: recording.sourceWidth }),
+    ...(recording.sourceHeight === undefined ? {} : { sourceHeight: recording.sourceHeight }),
   }
 }
 
-async function startFfmpegVideoEncoder(options: {
+function cdpRecordingSize(metrics: JsonObject): { readonly width: number; readonly height: number } {
+  const viewport = getObject(metrics.cssVisualViewport) ?? getObject(metrics.visualViewport)
+  const viewportWidth = typeof viewport?.clientWidth === "number" ? viewport.clientWidth : fallbackCdpWidth
+  const viewportHeight = typeof viewport?.clientHeight === "number" ? viewport.clientHeight : fallbackCdpHeight
+  return {
+    width: Math.max(2, Math.floor(viewportWidth) & ~1),
+    height: Math.max(2, Math.floor(viewportHeight) & ~1),
+  }
+}
+
+async function startFfmpegVideoEncoder(options: Parameters<StartVideoEncoder>[0]): Promise<VideoEncoder> {
+  // Preserve start-time dependency errors even though geometry arrives later.
+  await new Promise<void>((resolve, reject) => {
+    execFile("ffmpeg", ["-version"], { timeout: 5_000 }, (error) => error ? reject(error) : resolve())
+  })
+  // The first compositor frame supplies the backing surface's CSS width. It can
+  // differ from both the emulated viewport and the JPEG's Retina pixel width.
+  let acquisition: Promise<VideoEncoder> | undefined
+  let cancelled = false
+  return {
+    write: async (frame, timestampMs, durationMs, surfaceWidth) => {
+      if (cancelled) throw new Error("ffmpeg recording was cancelled")
+      acquisition ??= createFfmpegVideoEncoder({ ...options, surfaceWidth: surfaceWidth ?? options.width })
+      const encoder = await acquisition
+      if (cancelled) throw new Error("ffmpeg recording was cancelled")
+      await encoder.write(frame, timestampMs, durationMs)
+    },
+    finish: async () => {
+      if (!acquisition) throw new Error("No recording frames received")
+      await (await acquisition).finish()
+    },
+    cancel: async () => {
+      cancelled = true
+      if (acquisition) await (await acquisition).cancel()
+    },
+  }
+}
+
+async function createFfmpegVideoEncoder(options: {
   readonly outputPath: string
   readonly artifactType: "webm" | "mp4"
   readonly frameRate: number
   readonly width: number
   readonly height: number
+  readonly surfaceWidth: number
 }): Promise<VideoEncoder> {
   const temporaryOutputPath = `${options.outputPath}.partial-${process.pid}-${crypto.randomUUID()}`
   const outputArgs = options.artifactType === "webm"
@@ -1036,7 +1084,7 @@ async function startFfmpegVideoEncoder(options: {
     "-fps_mode",
     "cfr",
     "-vf",
-    `pad=${options.width}:${options.height}:0:0:gray,crop=${options.width}:${options.height}:0:0`,
+    `scale=min(iw\\,${options.surfaceWidth}):-1:flags=lanczos,pad=ceil(max(iw\\,${options.width})/2)*2:ceil(max(ih\\,${options.height})/2)*2:0:0:gray,crop=${options.width}:${options.height}:0:0`,
     ...outputArgs,
     "-f",
     options.artifactType,
@@ -1073,9 +1121,13 @@ async function startFfmpegVideoEncoder(options: {
     write: async (frame, timestampMs, durationMs) => {
       if (completed || finishingPromise || cancelPromise) throw new Error("ffmpeg input closed before recording finished")
       const envelope = mjpegMatroskaFrame(timestampMs, durationMs, frame.length)
-      await writeStreamChunk(child.stdin, envelope.header)
-      await writeStreamChunk(child.stdin, frame)
-      await writeStreamChunk(child.stdin, envelope.trailer)
+      try {
+        await writeStreamChunk(child.stdin, envelope.header)
+        await writeStreamChunk(child.stdin, frame)
+        await writeStreamChunk(child.stdin, envelope.trailer)
+      } catch (error) {
+        throw new Error(`${error instanceof Error ? error.message : String(error)}${stderr.trim() ? `: ${stderr.trim()}` : ""}`)
+      }
     },
     finish: async () => {
       if (completed) return

--- a/src/relay-schema.ts
+++ b/src/relay-schema.ts
@@ -390,6 +390,25 @@ const RecordingMode = Schema.Literals(["tab-capture", "cdp"])
 
 const RecordingRequestedMode = Schema.Literals(["auto", "tab-capture", "cdp"])
 
+const RecordingFrameRate = Schema.Number.check(Schema.isInt(), Schema.isBetween({ minimum: 1, maximum: 60 }))
+
+export const RecordingQuality = Schema.Struct({
+  width: Schema.Number,
+  height: Schema.Number,
+  frameRate: Schema.Number,
+  sourceFrameCount: Schema.Number,
+  encodedSourceFrameCount: Schema.Number,
+  coalescedFrameCount: Schema.Number,
+  droppedFrameCount: Schema.Number,
+  achievedSourceFrameRate: Schema.Number,
+  achievedEncodedSourceFrameRate: Schema.Number,
+  screenshotFallback: Schema.Boolean,
+  sourceWidth: Schema.optionalKey(Schema.Number),
+  sourceHeight: Schema.optionalKey(Schema.Number),
+})
+
+export interface RecordingQuality extends Schema.Schema.Type<typeof RecordingQuality> {}
+
 export const RecordingTargetRequest = Schema.Struct({
   sessionId: Schema.optionalKey(Schema.String),
   tabId: Schema.optionalKey(Schema.Number),
@@ -401,7 +420,7 @@ export const RecordingStartRequest = RecordingTargetRequest.pipe(Schema.fieldsAs
   outputPath: Schema.String,
   mode: Schema.optionalKey(RecordingRequestedMode),
   audio: Schema.optionalKey(Schema.Boolean),
-  frameRate: Schema.optionalKey(Schema.Number),
+  frameRate: Schema.optionalKey(RecordingFrameRate),
   videoBitsPerSecond: Schema.optionalKey(Schema.Number),
   audioBitsPerSecond: Schema.optionalKey(Schema.Number),
   maxDurationMs: Schema.optionalKey(Schema.Number),
@@ -419,6 +438,7 @@ export const RecordingStartResponse = Schema.Struct({
   mimeType: Schema.optionalKey(Schema.String),
   mode: Schema.optionalKey(RecordingMode),
   artifactType: Schema.optionalKey(RecordingArtifactType),
+  frameRate: Schema.optionalKey(Schema.Number),
   error: Schema.optionalKey(Schema.String),
 })
 
@@ -433,6 +453,7 @@ export const RecordingStopResponse = Schema.Struct({
   mode: Schema.optionalKey(RecordingMode),
   artifactType: Schema.optionalKey(RecordingArtifactType),
   frameCount: Schema.optionalKey(Schema.Number),
+  quality: Schema.optionalKey(RecordingQuality),
   error: Schema.optionalKey(Schema.String),
 })
 
@@ -447,6 +468,7 @@ export const RecordingStatusResponse = Schema.Struct({
   mode: Schema.optionalKey(RecordingMode),
   artifactType: Schema.optionalKey(RecordingArtifactType),
   frameCount: Schema.optionalKey(Schema.Number),
+  quality: Schema.optionalKey(RecordingQuality),
 })
 
 export interface RecordingStatusResponse extends Schema.Schema.Type<typeof RecordingStatusResponse> {}

--- a/src/screenshot-diff.ts
+++ b/src/screenshot-diff.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import pixelmatch from "pixelmatch"
+import { PNG } from "pngjs"
+import type { Page } from "playwright-core"
+
+const maxImageBytes = 32 * 1024 * 1024
+const maxImagePixels = 16 * 1024 * 1024
+const pngSignature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])
+
+export type ScreenshotDiffOptions = {
+  readonly baseline: string | Buffer
+  readonly path?: string
+  /** Per-pixel perceptual color threshold, 0..1. Not a changed-area allowance. */
+  readonly threshold?: number
+  readonly fullPage?: boolean
+}
+
+export type ScreenshotDiffResult = {
+  readonly matches: boolean
+  readonly width: number
+  readonly height: number
+  readonly changedPixels: number
+  readonly totalPixels: number
+  readonly changedRatio: number
+  readonly threshold: number
+  readonly image?: Buffer
+  readonly path?: string
+}
+
+export function createScreenshotDiff(page: Pick<Page, "screenshot">): (options: ScreenshotDiffOptions) => Promise<ScreenshotDiffResult> {
+  return async (options) => {
+    const threshold = validateThreshold(options.threshold ?? 0.1)
+    if (options.path !== undefined && (!path.isAbsolute(options.path) || path.extname(options.path).toLowerCase() !== ".png")) {
+      throw new Error("screenshotDiff output path must be an absolute .png path")
+    }
+    const baseline = typeof options.baseline === "string" ? await readBaseline(options.baseline) : options.baseline
+    const before = decodePng(baseline)
+    const current = await page.screenshot({ type: "png", scale: "css", fullPage: options.fullPage ?? false })
+    const after = decodePng(current)
+    if (before.width !== after.width || before.height !== after.height) {
+      throw new Error(`Screenshot dimensions differ: baseline ${before.width}×${before.height}, current ${after.width}×${after.height}. Capture both at the same CSS viewport and fullPage setting; images are never resized.`)
+    }
+    const diff = new PNG({ width: before.width, height: before.height })
+    const changedPixels = pixelmatch(before.data, after.data, diff.data, before.width, before.height, {
+      threshold,
+      includeAA: true,
+    })
+    const image = PNG.sync.write(diff)
+    const totalPixels = before.width * before.height
+    // Exclusive creation also rejects symlinks/hardlinks to the baseline.
+    if (options.path) await fs.writeFile(options.path, image, { flag: "wx", mode: 0o600 })
+    return {
+      matches: changedPixels === 0,
+      width: before.width,
+      height: before.height,
+      changedPixels,
+      totalPixels,
+      changedRatio: changedPixels / totalPixels,
+      threshold,
+      ...(options.path ? { path: options.path } : { image }),
+    }
+  }
+}
+
+async function readBaseline(filename: string): Promise<Buffer> {
+  if (!path.isAbsolute(filename)) throw new Error("screenshotDiff baseline path must be absolute")
+  const file = await fs.open(filename, "r")
+  try {
+    const stat = await file.stat()
+    if (!stat.isFile() || stat.size > maxImageBytes) throw new Error("Screenshot baseline must be a PNG file no larger than 32 MiB")
+    // Bound the read even if another process grows the file after stat.
+    const buffer = Buffer.alloc(stat.size)
+    let offset = 0
+    while (offset < buffer.length) {
+      const { bytesRead } = await file.read(buffer, offset, buffer.length - offset, offset)
+      if (!bytesRead) break
+      offset += bytesRead
+    }
+    return buffer.subarray(0, offset)
+  } finally {
+    await file.close()
+  }
+}
+
+function validateThreshold(threshold: number): number {
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    throw new Error("screenshotDiff threshold must be a finite number from 0 to 1")
+  }
+  return threshold
+}
+
+function decodePng(buffer: Buffer): PNG {
+  if (!Buffer.isBuffer(buffer) || buffer.length > maxImageBytes || buffer.length < 24 || !buffer.subarray(0, 8).equals(pngSignature) || buffer.toString("ascii", 12, 16) !== "IHDR") {
+    throw new Error("Screenshot must be a PNG buffer no larger than 32 MiB")
+  }
+  const width = buffer.readUInt32BE(16)
+  const height = buffer.readUInt32BE(20)
+  if (width === 0 || height === 0 || width * height > maxImagePixels) {
+    throw new Error("Screenshot exceeds the 16 megapixel comparison limit")
+  }
+  return PNG.sync.read(buffer)
+}

--- a/test/execute-sandbox.test.ts
+++ b/test/execute-sandbox.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events"
+import { PNG } from "pngjs"
 import { Effect, Fiber, Latch } from "effect"
 import { TestClock } from "effect/testing"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -14,6 +15,7 @@ vi.mock("playwright-core", () => ({
 
 class FakePage extends EventEmitter {
   closed = false
+  readonly screenshot = vi.fn(async () => PNG.sync.write(new PNG({ width: 2, height: 2 })))
   readonly frame = { url: () => this.url() }
   readonly evaluate = vi.fn(async (): Promise<unknown> => {
     if (this.closed) throw new Error("Target page has been closed")
@@ -69,6 +71,20 @@ beforeEach(() => {
 })
 
 describe("ExecuteSandbox", () => {
+  it("binds screenshotDiff to the session page and returns its image as execute media", async () => {
+    const context = new FakeContext()
+    connect(context)
+    const sandbox = new ExecuteSandbox({ endpointUrl: "http://relay.test" })
+    try {
+      const result = await Effect.runPromise(sandbox.execute("state.before = await page.screenshot(); return await screenshotDiff({ baseline: state.before })"))
+      expect(result).toMatchObject({ isError: false, value: { matches: true, changedPixels: 0, changedRatio: 0 } })
+      expect(result.media).toHaveLength(1)
+      expect(result.media?.[0]).toMatchObject({ mimeType: "image/png" })
+      expect(context.targets[0]?.screenshot).toHaveBeenLastCalledWith({ type: "png", scale: "css", fullPage: false })
+    } finally {
+      await Effect.runPromise(sandbox.closeSettled())
+    }
+  })
   it.each(["success", "failure"] as const)("awaits owned page close %s before disconnecting and cleans only its own listeners", async (outcome) => {
     await Effect.runPromise(Effect.gen(function* () {
       const context = new FakeContext()

--- a/test/http-api.test.ts
+++ b/test/http-api.test.ts
@@ -83,13 +83,16 @@ describe("HTTP request schemas", () => {
     const cancel = vi.spyOn(recordingRelay, "cancelRecording").mockResolvedValue({ success: true })
     const status = vi.spyOn(recordingRelay, "statusRecording").mockResolvedValue({ isRecording: false })
     try {
-      for (const options of [{}, { mode: "auto", audio: false, frameRate: 0, videoBitsPerSecond: 0, audioBitsPerSecond: 0, maxDurationMs: 0 }]) {
+      for (const options of [{}, { mode: "auto", audio: false, frameRate: 30, videoBitsPerSecond: 0, audioBitsPerSecond: 0, maxDurationMs: 0 }]) {
         await expect(postJson(port, "/recording/start", { sessionId: "owner-7", outputPath, ...options, ignored: "discard me" })).resolves.toMatchObject({ status: 200 })
         expect(start.mock.lastCall?.[0]).toStrictEqual({ tabId: 7, sessionId: "bc-tab-7", owner: "user", outputPath, ...options })
       }
       await postJson(port, "/recording/start", { tabId: 7, sessionId: "unknown", outputPath })
       expect(start.mock.lastCall?.[0]).toStrictEqual({ tabId: 7, sessionId: "bc-tab-7", owner: "user", outputPath })
       start.mockClear()
+      for (const frameRate of [0, -1, 61, 29.97]) {
+        await expect(postJson(port, "/recording/start", { tabId: 7, outputPath, frameRate })).resolves.toMatchObject({ status: 400, body: { code: "invalid-request" } })
+      }
       for (const [selector, message, code, statusCode] of [
         [{ sessionId: "unknown" }, "No attached tab found for sessionId unknown", "target-not-found", 404],
         [{ tabId: 0 }, "No attached tab found for tabId 0", "target-not-found", 404],

--- a/test/recording-presentation.test.ts
+++ b/test/recording-presentation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { formatRecordingQuality } from "../src/recording-presentation.ts"
+import type { RecordingQuality } from "../src/relay-schema.ts"
+
+const quality: RecordingQuality = {
+  width: 1280, height: 720, frameRate: 60,
+  sourceFrameCount: 120, encodedSourceFrameCount: 90,
+  coalescedFrameCount: 25, droppedFrameCount: 5,
+  achievedSourceFrameRate: 40, achievedEncodedSourceFrameRate: 30,
+  screenshotFallback: false, sourceWidth: 2560, sourceHeight: 1273,
+}
+
+describe("recording quality receipt", () => {
+  it("distinguishes source and output rates without claiming distinct motion", () => {
+    const text = formatRecordingQuality(quality)
+    expect(text).toContain("1280×720, output 60 fps")
+    expect(text).toContain("2560×1273 CSS px")
+    expect(text).toContain("120 received (40.0/s), 90 retained (30.0/s), 25 coalesced, 5 dropped")
+    expect(text).toContain("not a measurement of distinct motion")
+  })
+  it("calls out the stop-time screenshot fallback", () => {
+    expect(formatRecordingQuality({ ...quality, screenshotFallback: true, sourceFrameCount: 0 })).toContain("WARNING: no compositor frames arrived")
+  })
+  it("does not fabricate metrics for tab capture or an older relay", () => {
+    expect(formatRecordingQuality(undefined)).toContain("unavailable")
+  })
+})

--- a/test/recording-relay.test.ts
+++ b/test/recording-relay.test.ts
@@ -476,16 +476,56 @@ describe("RecordingRelay tab capture", () => {
 })
 
 describe("RecordingRelay CDP screencast", () => {
+  it.each([
+    { requested: undefined, expected: 60 },
+    { requested: 30, expected: 30 },
+    { requested: 1, expected: 1 },
+    { requested: 60, expected: 60 },
+  ])("uses $expected fps for requested $requested without reducing the viewport", async ({ requested, expected }) => {
+    const startVideoEncoder = vi.fn(async () => ({ write: async () => {}, finish: async () => {}, cancel: async () => {} }))
+    const relay = new RecordingRelay({
+      isExtensionConnected: () => true,
+      sendToExtension: async () => ({}),
+      sendDebuggerCommand: async ({ method }) => method === "Page.getLayoutMetrics"
+        ? { cssVisualViewport: { clientWidth: 1921, clientHeight: 1081 } }
+        : {},
+      startVideoEncoder,
+    })
+    try {
+      await expect(relay.startRecording({ tabId: 7, owner: "relay", outputPath: "/tmp/recording-quality-unit.mp4", mode: "cdp", ...(requested === undefined ? {} : { frameRate: requested }) })).resolves.toMatchObject({ success: true })
+      expect(startVideoEncoder).toHaveBeenCalledWith(expect.objectContaining({ frameRate: expected, width: 1920, height: 1080 }))
+    } finally {
+      await relay.cancelRecording({ tabId: 7 })
+    }
+  })
+
+  it.each([0, -1, 60.1, 120, 1.5, NaN, Infinity])("rejects invalid frame rate %s before allocating resources", async (frameRate) => {
+    const sendDebuggerCommand = vi.fn(async () => ({}))
+    const sendToExtension = vi.fn(async () => ({}))
+    const relay = new RecordingRelay({ isExtensionConnected: () => true, sendDebuggerCommand, sendToExtension })
+    for (const mode of ["cdp", "tab-capture", "auto"] as const) {
+      await expect(relay.startRecording({ tabId: 7, owner: "relay", mode, outputPath: "/tmp/invalid-recording-rate.webm", frameRate })).resolves.toEqual({
+        success: false,
+        error: "Recording frameRate must be an integer from 1 to 60",
+      })
+    }
+    expect(sendDebuggerCommand).not.toHaveBeenCalled()
+    expect(sendToExtension).not.toHaveBeenCalled()
+    expect(relay.hasActiveRecordings()).toBe(false)
+  })
+
   it("acknowledges compositor frames and timestamps source frames for constant-rate encoding", async () => {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "browser-control-recording-"))
     temporaryPaths.push(directory)
     const outputPath = path.join(directory, "demo.mp4")
     const debuggerCommands: Array<{ readonly method: string; readonly params: object }> = []
     const encodedFrames: Array<{ readonly contents: string; readonly timestampMs: number; readonly durationMs: number }> = []
+    const surfaceWidths: Array<number | undefined> = []
     let now = 1_000
     const encoder: VideoEncoder = {
-      write: async (frame, timestampMs, durationMs) => {
+      write: async (frame, timestampMs, durationMs, surfaceWidth) => {
         encodedFrames.push({ contents: frame.toString(), timestampMs, durationMs })
+        surfaceWidths.push(surfaceWidth)
       },
       finish: async () => {
         await fs.writeFile(outputPath, "video")
@@ -529,7 +569,7 @@ describe("RecordingRelay CDP screencast", () => {
     expect(debuggerCommands[2]).toEqual({
       tabId: 7,
       method: "Page.startScreencast",
-      params: { format: "jpeg", quality: 80, maxWidth: 1280, maxHeight: 638, everyNthFrame: 1 },
+      params: { format: "jpeg", quality: 100, everyNthFrame: 1 },
     })
 
     now = 1_100
@@ -549,11 +589,19 @@ describe("RecordingRelay CDP screencast", () => {
     const stop = await relay.stopRecording({ sessionId: "demo" })
 
     expect(stop).toMatchObject({ success: true, artifactType: "mp4", frameCount: 5 })
+    expect(stop).toMatchObject({ quality: {
+      width: 2560, height: 1276, frameRate: 10,
+      sourceFrameCount: 2, encodedSourceFrameCount: 2,
+      coalescedFrameCount: 0, droppedFrameCount: 0,
+      achievedSourceFrameRate: 4, achievedEncodedSourceFrameRate: 4,
+      screenshotFallback: false,
+    } })
     expect(encodedFrames).toEqual([
       { contents: "first", timestampMs: 0, durationMs: 300 },
       { contents: "second", timestampMs: 300, durationMs: 200 },
     ])
     expect(debuggerCommands.filter((command) => command.method === "Page.screencastFrameAck")).toHaveLength(2)
+    expect(surfaceWidths).toEqual([1920, 1920])
     expect(debuggerCommands.at(-1)?.method).toBe("Page.stopScreencast")
     expect(JSON.parse(await fs.readFile(`${outputPath}.json`, "utf8"))).toMatchObject({
       artifactType: "mp4",
@@ -562,8 +610,8 @@ describe("RecordingRelay CDP screencast", () => {
       sourceFrameCount: 2,
       encodedSourceFrameCount: 2,
       droppedFrameCount: 0,
-      width: 1280,
-      height: 638,
+      width: 2560,
+      height: 1276,
       sourceWidth: 1920,
       sourceHeight: 1080,
     })
@@ -582,6 +630,30 @@ describe("RecordingRelay CDP screencast", () => {
       outputPath: "/tmp/browser-control-frames",
       mode: "cdp",
     })).resolves.toEqual({ success: false, error: "CDP recording output path must end in .webm or .mp4" })
+  })
+
+  it("reports the stop-time screenshot fallback separately from compositor frames", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "browser-control-recording-"))
+    temporaryPaths.push(directory)
+    const outputPath = path.join(directory, "fallback.mp4")
+    let now = 0
+    const relay = new RecordingRelay({
+      isExtensionConnected: () => true,
+      sendToExtension: async () => ({}),
+      sendDebuggerCommand: async ({ method }) => method === "Page.captureScreenshot" ? { data: Buffer.from("screenshot").toString("base64") } : {},
+      startVideoEncoder: async () => ({ write: async () => {}, finish: async () => { await fs.writeFile(outputPath, "video") }, cancel: async () => {} }),
+      now: () => now,
+    })
+    await expect(relay.startRecording({ tabId: 7, owner: "relay", outputPath, mode: "cdp" })).resolves.toMatchObject({ success: true, frameRate: 60 })
+    now = 1000
+    expect(await relay.statusRecording({ tabId: 7 })).toMatchObject({ quality: { sourceFrameCount: 0, screenshotFallback: false } })
+    const result = await relay.stopRecording({ tabId: 7 })
+    expect(result).toMatchObject({ success: true, frameCount: 60, quality: {
+      sourceFrameCount: 0, encodedSourceFrameCount: 1, achievedSourceFrameRate: 0,
+      achievedEncodedSourceFrameRate: 1, screenshotFallback: true,
+    } })
+    if (!result.success) throw new Error(result.error)
+    expect(JSON.parse(await fs.readFile(`${outputPath}.json`, "utf8"))).toMatchObject(result.quality!)
   })
 
   it("caps timestamp discontinuities by wall-clock duration", async () => {

--- a/test/relay-client.test.ts
+++ b/test/relay-client.test.ts
@@ -231,6 +231,21 @@ describe("RelayClient", () => {
     })
   })
 
+  it("retains recording quality in decoded stop and status responses", async () => {
+    const quality = {
+      width: 1280, height: 720, frameRate: 60,
+      sourceFrameCount: 12, encodedSourceFrameCount: 10, coalescedFrameCount: 1, droppedFrameCount: 1,
+      achievedSourceFrameRate: 6, achievedEncodedSourceFrameRate: 5,
+      screenshotFallback: false, sourceWidth: 2560, sourceHeight: 1273,
+    }
+    routes.set("POST /recording/stop", { status: 200, body: { success: true, frameCount: 120, quality } })
+    routes.set("GET /recording/status", { status: 200, body: { isRecording: true, frameCount: 120, quality } })
+    expect((await withClient((client) => client.recordingStop({ tabId: 7 }))).quality).toEqual(quality)
+    expect((await withClient((client) => client.recordingStatus({ tabId: 7 }))).quality).toEqual(quality)
+    routes.set("POST /recording/stop", { status: 200, body: { success: true, frameCount: 120 } })
+    expect((await withClient((client) => client.recordingStop({ tabId: 7 }))).quality).toBeUndefined()
+  })
+
   it("preserves network limits and decodes capture results", async () => {
     routes.set("POST /network/start", {
       status: 200,

--- a/test/relay-schema.test.ts
+++ b/test/relay-schema.test.ts
@@ -27,6 +27,14 @@ import {
 } from "../src/relay-schema.ts"
 
 const decodeSession = Schema.decodeUnknownSync(SessionSummary)
+
+it.each([0, -1, 61, 120, 29.97, NaN, Infinity])("rejects invalid recording frame rate %s at the wire boundary", (frameRate) => {
+  expect(() => Schema.decodeUnknownSync(RecordingStartRequest)({ outputPath: "/tmp/demo.mp4", frameRate })).toThrow()
+})
+
+it.each([1, 30, 60])("accepts recording frame rate %s without clamping", (frameRate) => {
+  expect(Schema.decodeUnknownSync(RecordingStartRequest)({ outputPath: "/tmp/demo.mp4", frameRate }).frameRate).toBe(frameRate)
+})
 const decodeSessions = Schema.decodeUnknownSync(SessionsContainer)
 const decodeSessionContainer = Schema.decodeUnknownSync(SessionContainer)
 const decodeAdoptRequest = Schema.decodeUnknownSync(SessionAdoptRequest)

--- a/test/screenshot-diff.test.ts
+++ b/test/screenshot-diff.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { PNG } from "pngjs"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createScreenshotDiff } from "../src/screenshot-diff.ts"
+
+const directories: string[] = []
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })))
+})
+
+function image(width = 2, height = 2, red = 255): Buffer {
+  const png = new PNG({ width, height })
+  png.data.fill(255)
+  png.data[0] = red
+  return PNG.sync.write(png)
+}
+
+describe("screenshotDiff", () => {
+  it("returns a PNG and exact zero-change metrics for equal images", async () => {
+    const baseline = image()
+    const screenshot = vi.fn(async () => baseline)
+    const result = await createScreenshotDiff({ screenshot })({ baseline })
+    expect(screenshot).toHaveBeenCalledWith({ type: "png", scale: "css", fullPage: false })
+    expect(result).toMatchObject({ matches: true, width: 2, height: 2, changedPixels: 0, totalPixels: 4, changedRatio: 0, threshold: 0.1 })
+    expect(PNG.sync.read(result.image!).width).toBe(2)
+  })
+
+  it("highlights changes in red and reports the changed fraction", async () => {
+    const result = await createScreenshotDiff({ screenshot: async () => image(2, 2, 0) })({ baseline: image(), threshold: 0, fullPage: true })
+    expect(result).toMatchObject({ matches: false, changedPixels: 1, totalPixels: 4, changedRatio: 0.25 })
+    expect([...PNG.sync.read(result.image!).data.subarray(0, 4)]).toEqual([255, 0, 0, 255])
+  })
+
+  it("applies a color threshold rather than a changed-area allowance", async () => {
+    const diff = createScreenshotDiff({ screenshot: async () => image(2, 2, 254) })
+    expect((await diff({ baseline: image(), threshold: 0 })).changedPixels).toBe(1)
+    expect((await diff({ baseline: image(), threshold: 0.1 })).changedPixels).toBe(0)
+  })
+
+  it("rejects differing dimensions without resizing", async () => {
+    await expect(createScreenshotDiff({ screenshot: async () => image(3, 2) })({ baseline: image() })).rejects.toThrow("baseline 2×2, current 3×2")
+  })
+
+  it.each([-1, 1.1, NaN, Infinity])("rejects threshold %s before taking a screenshot", async (threshold) => {
+    const screenshot = vi.fn(async () => image())
+    await expect(createScreenshotDiff({ screenshot })({ baseline: image(), threshold })).rejects.toThrow("threshold")
+    expect(screenshot).not.toHaveBeenCalled()
+  })
+
+  it("rejects corrupt and oversized PNGs before taking a screenshot", async () => {
+    const screenshot = vi.fn(async () => image())
+    const oversized = image()
+    oversized.writeUInt32BE(100_000, 16)
+    oversized.writeUInt32BE(100_000, 20)
+    await expect(createScreenshotDiff({ screenshot })({ baseline: oversized })).rejects.toThrow("megapixel")
+    await expect(createScreenshotDiff({ screenshot })({ baseline: Buffer.from("not a PNG") })).rejects.toThrow("PNG")
+    const corrupt = image().subarray(0, 26)
+    await expect(createScreenshotDiff({ screenshot })({ baseline: corrupt })).rejects.toThrow()
+    expect(screenshot).not.toHaveBeenCalled()
+  })
+
+  it("reads a saved baseline and writes a private diff without overwriting either artifact", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "screenshot-diff-"))
+    directories.push(directory)
+    const baseline = path.join(directory, "before.png")
+    const output = path.join(directory, "diff.png")
+    const before = image()
+    await fs.writeFile(baseline, before)
+    const diff = createScreenshotDiff({ screenshot: async () => image(2, 2, 0) })
+    const result = await diff({ baseline, path: output })
+    expect(result).toMatchObject({ path: output, changedPixels: 1 })
+    expect(result.image).toBeUndefined()
+    expect((await fs.stat(output)).mode & 0o777).toBe(0o600)
+    expect(PNG.sync.read(await fs.readFile(output)).width).toBe(2)
+    await expect(diff({ baseline, path: baseline })).rejects.toThrow("EEXIST")
+    await expect(diff({ baseline, path: output })).rejects.toThrow("EEXIST")
+    expect(await fs.readFile(baseline)).toEqual(before)
+  })
+
+  it("requires absolute baseline and PNG output paths", async () => {
+    const screenshot = vi.fn(async () => image())
+    const diff = createScreenshotDiff({ screenshot })
+    await expect(diff({ baseline: "before.png" })).rejects.toThrow("absolute")
+    await expect(diff({ baseline: image(), path: "diff.png" })).rejects.toThrow("absolute")
+    await expect(diff({ baseline: image(), path: "/tmp/diff.jpg" })).rejects.toThrow(".png")
+    expect(screenshot).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Why

CDP recordings could shrink an emulated 1280×720 page into a padded corner, and Retina captures could be cropped at the wrong scale. Output frame counts also hid the difference between real compositor capture and a video holding one screenshot.

## What Changes

| Behavior | Result |
| --- | --- |
| Emulated or Retina viewport | Capture uncapped JPEG100 frames, normalize the backing surface, and preserve the starting CSS viewport without upscaling |
| Recording frame rate | Default to 60 fps for CDP; reject explicit rates outside integer 1..60 |
| Recording stop/status | Return dimensions, source/retained counts and rates, coalescing, drops, and an explicit screenshot-fallback warning |
| `recording start/stop/status --json` | Machine-readable receipts through the shared relay schemas |
| `screenshotDiff({ baseline })` | Highlight changed pixels and return their count/ratio plus a PNG; reject dimension mismatches and existing output files |

```ts
await page.screenshot({ path: "/absolute/before.png", scale: "css" })
// After the intended UI change, at the same viewport:
return await screenshotDiff({ baseline: "/absolute/before.png" })
```

Source counters describe compositor events, not visually distinct motion. Larger viewports and 60 fps cost more CPU/bandwidth; `--frame-rate 30` remains available. Snapshot-based fallback is still supported but can no longer masquerade as captured motion in the receipt.

## Demo

Deterministic synthetic Chromium fixture, real production recorder and ffmpeg. The earlier pre-fix reproduction shrinks the emulated page against a larger backing surface:

![Before geometry fix](https://github.com/user-attachments/assets/c4e0604d-62b2-4ff7-a3b3-64ef838e359a)

Encoded frame from the integrated branch, native 1280×720, no delivery upscaling:

![After geometry fix](https://github.com/user-attachments/assets/7528dc38-228e-46f7-b6d1-e108dc7f2754)

The screenshot-diff helper highlights a real button color change (9,394 pixels, 1.529% of this fixture):

![Highlighted visual difference](https://github.com/user-attachments/assets/c9cb3072-b905-444b-a117-b570d5e9da14)

## Scope

Recording quality, truthful recording receipts, and a code-first PNG visual-diff helper. Preserves current main's Effect cohort, release/toolchain versions, browser ownership, and runtime upgrade safeguards. No extension protocol change or shared-runtime restart.

## Verification

```sh
pnpm install --frozen-lockfile
pnpm typecheck
pnpm check:locals
pnpm check:unused
bun run test
pnpm run ci
pnpm bench:recording-quality --browser <Chromium-executable> --backing-surface --verify --out <fresh-directory>
pnpm runtime:prepare --staging <fresh-directory> --install <fresh-directory>
```

774 tests pass on the integrated branch. Full GitHub CI and standalone package validation pass. One warmup plus seven measured Chromium recordings pass the geometry/quality gate: median text SSIM 0.993320 and 58.64 actual motion changes/sec. A separate real Chromium screenshot/receipt proof passed, including wire decoding and sidecar agreement. No full browser smoke-set claim.

The autoresearch history in `perf/recording-quality.md` retains baseline and rejected intermediate results; historical checkpoint proofs are not relabeled as current-main runs.
